### PR TITLE
Amazon Route53 requires quotes around the values of DNS TXT records.

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
@@ -1354,6 +1354,10 @@ public class DiscoveryClient implements LookupService {
             txtRecord = attr.get().toString();
         }
 
+        if (txtRecord.startsWith("\"") && txtRecord.endsWith("\"")) {
+            txtRecord = txtRecord.substring(1, txtRecord.length() - 1);
+        }
+
         Set<String> cnamesSet = new TreeSet<String>();
         if ((txtRecord == null) || ("".equals(txtRecord.trim()))) {
             return cnamesSet;


### PR DESCRIPTION
 Will now strip leading and traling quote from TXT record when reading it.
