### PR TITLE
Fix log level for serviceUrls

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
@@ -1148,7 +1148,7 @@ public class DiscoveryClient implements LookupService {
         arrangeListBasedonHostname(serviceUrls);
         serviceUrls.add(0, primaryServiceUrl);
 
-        logger.info(
+        logger.debug(
                 "This client will talk to the following serviceUrls in order : {} ",
                 Arrays.toString(serviceUrls.toArray()));
         t.stop();
@@ -1639,7 +1639,7 @@ public class DiscoveryClient implements LookupService {
                         return;
                     }
                     if (!serviceUrlList.equals(eurekaServiceUrls.get())) {
-                        logger.debug(
+                        logger.info(
                                 "Updating the serviceUrls as they seem to have changed from {} to {} ",
                                 Arrays.toString(eurekaServiceUrls.get()
                                         .toArray()), Arrays


### PR DESCRIPTION
Currently Eureka will log.info serviceUrls everytime it reads them.
It should only log.info serviceUrls if they have changed. Logging
everytime it reads should be at the debug level.
