### PR TITLE
Added the UniqueIdentifier interface

### DIFF
--- a/eureka-client/src/main/java/com/netflix/appinfo/AmazonInfo.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/AmazonInfo.java
@@ -41,7 +41,7 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
  * @author Karthik Ranganathan, Greg Kim
  * 
  */
-public class AmazonInfo implements DataCenterInfo {
+public class AmazonInfo implements DataCenterInfo, UniqueIdentifier {
 
     private Map<String, String> metadata = new HashMap<String, String>();
     private static DynamicBooleanProperty shouldLogAWSMetadataError;
@@ -216,5 +216,10 @@ public class AmazonInfo implements DataCenterInfo {
      */
     public String get(MetaDataKey key) {
         return metadata.get(key.getName());
+    }
+
+    @Override
+    public String getId() {
+        return get(MetaDataKey.instanceId);
     }
 }

--- a/eureka-client/src/main/java/com/netflix/appinfo/InstanceInfo.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/InstanceInfo.java
@@ -686,8 +686,8 @@ public class InstanceInfo {
      * @return the unique id.
      */
     public String getId() {
-        if (dataCenterInfo.getName() == Name.Amazon) {
-            return ((AmazonInfo) dataCenterInfo).get(MetaDataKey.instanceId);
+        if (dataCenterInfo instanceof UniqueIdentifier) {
+            return ((UniqueIdentifier) dataCenterInfo).getId();
         } else {
             return hostName;
         }

--- a/eureka-client/src/main/java/com/netflix/appinfo/UniqueIdentifier.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/UniqueIdentifier.java
@@ -1,0 +1,10 @@
+package com.netflix.appinfo;
+
+/**
+ * Generally indicates the unique identifier of a {@link com.netflix.appinfo.DataCenterInfo}, if applicable.
+ *
+ * @author rthomas@atlassian.com
+ */
+public interface UniqueIdentifier {
+    String getId();
+}


### PR DESCRIPTION
Added the UniqueIdentifier interface and modified InstanceInfo to call this getId method if this interface is implemented, rather than checking if name is Name.AMAZON. Updated AmazonInfo to use this.

This change is to allow non-amazon instances to be identified by a mechanism other than their hostname - e.g. multiple docker containers on the same host, registering with Eureka with the docker-host address.
