### PR TITLE
eureka.port appears to be pulling double duty:

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/DefaultEurekaClientConfig.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DefaultEurekaClientConfig.java
@@ -226,7 +226,7 @@ public class DefaultEurekaClientConfig implements EurekaClientConfig {
      */
     @Override
     public String getEurekaServerURLContext() {
-        return configInstance.getStringProperty(namespace + "context", null)
+        return configInstance.getStringProperty(namespace + "eurekaServer.context", null)
                 .get();
     }
 
@@ -237,7 +237,7 @@ public class DefaultEurekaClientConfig implements EurekaClientConfig {
      */
     @Override
     public String getEurekaServerPort() {
-        return configInstance.getStringProperty(namespace + "port", null).get();
+        return configInstance.getStringProperty(namespace + "eurekaServer.port", null).get();
     }
 
     /*
@@ -247,7 +247,7 @@ public class DefaultEurekaClientConfig implements EurekaClientConfig {
      */
     @Override
     public String getEurekaServerDNSName() {
-        return configInstance.getStringProperty(namespace + "domainName", null)
+        return configInstance.getStringProperty(namespace + "eurekaServer.domainName", null)
                 .get();
     }
 


### PR DESCRIPTION
both telling what port to register as and what port the eureka server is listening on. Changed the properties that deal with DNS discovery of eureka servers to be eureka.eurekaServer.<property>
