### PR TITLE
Fix for issue #53 #70 #72

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,11 @@ project(':eureka-client') {
         compile 'com.netflix.archaius:archaius-core:0.3.3'
         compile 'javax.ws.rs:jsr311-api:1.1.1'
         compile 'com.netflix.servo:servo-core:0.4.36'
-        provided 'com.sun.jersey:jersey-bundle:1.9.1'
+        compile 'com.sun.jersey:jersey-core:1.11'
+        compile 'com.sun.jersey:jersey-client:1.11'
         compile 'com.sun.jersey.contribs:jersey-apache-client4:1.8'
         compile 'org.apache.httpcomponents:httpclient:4.1.2'
+        compile 'com.netflix.ribbon:ribbon-httpclient:0.3.4'
         runtime 'org.codehaus.jettison:jettison:1.2'
 
         testCompile 'junit:junit:4.10'
@@ -55,9 +57,6 @@ project(':eureka-core') {
         compile 'com.netflix.archaius:archaius-core:0.3.3'
         compile 'javax.ws.rs:jsr311-api:1.1.1'
         compile 'com.netflix.servo:servo-core:0.4.36'
-        provided 'com.sun.jersey:jersey-bundle:1.9.1'
-        compile 'com.sun.jersey.contribs:jersey-apache-client4:1.8'
-        compile 'org.apache.httpcomponents:httpclient:4.1.2'
         compile 'com.netflix.blitz4j:blitz4j:1.18'
 
         testCompile 'junit:junit:4.10'
@@ -90,8 +89,8 @@ project(':eureka-server') {
         compile project(':eureka-client')
         compile project(':eureka-core')
         runtime 'xerces:xercesImpl:2.4.0'
-        runtime 'asm:asm:3.1' 
-        runtime 'com.sun.jersey:jersey-bundle:1.9.1'
+        runtime 'asm:asm:3.1'
+        compile 'com.sun.jersey:jersey-server:1.11'
         compile 'org.slf4j:slf4j-log4j12:1.6.1'
         runtime 'org.codehaus.jettison:jettison:1.2' 
         providedCompile 'javax.servlet:servlet-api:2.4'

--- a/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
@@ -174,7 +174,7 @@ public class DiscoveryClient implements LookupService {
             }
             String proxyHost = clientConfig.getProxyHost();
             String proxyPort = clientConfig.getProxyPort();
-            discoveryJerseyClient = EurekaJerseyClient.createJerseyClient(
+            discoveryJerseyClient = EurekaJerseyClient.createJerseyClient("DiscoveryClient-HTTPClient",
                     clientConfig.getEurekaServerConnectTimeoutSeconds(),
                     clientConfig.getEurekaServerReadTimeoutSeconds(),
                     clientConfig.getEurekaServerTotalConnectionsPerHost(),

--- a/eureka-core/src/main/java/com/netflix/eureka/InstanceRegistry.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/InstanceRegistry.java
@@ -1206,7 +1206,8 @@ public abstract class InstanceRegistry implements LeaseManager<InstanceInfo>,
             allKnownRemoteRegions = new String[remoteRegionUrlsWithName.size()];
             int remoteRegionArrayIndex = 0;
             for (Entry<String, String> remoteRegionUrlWithName : remoteRegionUrlsWithName.entrySet()) {
-                RemoteRegionRegistry remoteRegionRegistry = new RemoteRegionRegistry(new URL(remoteRegionUrlWithName.getValue()));
+                RemoteRegionRegistry remoteRegionRegistry = new RemoteRegionRegistry(remoteRegionUrlWithName.getKey(),
+                                                                                     new URL(remoteRegionUrlWithName.getValue()));
                 regionNameVSRemoteRegistry.put(remoteRegionUrlWithName.getKey(), remoteRegionRegistry);
                 allKnownRemoteRegions[remoteRegionArrayIndex++] = remoteRegionUrlWithName.getKey();
             }

--- a/eureka-core/src/main/java/com/netflix/eureka/RemoteRegionRegistry.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/RemoteRegionRegistry.java
@@ -68,26 +68,27 @@ public class RemoteRegionRegistry implements LookupService<String> {
     private volatile AtomicReference<Applications> applicationsDelta = new AtomicReference<Applications>();
     private volatile boolean readyForServingData;
 
-    public RemoteRegionRegistry(URL remoteRegionURL) {
+    public RemoteRegionRegistry(String regionName, URL remoteRegionURL) {
         this.remoteRegionURL = remoteRegionURL;
         this.fetchRegistryTimer = Monitors.newTimer(this.remoteRegionURL
                 .toString() + "_" + "FetchRegistry");
         if (remoteRegionURL.getProtocol().equals("http")) {
-            discoveryJerseyClient = EurekaJerseyClient.createJerseyClient(
+            discoveryJerseyClient = EurekaJerseyClient.createJerseyClient(regionName,
                     EUREKA_SERVER_CONFIG.getRemoteRegionConnectTimeoutMs(),
                     EUREKA_SERVER_CONFIG.getRemoteRegionReadTimeoutMs(),
                     EUREKA_SERVER_CONFIG.getRemoteRegionTotalConnectionsPerHost(),
                     EUREKA_SERVER_CONFIG.getRemoteRegionTotalConnections(),
                     EUREKA_SERVER_CONFIG.getRemoteRegionConnectionIdleTimeoutSeconds());
         } else {
-            discoveryJerseyClient = EurekaJerseyClient.createSSLJerseyClient(
-                    EUREKA_SERVER_CONFIG.getRemoteRegionConnectTimeoutMs(),
-                    EUREKA_SERVER_CONFIG.getRemoteRegionReadTimeoutMs(),
-                    EUREKA_SERVER_CONFIG.getRemoteRegionTotalConnectionsPerHost(),
-                    EUREKA_SERVER_CONFIG.getRemoteRegionTotalConnections(),
-                    EUREKA_SERVER_CONFIG.getRemoteRegionConnectionIdleTimeoutSeconds(),
-                    EUREKA_SERVER_CONFIG.getRemoteRegionTrustStore(),
-                    EUREKA_SERVER_CONFIG.getRemoteRegionTrustStorePassword());
+            discoveryJerseyClient =
+                    EurekaJerseyClient.createSSLJerseyClient(regionName,
+                                                             EUREKA_SERVER_CONFIG.getRemoteRegionConnectTimeoutMs(),
+                                                             EUREKA_SERVER_CONFIG.getRemoteRegionReadTimeoutMs(),
+                                                             EUREKA_SERVER_CONFIG.getRemoteRegionTotalConnectionsPerHost(),
+                                                             EUREKA_SERVER_CONFIG.getRemoteRegionTotalConnections(),
+                                                             EUREKA_SERVER_CONFIG.getRemoteRegionConnectionIdleTimeoutSeconds(),
+                                                             EUREKA_SERVER_CONFIG.getRemoteRegionTrustStore(),
+                                                             EUREKA_SERVER_CONFIG.getRemoteRegionTrustStorePassword());
         }
         discoveryApacheClient = discoveryJerseyClient.getClient();
         ClientConfig cc = discoveryJerseyClient.getClientconfig();

--- a/eureka-core/src/main/java/com/netflix/eureka/cluster/PeerEurekaNode.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/cluster/PeerEurekaNode.java
@@ -100,7 +100,13 @@ public class PeerEurekaNode {
 
             if (jerseyApacheClient == null) {
                 try {
-                    jerseyClient = EurekaJerseyClient.createJerseyClient(
+                    String hostname;
+                    try {
+                        hostname = new URL(serviceUrl).getHost();
+                    } catch (MalformedURLException e) {
+                        hostname = serviceUrl;
+                    }
+                    jerseyClient = EurekaJerseyClient.createJerseyClient(hostname,
                             config.getPeerNodeConnectTimeoutMs(),
                             config.getPeerNodeReadTimeoutMs(),
                             config.getPeerNodeTotalConnections(),


### PR DESCRIPTION
Issue #70 Using ribbon's MonitoredConnectionManager instead of apache's ThreadSafeClientConnManager
Issue #72 Improved exception handling in DiscoveryJerseyProvider & closing inputstream on Error during read.
