### PR TITLE
Instantly start up if there are no peers to sync with

### DIFF
--- a/eureka-client/src/test/java/com/netflix/discovery/BackUpRegistryTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/BackUpRegistryTest.java
@@ -8,7 +8,6 @@ import com.netflix.discovery.shared.Application;
 import com.netflix.discovery.shared.Applications;
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import javax.annotation.Nullable;
@@ -24,11 +23,9 @@ public class BackUpRegistryTest {
 
     public static final String ALL_REGIONS_VIP_ADDR = "myvip";
     public static final String REMOTE_REGION_INSTANCE_1_HOSTNAME = "blah";
-    public static final String REMOTE_REGION_INSTANCE_2_HOSTNAME = "blah2";
 
     public static final String LOCAL_REGION_APP_NAME = "MYAPP_LOC";
     public static final String LOCAL_REGION_INSTANCE_1_HOSTNAME = "blahloc";
-    public static final String LOCAL_REGION_INSTANCE_2_HOSTNAME = "blahloc2";
 
     public static final String REMOTE_REGION_APP_NAME = "MYAPP";
     public static final String REMOTE_REGION = "myregion";

--- a/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientRegistryTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientRegistryTest.java
@@ -37,9 +37,9 @@ public class DiscoveryClientRegistryTest {
 
     @Rule
     public MockRemoteEurekaServer mockLocalEurekaServer= new MockRemoteEurekaServer();
-    
+
     private DiscoveryClient client;
-    
+
     @Before
     public void setUp() throws Exception {
 
@@ -51,7 +51,7 @@ public class DiscoveryClientRegistryTest {
         ConfigurationManager.getConfigInstance().setProperty("eureka.serviceUrl.default",
                                                              "http://localhost:" + mockLocalEurekaServer.getPort() +
                                                              MockRemoteEurekaServer.EUREKA_API_BASE_PATH);
-        
+
         populateLocalRegistryAtStartup();
         populateRemoteRegistryAtStartup();
 
@@ -158,7 +158,7 @@ public class DiscoveryClientRegistryTest {
     private void populateRemoteRegistryAtStartup() {
         Application myapp = createRemoteApps();
         Application myappDelta = createRemoteAppsDelta();
-        
+
         mockLocalEurekaServer.addRemoteRegionApps(REMOTE_REGION_APP_NAME, myapp);
         mockLocalEurekaServer.addRemoteRegionAppsDelta(REMOTE_REGION_APP_NAME, myappDelta);
     }

--- a/eureka-client/src/test/java/com/netflix/discovery/DiscoveryStatusCheckerTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/DiscoveryStatusCheckerTest.java
@@ -31,7 +31,7 @@ import com.netflix.governator.guice.BootstrapModule;
 import com.netflix.governator.guice.LifecycleInjector;
 
 public class DiscoveryStatusCheckerTest {
-    
+
     public static final String ALL_REGIONS_VIP_ADDR = "myvip";
     public static final String REMOTE_REGION_INSTANCE_1_HOSTNAME = "blah";
     public static final String REMOTE_REGION_INSTANCE_2_HOSTNAME = "blah2";
@@ -48,10 +48,10 @@ public class DiscoveryStatusCheckerTest {
 
     @Rule
     public MockRemoteEurekaServer mockLocalEurekaServer = new MockRemoteEurekaServer();
-    
+
     private InstanceInfo instanceInfo;
     private static EventBus eventBus = new EventBusImpl();
-    
+
     @Before
     public void setUp() throws Exception {
         final int eurekaPort = mockLocalEurekaServer.getPort();
@@ -76,16 +76,16 @@ public class DiscoveryStatusCheckerTest {
                 return Name.MyOwn;
             }
         });
-        
+
         instanceInfo = builder.build();
     }
-    
-    
+
+
     public static class Service {
         final Supplier<Boolean> upStatusSupplier;
         final Supplier<Boolean> dnStatusSupplier;
         final DiscoveryClient client;
-        
+
         @Inject
         public Service(
                 DiscoveryClient client,
@@ -96,13 +96,13 @@ public class DiscoveryStatusCheckerTest {
             this.upStatusSupplier = upStatusSupplier;
             this.dnStatusSupplier = dnStatusSupplier;
         }
-        
+
         public void assertState(boolean state) {
             Assert.assertEquals(state, (boolean)upStatusSupplier.get());
             Assert.assertEquals(state, !dnStatusSupplier.get());
         }
     }
-    
+
     @Test
     public void testStatus() throws Exception {
         Injector injector = LifecycleInjector.builder()
@@ -127,17 +127,17 @@ public class DiscoveryStatusCheckerTest {
                     })
                 .build()
                 .createInjector();
-        
+
         Service service = injector.getInstance(Service.class);
         mockLocalEurekaServer.waitForDeltaToBeRetrieved(CLIENT_REFRESH_RATE);
         service.assertState(true);
-        
+
         DiscoveryClient client = injector.getInstance(DiscoveryClient.class);
         client.unregister();
         mockLocalEurekaServer.waitForDeltaToBeRetrieved(CLIENT_REFRESH_RATE);
         TimeUnit.SECONDS.sleep(CLIENT_REFRESH_RATE * 2);
 //        service.assertState(false);
-        
+
         // TODO: More work needs to be done on the MockEurekaServer to properly support this
         //       This is disabled for now until MockEurekaServer can be updated
 //        System.out.println("****** Re-register");
@@ -146,7 +146,7 @@ public class DiscoveryStatusCheckerTest {
 //        TimeUnit.SECONDS.sleep(CLIENT_REFRESH_RATE * 2);
 //        service.assertState(true);
     }
-    
+
     private void populateLocalRegistryAtStartup() {
         Application myapp = createLocalApps();
         Application myappDelta = createLocalAppsDelta();
@@ -192,7 +192,7 @@ public class DiscoveryStatusCheckerTest {
         azBuilder.addMetadata(AmazonInfo.MetaDataKey.publicHostname, instanceHostName);
         return azBuilder.build();
     }
-    
+
     private void populateRemoteRegistryAtStartup() {
         Application myapp = createRemoteApps();
         Application myappDelta = createRemoteAppsDelta();

--- a/eureka-client/src/test/java/com/netflix/discovery/EurekaLifecycleTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/EurekaLifecycleTest.java
@@ -5,7 +5,6 @@ import junit.framework.Assert;
 import org.junit.After;
 import org.junit.Test;
 
-import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import com.netflix.config.ConfigurationManager;
 import com.netflix.governator.guice.BootstrapBinder;
@@ -17,29 +16,29 @@ public class EurekaLifecycleTest {
     public void afterEachTest() {
         ConfigurationManager.getConfigInstance().clear();
     }
-    
+
     @Test
     public void testDefaultInstanceConfig() {
         ConfigurationManager.getConfigInstance().setProperty("eureka.validateInstanceId", "false");
         ConfigurationManager.getConfigInstance().setProperty("eureka.shouldFetchRegistry", "false");
         ConfigurationManager.getConfigInstance().setProperty("eureka.registration.enabled", "false");
         ConfigurationManager.getConfigInstance().setProperty("eureka.serviceUrl.default", "http://localhost:8080/");
-        
+
         Injector injector = LifecycleInjector.builder()
                 .build()
                 .createInjector();
-        
+
         DiscoveryClient client = injector.getInstance(DiscoveryClient.class);
         Assert.assertEquals(client, DiscoveryManager.getInstance().getDiscoveryClient());
     }
-    
+
     @Test
     public void testNamespaceOverride() {
         ConfigurationManager.getConfigInstance().setProperty("testnamespace.validateInstanceId", "false");
         ConfigurationManager.getConfigInstance().setProperty("testnamespace.shouldFetchRegistry", "false");
         ConfigurationManager.getConfigInstance().setProperty("testnamespace.registration.enabled", "false");
         ConfigurationManager.getConfigInstance().setProperty("testnamespace.serviceUrl.default", "http://localhost:8080/");
-        
+
         Injector injector = LifecycleInjector.builder()
                 .withBootstrapModule(new BootstrapModule() {
                     @Override
@@ -49,7 +48,7 @@ public class EurekaLifecycleTest {
                 })
                 .build()
                 .createInjector();
-        
+
         DiscoveryClient client = injector.getInstance(DiscoveryClient.class);
         Assert.assertEquals(client, DiscoveryManager.getInstance().getDiscoveryClient());
     }

--- a/eureka-client/src/test/java/com/netflix/discovery/MockRemoteEurekaServer.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/MockRemoteEurekaServer.java
@@ -59,12 +59,12 @@ public class MockRemoteEurekaServer extends ExternalResource {
     public int getPort() {
         return port;
     }
-    
+
     public void stop() throws Exception {
         server.stop();
         server = null;
         port = 0;
-        
+
         applicationMap.clear();
         remoteRegionApps.clear();
         remoteRegionAppsDelta.clear();


### PR DESCRIPTION
Please feel free to reject this; it's as much an RFC on how to address #42 as anything else.  Instead of introducing new settings for instant startup in development environments, I'm instead simply bypassing the wait part of the cycle if there are no peers to sync with.  This *might* have negative implications in a production environment, but I'm struggling to come up with one; it only shows up if you launch Eurekas a second before you populate DNS or the like.  I believe it ought to be safe.