### PR TITLE
Bug fix & default az->region mapping

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import javax.annotation.Nullable;
 import javax.naming.directory.DirContext;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response.Status;
@@ -285,11 +286,13 @@ public class DiscoveryClient implements LookupService {
      *
      * @param vipAddress - The VIP address to match the instances for.
      * @param secure - true if it is a secure vip address, false otherwise
-     * @param region - region from which the instances are to be fetched.
+     * @param region - region from which the instances are to be fetched. If <code>null</code> then local region is
+     *               assumed.
      *
      * @return - The list of {@link InstanceInfo} objects matching the criteria, empty list if not instances found.
      */
-    public List<InstanceInfo> getInstancesByVipAddress(String vipAddress, boolean secure, String region) {
+    public List<InstanceInfo> getInstancesByVipAddress(String vipAddress, boolean secure,
+                                                       @Nullable String region) {
         if (vipAddress == null) {
             throw new IllegalArgumentException(
                     "Supplied VIP Address cannot be null");
@@ -299,7 +302,7 @@ public class DiscoveryClient implements LookupService {
             applications = this.localRegionApps.get();
         } else {
             applications = remoteRegionVsApps.get(region);
-            if (null == region) {
+            if (null == applications) {
                 logger.debug("No applications are defined for region {}, so returning an empty instance list for vip address {}.",
                              region, vipAddress);
                 return Collections.emptyList();

--- a/eureka-client/src/main/java/com/netflix/discovery/InstanceRegionChecker.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/InstanceRegionChecker.java
@@ -1,5 +1,8 @@
 package com.netflix.discovery;
 
+import com.google.common.base.Supplier;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
 import com.netflix.appinfo.AmazonInfo;
 import com.netflix.appinfo.DataCenterInfo;
 import com.netflix.appinfo.InstanceInfo;
@@ -7,7 +10,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static com.netflix.discovery.DefaultEurekaClientConfig.DEFAULT_ZONE;
@@ -19,10 +25,24 @@ public class InstanceRegionChecker {
 
     private static final Logger logger = LoggerFactory.getLogger(InstanceRegionChecker.class);
 
+    /**
+     * A default for the mapping that we know of, if a remote region is configured to be fetched but does not have
+     * any availability zone mapping, we will use these defaults. OTOH, if the remote region has any mapping defaults
+     * will not be used.
+     */
+    private final Multimap<String, String> defaultRegionVsAzMap =
+            Multimaps.newListMultimap(new HashMap<String, Collection<String>>(), new Supplier<List<String>>() {
+                @Override
+                public List<String> get() {
+                    return new ArrayList<String>();
+                }
+            });
+
     private final Map<String, String> availabilityZoneVsRegion = new HashMap<String, String>();
     private final String localRegion;
 
     InstanceRegionChecker(String remoteRegionsToFetch, EurekaClientConfig clientConfig) {
+        populateDefaultAZToRegionMap();
         localRegion = clientConfig.getRegion();
         if (null != remoteRegionsToFetch) {
             String[] remoteRegions = remoteRegionsToFetch.split(",");
@@ -30,24 +50,54 @@ public class InstanceRegionChecker {
                 String[] availabilityZones = clientConfig.getAvailabilityZones(remoteRegion);
                 if (null == availabilityZones ||
                     (availabilityZones.length == 1 && availabilityZones[0].equals(DEFAULT_ZONE))) {
-                    String msg = "No availability zone information available for remote region: " + remoteRegion +
-                                 ". This is required if registry information for this region is configured to be fetched.";
-                    logger.error(msg);
-                    throw new RuntimeException(msg);
+                    logger.info("No availability zone information available for remote region: " + remoteRegion +
+                                " via config. Now checking in the default mapping.");
+                    if (defaultRegionVsAzMap.containsKey(remoteRegion)) {
+                        Collection<String> defaultAvailabilityZones = defaultRegionVsAzMap.get(remoteRegion);
+                        for (String defaultAvailabilityZone : defaultAvailabilityZones) {
+                            availabilityZoneVsRegion.put(defaultAvailabilityZone, remoteRegion);
+                        }
+                    } else {
+                        String msg = "No availability zone information available for remote region: " + remoteRegion +
+                                     ". This is required if registry information for this region is configured to be fetched.";
+                        logger.error(msg);
+                        throw new RuntimeException(msg);
+                    }
                 } else {
                     for (String availabilityZone : availabilityZones) {
                         availabilityZoneVsRegion.put(availabilityZone, remoteRegion);
                     }
                 }
             }
+
+            logger.info("Availability zone to region mapping for all remote regions: {}", availabilityZoneVsRegion);
         }
+    }
+
+    private void populateDefaultAZToRegionMap() {
+        defaultRegionVsAzMap.put("us-east-1", "us-east-1a");
+        defaultRegionVsAzMap.put("us-east-1", "us-east-1c");
+        defaultRegionVsAzMap.put("us-east-1", "us-east-1d");
+        defaultRegionVsAzMap.put("us-east-1", "us-east-1e");
+
+        defaultRegionVsAzMap.put("us-west-1", "us-west-1a");
+        defaultRegionVsAzMap.put("us-west-1", "us-west-1c");
+
+        defaultRegionVsAzMap.put("us-west-2", "us-west-2a");
+        defaultRegionVsAzMap.put("us-west-2", "us-west-2b");
+        defaultRegionVsAzMap.put("us-west-2", "us-west-2c");
+
+        defaultRegionVsAzMap.put("eu-west-1", "eu-west-1a");
+        defaultRegionVsAzMap.put("eu-west-1", "eu-west-1b");
+        defaultRegionVsAzMap.put("eu-west-1", "eu-west-1c");
     }
 
 
     @Nullable
     public String getInstanceRegion(InstanceInfo instanceInfo) {
         if (DataCenterInfo.Name.Amazon.equals(instanceInfo.getDataCenterInfo().getName())) {
-            Map<String, String> metadata = instanceInfo.getMetadata();
+            AmazonInfo amazonInfo = (AmazonInfo) instanceInfo.getDataCenterInfo();
+            Map<String, String> metadata = amazonInfo.getMetadata();
             String availabilityZone = metadata.get(AmazonInfo.MetaDataKey.availabilityZone.getName());
             if (null != availabilityZone) {
                 return availabilityZoneVsRegion.get(availabilityZone);
@@ -55,11 +105,6 @@ public class InstanceRegionChecker {
         }
 
         return null;
-    }
-
-    public boolean isInstanceInLocalRegion(InstanceInfo instanceInfo) {
-        String instanceRegion = getInstanceRegion(instanceInfo);
-        return isLocalRegion(instanceRegion);
     }
 
     public boolean isLocalRegion(@Nullable String instanceRegion) {

--- a/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientTest.java
@@ -98,6 +98,18 @@ public class DiscoveryClientTest {
     }
 
     @Test
+    public void testGetInvalidVIP() throws Exception {
+        List<InstanceInfo> instancesByVipAddress = client.getInstancesByVipAddress("XYZ", false);
+        Assert.assertEquals("Unexpected number of instances found for local region.", 0, instancesByVipAddress.size());
+    }
+
+    @Test
+    public void testGetInvalidVIPForRemoteRegion() throws Exception {
+        List<InstanceInfo> instancesByVipAddress = client.getInstancesByVipAddress("XYZ", false, REMOTE_REGION);
+        Assert.assertEquals("Unexpected number of instances found for local region.", 0, instancesByVipAddress.size());
+    }
+
+    @Test
     public void testGetByVipInRemoteRegion() throws Exception {
         List<InstanceInfo> instancesByVipAddress = client.getInstancesByVipAddress(ALL_REGIONS_VIP_ADDR, false, REMOTE_REGION);
         Assert.assertEquals("Unexpected number of instances found for remote region.", 1, instancesByVipAddress.size());

--- a/eureka-client/src/test/java/com/netflix/discovery/InstanceRegionCheckerTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/InstanceRegionCheckerTest.java
@@ -1,0 +1,39 @@
+package com.netflix.discovery;
+
+import com.netflix.appinfo.AmazonInfo;
+import com.netflix.appinfo.InstanceInfo;
+import com.netflix.config.ConfigurationManager;
+import junit.framework.Assert;
+import org.junit.Test;
+
+/**
+ * @author Nitesh Kant
+ */
+public class InstanceRegionCheckerTest {
+
+    @Test
+    public void testDefaults() throws Exception {
+        InstanceRegionChecker checker =
+                new InstanceRegionChecker("us-east-1", new DefaultEurekaClientConfig());
+        AmazonInfo dcInfo = AmazonInfo.Builder.newBuilder().addMetadata(AmazonInfo.MetaDataKey.availabilityZone,
+                                                                              "us-east-1c").build();
+        InstanceInfo instanceInfo = InstanceInfo.Builder.newBuilder().setAppName("abc").setDataCenterInfo(dcInfo).build();
+        String instanceRegion = checker.getInstanceRegion(instanceInfo);
+
+        Assert.assertEquals("Invalid instance region.", "us-east-1", instanceRegion);
+    }
+
+    @Test
+    public void testDefaultOverride() throws Exception {
+        ConfigurationManager.getConfigInstance().setProperty("eureka.us-east-1.availabilityZones", "abc,def");
+        InstanceRegionChecker checker =
+                new InstanceRegionChecker("us-east-1", new DefaultEurekaClientConfig());
+        AmazonInfo dcInfo = AmazonInfo.Builder.newBuilder().addMetadata(AmazonInfo.MetaDataKey.availabilityZone,
+                                                                              "def").build();
+        InstanceInfo instanceInfo = InstanceInfo.Builder.newBuilder().setAppName("abc").setDataCenterInfo(
+                dcInfo).build();
+        String instanceRegion = checker.getInstanceRegion(instanceInfo);
+
+        Assert.assertEquals("Invalid instance region.", "us-east-1", instanceRegion);
+    }
+}


### PR DESCRIPTION
1) Provided a default availability zone -> region mapping for ec2 so that every client does not have to provide the same. This can be overridden by a property per region.
2) Fixed a bug in DiscoveryClient.getInstancesByVipAddress() for a region. For invalid VIPs, the null check was wrong.
