### PR TITLE
Do not get into a 500 state when a bad app registers

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/converters/Converters.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/converters/Converters.java
@@ -488,11 +488,13 @@ public final class Converters {
                             dataCenterName)) {
                         info = new AmazonInfo();
                     } else {
+                        final DataCenterInfo.Name name =
+                                DataCenterInfo.Name.valueOf(dataCenterName);
                         info = new DataCenterInfo() {
 
                             @Override
                             public Name getName() {
-                                return Name.valueOf(dataCenterName);
+                                return name;
                             }
                         };
                     }


### PR DESCRIPTION
Previously, the DataCenterInfo was not effectively "validated" until read
time, which meant that a malicious (or simply badly coded) app could take the
Eureka cluster offline by specifying a dataCenterName that wasn't one of
Amazon, MyOwn, or Netflix.  Move the validation code to write time by doing
the conversion to DataCenterInfo.Name as part of the deserialization process.
