### PR TITLE
Changing external dependencies to follow a range version scheme.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,10 @@ ext.githubProjectName = 'eureka'
 
 ext {
     jerseyVersion="1.11"
-    governatorVersion="[1.2.7,)"
-    archaiusVersion="[0.3,)"
-    ribbonVersion="[0.3,)"
-    blitzVersion="[1.18,)"
+    governatorVersion="[1.2.7,2.0["
+    archaiusVersion="[0.3,1.0["
+    ribbonVersion="[0.3,1.0["
+    blitzVersion="[1.18,2.0["
 }
 
 buildscript {


### PR DESCRIPTION
The fixed version numbers for dependencies requires too many changes for every upgrade of any library.
This new scheme will pin to the same major version instead.
