### PR TITLE
Fix DefaultEurekaClientConfig units

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/DefaultEurekaClientConfig.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DefaultEurekaClientConfig.java
@@ -132,7 +132,7 @@ public class DefaultEurekaClientConfig implements EurekaClientConfig {
     @Override
     public int getEurekaServiceUrlPollIntervalSeconds() {
         return configInstance.getIntProperty(
-                namespace + "serviceUrlPollIntervalMs", 5 * 60 * 1000).get();
+                namespace + "serviceUrlPollIntervalMs", 5 * 60 * 1000).get() / 1000;
     }
 
     /*
@@ -176,7 +176,7 @@ public class DefaultEurekaClientConfig implements EurekaClientConfig {
     @Override
     public int getEurekaServerReadTimeoutSeconds() {
         return configInstance.getIntProperty(
-                namespace + "eurekaServer.readTimeout", 8000).get();
+                namespace + "eurekaServer.readTimeout", 8).get();
     }
 
     /*
@@ -187,7 +187,7 @@ public class DefaultEurekaClientConfig implements EurekaClientConfig {
     @Override
     public int getEurekaServerConnectTimeoutSeconds() {
         return configInstance.getIntProperty(
-                namespace + "eurekaServer.connectTimeout", 5000).get();
+                namespace + "eurekaServer.connectTimeout", 5).get();
     }
 
     /*

--- a/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
@@ -186,9 +186,9 @@ public class DiscoveryClient implements LookupService {
             String proxyPort = clientConfig.getProxyPort();
             discoveryJerseyClient = EurekaJerseyClient.createJerseyClient("DiscoveryClient-HTTPClient",
                                                                           clientConfig
-                                                                                  .getEurekaServerConnectTimeoutSeconds(),
+                                                                                  .getEurekaServerConnectTimeoutSeconds() * 1000,
                                                                           clientConfig
-                                                                                  .getEurekaServerReadTimeoutSeconds(),
+                                                                                  .getEurekaServerReadTimeoutSeconds() * 1000,
                                                                           clientConfig
                                                                                   .getEurekaServerTotalConnectionsPerHost(),
                                                                           clientConfig

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/EurekaJerseyClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/EurekaJerseyClient.java
@@ -65,16 +65,16 @@ public final class EurekaJerseyClient {
      *
      * @param clientName
      * @param connectionTimeout
-     *            - The connection timeout of the connection
+     *            - The connection timeout of the connection in milliseconds
      * @param readTimeout
-     *            - The read timeout of the connection
+     *            - The read timeout of the connection in milliseconds
      * @param maxConnectionsPerHost
      *            - The maximum number of connections to a particular host
      * @param maxTotalConnections
      *            - The maximum number of total connections across all hosts
      * @param connectionIdleTimeout
      *            - The idle timeout after which the connections will be cleaned
-     *            up
+     *            up in seconds
      * @return - The jersey client object encapsulating the connection
      */
     public static JerseyClient createJerseyClient(String clientName, int connectionTimeout,
@@ -100,16 +100,16 @@ public final class EurekaJerseyClient {
      *
      * @param clientName
      * @param connectionTimeout
-     *            - The connection timeout of the connection
+     *            - The connection timeout of the connection in milliseconds
      * @param readTimeout
-     *            - The read timeout of the connection
+     *            - The read timeout of the connection in milliseconds
      * @param maxConnectionsPerHost
      *            - The maximum number of connections to a particular host
      * @param maxTotalConnections
      *            - The maximum number of total connections across all hosts
      * @param connectionIdleTimeout
      *            - The idle timeout after which the connections will be cleaned
-     *            up
+     *            up in seconds
      * @param trustStoreFileName
      *            - The full path to the trust store file
      * @param trustStorePassword


### PR DESCRIPTION
EurekaServiceUrlPollInterval is named
getEurekaServiceUrlPollIntervalSeconds in EurekaClientConfig interface
but serviceUrlPollIntervalMs in config files. Its default looks
suspiciously like it shouldn't be multiplied by 1000. This config is
actually used as seconds. Changed to be seconds
serviceUrlPollIntervalSeconds and fixed the default.

EurekaServerReadTimeoutSeconds and EurekaServerConnectTimeoutSeconds
were both being contributed as millseconds and used as milliseconds.
Changed to seconds in config files and use of the config changed to use
seconds.
