### PR TITLE
Add support for Eucalyptus endpoints

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ subprojects {
 
 project(':eureka-client') {
     dependencies {
+        compile 'com.amazonaws:aws-java-sdk:1.3.27'
         compile 'com.thoughtworks.xstream:xstream:1.4.2'
         compile 'com.netflix.archaius:archaius-core:0.3.3'
         compile 'javax.ws.rs:jsr311-api:1.1.1'

--- a/eureka-client/src/main/java/com/netflix/discovery/DefaultEurekaClientConfig.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DefaultEurekaClientConfig.java
@@ -327,6 +327,16 @@ public class DefaultEurekaClientConfig implements EurekaClientConfig {
                 .get();
     }
 
+    @Override
+    public String getEc2Endpoint( ) {
+      return "ec2." + this.getRegion( ).trim( ).toLowerCase( ) + ".amazonaws.com";
+    }
+
+    @Override
+    public String getAutoScalingEndpoint( ) {
+      return "autoscaling." + this.getRegion( ).trim( ).toLowerCase( ) + ".amazonaws.com";
+    }
+
     /*
      * (non-Javadoc)
      * 

--- a/eureka-client/src/main/java/com/netflix/discovery/EucalyptusEurekaClientConfig.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/EucalyptusEurekaClientConfig.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2012 Netflix, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.netflix.discovery;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netflix.config.ConfigurationManager;
+import com.netflix.config.DynamicPropertyFactory;
+import com.netflix.config.DynamicStringProperty;
+
+public class EucalyptusEurekaClientConfig extends DefaultEurekaClientConfig implements EurekaClientConfig {
+  private static final DynamicPropertyFactory configInstance = com.netflix.config.DynamicPropertyFactory
+      .getInstance();
+
+  @Override
+  public String getEc2Endpoint( ) {
+    String eucalyptusHost = configInstance.getStringProperty("eureka.eucalyptus.host", super.getEc2Endpoint( ))
+    .get();
+    return URI.create( "http://" + eucalyptusHost + ":8773/services/Eucalyptus" ).toASCIIString( );
+  }
+
+  @Override
+  public String getAutoScalingEndpoint( ) {
+    String eucalyptusHost = configInstance.getStringProperty("eureka.eucalyptus.host", super.getAutoScalingEndpoint( ))
+    .get();
+    return URI.create( "http://" + eucalyptusHost + ":8773/services/AutoScaling" ).toASCIIString( );
+  }
+}

--- a/eureka-client/src/main/java/com/netflix/discovery/EurekaClientConfig.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/EurekaClientConfig.java
@@ -19,9 +19,8 @@ package com.netflix.discovery;
 import java.net.URI;
 import java.net.URL;
 import java.util.List;
-
 import org.apache.http.client.HttpClient;
-
+import com.amazonaws.AmazonWebServiceClient;
 import com.netflix.appinfo.InstanceInfo.InstanceStatus;
 
 /**
@@ -331,6 +330,22 @@ public interface EurekaClientConfig {
      * @return AWS region where this instance resides.
      */
     String getRegion();
+
+    /**
+     * Gets the EC2 endpoint URL (used in AWS datacenters). The URL is determined by the
+     * implementor and may not be a string substitution as in AWS.
+     * 
+     * @return AWS service URL which this instance should use.
+     */
+    String getEc2Endpoint();
+
+    /**
+     * Gets the AutoScaling endpoint URL (used in AWS datacenters). The URL is determined by the
+     * implementor and may not be a string substitution as in AWS.
+     * 
+     * @return AWS service URL which this instance should use.
+     */
+    String getAutoScalingEndpoint();
 
     /**
      * Gets the list of availability zones (used in AWS data centers) for the

--- a/eureka-core/src/main/java/com/netflix/eureka/util/AwsAsgUtil.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/util/AwsAsgUtil.java
@@ -88,9 +88,9 @@ public class AwsAsgUtil {
     private static final AwsAsgUtil awsAsgUtil = new AwsAsgUtil();
 
     private AwsAsgUtil() {
-        String region = DiscoveryManager.getInstance().getEurekaClientConfig()
-                .getRegion();
-        client.setEndpoint("autoscaling." + region + ".amazonaws.com");
+        String autoscalingUrl = DiscoveryManager.getInstance().getEurekaClientConfig()
+                .getAutoScalingEndpoint();
+        client.setEndpoint(autoscalingUrl);
         timer.schedule(getASGUpdateTask(),
                 eurekaConfig.getASGUpdateIntervalMs(),
                 eurekaConfig.getASGUpdateIntervalMs());

--- a/eureka-core/src/main/java/com/netflix/eureka/util/EIPManager.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/util/EIPManager.java
@@ -17,6 +17,7 @@
 package com.netflix.eureka.util;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -331,9 +332,7 @@ public class EIPManager {
             regionPhrase = "." + region;
         }
         for (String cname : ec2Urls) {
-            int beginIndex = cname.indexOf("ec2-") + 4;
-            int endIndex = cname.indexOf(regionPhrase + ".compute");
-            String eipStr = cname.substring(beginIndex, endIndex);
+            String eipStr = URI.create(cname).getHost().replaceFirst("^[^-]*-","").replaceFirst("\\..*$","");
             String eip = eipStr.replaceAll("\\-", ".");
             returnedUrls.add(eip);
         }
@@ -386,11 +385,10 @@ public class EIPManager {
             ec2Service = new AmazonEC2Client(
                     new InstanceProfileCredentialsProvider());
         }
-
-        String region = DiscoveryManager.getInstance().getEurekaClientConfig()
-        .getRegion();
-        region = region.trim().toLowerCase();
-        ec2Service.setEndpoint("ec2." + region + ".amazonaws.com");
+        
+        String ec2url = DiscoveryManager.getInstance().getEurekaClientConfig()
+            .getEc2Endpoint();
+        ec2Service.setEndpoint(ec2url);
         return ec2Service;
     }
 }


### PR DESCRIPTION
- Use EurekaClientConfig to obtain EC2 and AutoScaling endpoints.
- Introduce EucalyptusEurekaClientConfig for construcing euca URLs.
- Modify AwsAsgUtil and EIPManager accordingly.
