### PR TITLE
Bumping snapshot version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.1.121-SNAPSHOT
+version=1.1.123-SNAPSHOT


### PR DESCRIPTION
For some odd reason the snapshot versions are messed up in Netflix artifactory. So bumping the revision manually.
