### PR TITLE
eureka-client should declare dependency on Jettison

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ project(':eureka-client') {
         compile 'com.sun.jersey:jersey-bundle:1.9.1'
         compile 'com.sun.jersey.contribs:jersey-apache-client4:1.8'
         compile 'org.apache.httpcomponents:httpclient:4.1.2'
+        runtime 'org.codehaus.jettison:jettison:1.2'
     }
 }
 


### PR DESCRIPTION
The eureka-client package requires Jettison to be on the classpath, but doesn't declare the dependency.  Without Jettison on the classpath, `com.netflix.discovery.converters.JsonXStream` can't load resulting in this error from the heartbeat thread:

```
| Error 2013-01-28 13:21:32,659 [DiscoveryClient_Heartbeat] ERROR discovery.DiscoveryClient  - DiscoveryClient_AIQ/172.16.16.137 - registration failedjava.io.IOException: Cannot write the object for :class com.netflix.appinfo.InstanceInfo
Message: java.io.IOException: Cannot write the object for :class com.netflix.appinfo.InstanceInfo
    Line | Method
->>  184 | handle         in com.sun.jersey.client.apache4.ApacheHttpClient4Handler
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
|    120 | handle         in com.sun.jersey.api.client.filter.GZIPContentEncodingFilter
|    648 | handle . . . . in com.sun.jersey.api.client.Client
|    670 | handle         in com.sun.jersey.api.client.WebResource
|     74 | access$200 . . in     ''
|    563 | post           in com.sun.jersey.api.client.WebResource$Builder
|    810 | makeRemoteCall in com.netflix.discovery.DiscoveryClient
|    753 | makeRemoteCall in     ''
|    427 | register . . . in     ''
|   1224 | run            in com.netflix.discovery.DiscoveryClient$HeartbeatThread
|    512 | mainLoop . . . in java.util.TimerThread
^    462 | run            in     ''

Caused by IOException: Cannot write the object for :class com.netflix.appinfo.InstanceInfo
->>  144 | writeTo        in com.netflix.discovery.provider.DiscoveryJerseyProvider
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
|    231 | writeRequestEntity in com.sun.jersey.api.client.RequestWriter$RequestEntityWriterImpl
|    262 | writeTo . . .  in com.sun.jersey.client.apache4.ApacheHttpClient4Handler$2
|    115 | writeTo        in org.apache.http.entity.BufferedHttpEntity
|     98 | writeTo . . .  in org.apache.http.entity.HttpEntityWrapper
|    108 | writeTo        in org.apache.http.impl.client.EntityEnclosingRequestWrapper$EntityWrapper
|    122 | serialize . .  in org.apache.http.impl.entity.EntitySerializer
|    271 | sendRequestEntity in org.apache.http.impl.AbstractHttpClientConnection
|    227 | sendRequestEntity in org.apache.http.impl.conn.AbstractClientConnAdapter
|    257 | doSendRequest  in org.apache.http.protocol.HttpRequestExecutor
|    125 | execute . . .  in     ''
|    712 | tryExecute     in org.apache.http.impl.client.DefaultRequestDirector
|    517 | execute . . .  in     ''
|    906 | execute        in org.apache.http.impl.client.AbstractHttpClient
|    827 | execute . . .  in     ''
|    170 | handle         in com.sun.jersey.client.apache4.ApacheHttpClient4Handler
|    120 | handle . . . . in com.sun.jersey.api.client.filter.GZIPContentEncodingFilter
|    648 | handle         in com.sun.jersey.api.client.Client
|    670 | handle . . . . in com.sun.jersey.api.client.WebResource
|     74 | access$200     in     ''
|    563 | post . . . . . in com.sun.jersey.api.client.WebResource$Builder
|    810 | makeRemoteCall in com.netflix.discovery.DiscoveryClient
|    753 | makeRemoteCall in     ''
|    427 | register       in     ''
|   1224 | run . . . . .  in com.netflix.discovery.DiscoveryClient$HeartbeatThread
|    512 | mainLoop       in java.util.TimerThread
^    462 | run . . . . .  in     ''

Caused by NoClassDefFoundError: Could not initialize class com.netflix.discovery.converters.JsonXStream
->>   78 | write          in com.netflix.discovery.converters.EntityBodyConverter
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
|    142 | writeTo        in com.netflix.discovery.provider.DiscoveryJerseyProvider
|    231 | writeRequestEntity in com.sun.jersey.api.client.RequestWriter$RequestEntityWriterImpl
|    262 | writeTo        in com.sun.jersey.client.apache4.ApacheHttpClient4Handler$2
|    115 | writeTo . . .  in org.apache.http.entity.BufferedHttpEntity
|     98 | writeTo        in org.apache.http.entity.HttpEntityWrapper
|    108 | writeTo . . .  in org.apache.http.impl.client.EntityEnclosingRequestWrapper$EntityWrapper
|    122 | serialize      in org.apache.http.impl.entity.EntitySerializer
|    271 | sendRequestEntity in org.apache.http.impl.AbstractHttpClientConnection
|    227 | sendRequestEntity in org.apache.http.impl.conn.AbstractClientConnAdapter
|    257 | doSendRequest  in org.apache.http.protocol.HttpRequestExecutor
|    125 | execute        in     ''
|    712 | tryExecute . . in org.apache.http.impl.client.DefaultRequestDirector
|    517 | execute        in     ''
|    906 | execute . . .  in org.apache.http.impl.client.AbstractHttpClient
|    827 | execute        in     ''
|    170 | handle . . . . in com.sun.jersey.client.apache4.ApacheHttpClient4Handler
|    120 | handle         in com.sun.jersey.api.client.filter.GZIPContentEncodingFilter
|    648 | handle . . . . in com.sun.jersey.api.client.Client
|    670 | handle         in com.sun.jersey.api.client.WebResource
|     74 | access$200 . . in     ''
|    563 | post           in com.sun.jersey.api.client.WebResource$Builder
|    810 | makeRemoteCall in com.netflix.discovery.DiscoveryClient
|    753 | makeRemoteCall in     ''
|    427 | register . . . in     ''
|   1224 | run            in com.netflix.discovery.DiscoveryClient$HeartbeatThread
|    512 | mainLoop . . . in java.util.TimerThread
^    462 | run            in     ''
```
