### PR TITLE
remove import of com.netflix.logging.* from status.jsp, as it does not a...

### DIFF
--- a/eureka-resources/src/main/resources/jsp/status.jsp
+++ b/eureka-resources/src/main/resources/jsp/status.jsp
@@ -1,4 +1,4 @@
-<%@ page language="java" import="java.util.*,java.util.Map.Entry,com.netflix.discovery.shared.Pair,com.netflix.logging.*,com.netflix.discovery.shared.*, com.netflix.eureka.util.*,com.netflix.appinfo.InstanceInfo.*, com.netflix.appinfo.DataCenterInfo.*,com.netflix.appinfo.AmazonInfo.MetaDataKey,com.netflix.eureka.resources.*,com.netflix.eureka.*,com.netflix.appinfo.*" pageEncoding="UTF-8" %>
+<%@ page language="java" import="java.util.*,java.util.Map.Entry,com.netflix.discovery.shared.Pair,com.netflix.discovery.shared.*, com.netflix.eureka.util.*,com.netflix.appinfo.InstanceInfo.*, com.netflix.appinfo.DataCenterInfo.*,com.netflix.appinfo.AmazonInfo.MetaDataKey,com.netflix.eureka.resources.*,com.netflix.eureka.*,com.netflix.appinfo.*" pageEncoding="UTF-8" %>
 <%
 String path = request.getContextPath();
 String basePath = request.getScheme()+"://"+request.getServerName()+":"+request.getServerPort()+path+"/";


### PR DESCRIPTION
Remove import of com.netflix.logging.\* from status.jsp, as it does not appear to be actually used. (Should be hidden to app layer really)

And it makes jetty9 angry due to there being no classes at that node of the package namespace, only below it. 

Alternate possibility, if classes _are_ needed, is to import deeper into the package space where needed. But if its not referenced, removal is probably better.
