### PR TITLE
Fix service UP timestamp from getting reset

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/InstanceRegistry.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/InstanceRegistry.java
@@ -184,6 +184,9 @@ public abstract class InstanceRegistry implements LeaseManager<InstanceInfo>,
             }
             Lease<InstanceInfo> lease = new Lease<InstanceInfo>(r,
                     leaseDuration);
+            if (existingLease != null) {
+                lease.setServiceUpTimestamp(existingLease.getServiceUpTimestamp());
+            }
             gMap.put(r.getId(), lease);
             synchronized (recentRegisteredQueue) {
                 recentRegisteredQueue.add(new Pair<Long, String>(Long

--- a/eureka-core/src/main/java/com/netflix/eureka/lease/Lease.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/lease/Lease.java
@@ -85,6 +85,13 @@ public class Lease<T> {
     }
 
     /**
+     * Set the leases service UP timestamp
+     */
+    public void setServiceUpTimestamp(long serviceUpTimestamp) {
+        this.serviceUpTimestamp = serviceUpTimestamp;
+    }
+
+    /**
      * Checks if the lease of a given {@link InstanceInfo} has expired or not.
      */
     public boolean isExpired() {

--- a/eureka-server/test/java/com/netflix/eureka/SampleEurekaService.java
+++ b/eureka-server/test/java/com/netflix/eureka/SampleEurekaService.java
@@ -55,12 +55,32 @@ public class SampleEurekaService {
     .getLogger(SampleEurekaService.class);
 
     public void registerWithEureka() {
+        int sleepSeconds = 60; // Application initialization and running simulation time
+
         // Register with Eureka
         DiscoveryManager.getInstance().initComponent(
                 new MyDataCenterInstanceConfig(),
                 new DefaultEurekaClientConfig());
+
+        // A good practice is to register as STARTING and only change status to UP
+        // after the service is ready to receive traffic
+        System.out.println("Registering service to eureka with STARTING status");
+        ApplicationInfoManager.getInstance().setInstanceStatus(
+                InstanceStatus.STARTING);
+
+        System.out.println("Simulating service initialization by sleeping for " +
+                           sleepSeconds + " seconds...");
+        try {
+            Thread.sleep(sleepSeconds * 1000);
+        } catch (InterruptedException e) {
+            // Nothing
+        }
+
+        // Now we change our status to UP
+        System.out.println("Done sleeping, now changing status to UP");
         ApplicationInfoManager.getInstance().setInstanceStatus(
                 InstanceStatus.UP);
+
         String vipAddress = configInstance.getStringProperty(
                 "eureka.vipAddress", "sampleservice.mydomain.net").get();
         InstanceInfo nextServerInfo = null;
@@ -95,7 +115,18 @@ public class SampleEurekaService {
         } catch (IOException e) {
             e.printStackTrace();
         }
+
+        System.out.println("Simulating service doing work by sleeping for " +
+                sleepSeconds + " seconds...");
+        try {
+            Thread.sleep(sleepSeconds * 1000);
+        } catch (InterruptedException e) {
+            // Nothing
+        }
+
+        System.out.println("Removing registration from eureka");
         this.unRegisterWithEureka();
+
         System.out.println("Shutting down server.Demo over.");
 
     }
@@ -116,7 +147,7 @@ public class SampleEurekaService {
             PrintStream out = new PrintStream(s.getOutputStream());
             System.out.println("Sending the response to the client...");
 
-            out.println("Reponse at " + new Date());
+            out.println("Response at " + new Date());
 
         } catch (Throwable e) {
             System.err.println("Error processing requests");


### PR DESCRIPTION
There was an issue with service UP timestamp tracking where the
timestamp would get reset in cases where a lease was re-registered.

Also modified the sample service to start in STARTING mode and only
transition to UP status after simulating application initialization
time by sleeping for 60 seconds.
