### PR TITLE
Do not instantly fail tests when MockEureka port is in use

### DIFF
--- a/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientDisableRegistryTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientDisableRegistryTest.java
@@ -15,24 +15,21 @@ import java.util.UUID;
  * @author Nitesh Kant
  */
 public class DiscoveryClientDisableRegistryTest {
-
-    private static final int localRandomEurekaPort = 7799;
     private DiscoveryClient client;
     private MockRemoteEurekaServer mockLocalEurekaServer;
 
     @Before
     public void setUp() throws Exception {
-        final int eurekaPort = localRandomEurekaPort + (int)(Math.random() * 10);
+        mockLocalEurekaServer = MockRemoteEurekaServer.createNearPort(
+                7799,
+                Collections.<String, Application>emptyMap(),
+                Collections.<String, Application>emptyMap(),
+                Collections.<String, Application>emptyMap(),
+                Collections.<String, Application>emptyMap());
         ConfigurationManager.getConfigInstance().setProperty("eureka.registration.enabled", "false");
         ConfigurationManager.getConfigInstance().setProperty("eureka.serviceUrl.default",
-                                                             "http://localhost:" + eurekaPort +
-                                                             MockRemoteEurekaServer.EUREKA_API_BASE_PATH);
-
-        mockLocalEurekaServer = new MockRemoteEurekaServer(eurekaPort, Collections.<String, Application>emptyMap(),
-                                                           Collections.<String, Application>emptyMap(),
-                                                           Collections.<String, Application>emptyMap(),
-                                                           Collections.<String, Application>emptyMap());
-        mockLocalEurekaServer.start();
+                "http://localhost:" + mockLocalEurekaServer.getPort() +
+                        MockRemoteEurekaServer.EUREKA_API_BASE_PATH);
 
         InstanceInfo.Builder builder = InstanceInfo.Builder.newBuilder();
         builder.setIPAddr("10.10.101.00");

--- a/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientRegistryTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientRegistryTest.java
@@ -43,25 +43,24 @@ public class DiscoveryClientRegistryTest {
     private final Map<String, Application> remoteRegionAppsDelta = new HashMap<String, Application>();
 
     private DiscoveryClient client;
-    private final int localRandomEurekaPort = 7799;
 
     @Before
     public void setUp() throws Exception {
-        final int eurekaPort = localRandomEurekaPort + (int)(Math.random() * 10);
+        populateLocalRegistryAtStartup();
+        populateRemoteRegistryAtStartup();
+
+        mockLocalEurekaServer = MockRemoteEurekaServer.createNearPort(
+                7799, localRegionApps, localRegionAppsDelta,
+                remoteRegionApps, remoteRegionAppsDelta);
+
         ConfigurationManager.getConfigInstance().setProperty("eureka.client.refresh.interval", CLIENT_REFRESH_RATE);
         ConfigurationManager.getConfigInstance().setProperty("eureka.registration.enabled", "false");
         ConfigurationManager.getConfigInstance().setProperty("eureka.fetchRemoteRegionsRegistry", REMOTE_REGION);
         ConfigurationManager.getConfigInstance().setProperty("eureka.myregion.availabilityZones", REMOTE_ZONE);
         ConfigurationManager.getConfigInstance().setProperty("eureka.serviceUrl.default",
-                                                             "http://localhost:" + eurekaPort +
-                                                             MockRemoteEurekaServer.EUREKA_API_BASE_PATH);
-        populateLocalRegistryAtStartup();
-        populateRemoteRegistryAtStartup();
-
-        mockLocalEurekaServer = new MockRemoteEurekaServer(eurekaPort, localRegionApps, localRegionAppsDelta,
-                                                           remoteRegionApps, remoteRegionAppsDelta);
-        mockLocalEurekaServer.start();
-
+                "http://localhost:" + mockLocalEurekaServer.getPort() +
+                        MockRemoteEurekaServer.EUREKA_API_BASE_PATH
+        );
         InstanceInfo.Builder builder = InstanceInfo.Builder.newBuilder();
         builder.setIPAddr("10.10.101.00");
         builder.setHostName("Hosttt");


### PR DESCRIPTION
When the tests run quickly, the MockRemoteEurekaServer port is frequently still
in use, throwing a BindError.  Rather than dying instantly, repeatedly try to
grab the port, backing off slightly each time.
