### PR TITLE
Fix Eureka instance count and status logging

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
@@ -666,11 +666,11 @@ public class DiscoveryClient implements LookupService {
                             || clientConfig.shouldLogDeltaDiff()) {
                         response = reconcileAndLogDifference(response, delta,
                                 reconcileHashCode);
-
                     }
                 }
-                logTotalInstances();
             }
+            applications.setAppsHashCode(applications.getReconcileHashCode());
+            logTotalInstances();
 
             logger.debug(PREFIX + appPathIdentifier + " -  refresh status: "
                     + response.getStatus());
@@ -1606,7 +1606,9 @@ public class DiscoveryClient implements LookupService {
                     apps = backupRegistryInstance.fetchRegistry();
                 }
                 if (apps != null) {
-                    localRegionApps.set(this.filterAndShuffle(apps));
+                    final Applications applications = this.filterAndShuffle(apps);
+                    applications.setAppsHashCode(applications.getReconcileHashCode());
+                    localRegionApps.set(applications);
                     logTotalInstances();
                     logger.info("Fetched registry successfully from the backup");
                 }

--- a/eureka-client/src/test/java/com/netflix/discovery/AbstractDiscoveryClientTester.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/AbstractDiscoveryClientTester.java
@@ -24,8 +24,10 @@ public class AbstractDiscoveryClientTester {
     public static final String REMOTE_REGION_INSTANCE_1_HOSTNAME = "blah";
     public static final String REMOTE_REGION_INSTANCE_2_HOSTNAME = "blah2";
     public static final String LOCAL_REGION_APP_NAME = "MYAPP_LOC";
+    public static final String LOCAL_REGION_APP_NAME_2 = "MYAPP_LOC2";
     public static final String LOCAL_REGION_INSTANCE_1_HOSTNAME = "blahloc";
     public static final String LOCAL_REGION_INSTANCE_2_HOSTNAME = "blahloc2";
+    public static final String LOCAL_REGION_INSTANCE_3_HOSTNAME = "blahloc3";
     public static final String REMOTE_REGION_APP_NAME = "MYAPP";
     public static final String REMOTE_REGION = "myregion";
     public static final String REMOTE_ZONE = "myzone";
@@ -119,28 +121,36 @@ public class AbstractDiscoveryClientTester {
         mockLocalEurekaServer.addLocalRegionAppsDelta(LOCAL_REGION_APP_NAME, myappDelta);
     }
 
+    protected void addLocalAppDelta() {
+        Application myappDelta = new Application(LOCAL_REGION_APP_NAME_2);
+        InstanceInfo instanceInfo = createInstance(LOCAL_REGION_APP_NAME_2, ALL_REGIONS_VIP_ADDR, LOCAL_REGION_INSTANCE_3_HOSTNAME, null);
+        instanceInfo.setActionType(InstanceInfo.ActionType.ADDED);
+        myappDelta.addInstance(instanceInfo);
+        mockLocalEurekaServer.addLocalRegionAppsDelta(LOCAL_REGION_APP_NAME_2, myappDelta);
+    }
+
     private static Application createLocalApps() {
         Application myapp = new Application(LOCAL_REGION_APP_NAME);
-        InstanceInfo instanceInfo = createLocalInstance(LOCAL_REGION_INSTANCE_1_HOSTNAME);
+        InstanceInfo instanceInfo = createInstance(LOCAL_REGION_APP_NAME, ALL_REGIONS_VIP_ADDR, LOCAL_REGION_INSTANCE_1_HOSTNAME, null);
         myapp.addInstance(instanceInfo);
         return myapp;
     }
 
     private static Application createLocalAppsDelta() {
         Application myapp = new Application(LOCAL_REGION_APP_NAME);
-        InstanceInfo instanceInfo = createLocalInstance(LOCAL_REGION_INSTANCE_2_HOSTNAME);
+        InstanceInfo instanceInfo = createInstance(LOCAL_REGION_APP_NAME, ALL_REGIONS_VIP_ADDR, LOCAL_REGION_INSTANCE_2_HOSTNAME, null);
         instanceInfo.setActionType(InstanceInfo.ActionType.ADDED);
         myapp.addInstance(instanceInfo);
         return myapp;
     }
 
-    private static InstanceInfo createLocalInstance(String instanceHostName) {
+    private static InstanceInfo createInstance(String appName, String vipAddress, String instanceHostName, String zone) {
         InstanceInfo.Builder instanceBuilder = InstanceInfo.Builder.newBuilder();
-        instanceBuilder.setAppName(LOCAL_REGION_APP_NAME);
-        instanceBuilder.setVIPAddress(ALL_REGIONS_VIP_ADDR);
+        instanceBuilder.setAppName(appName);
+        instanceBuilder.setVIPAddress(vipAddress);
         instanceBuilder.setHostName(instanceHostName);
         instanceBuilder.setIPAddr("10.10.101.1");
-        AmazonInfo amazonInfo = getAmazonInfo(null, instanceHostName);
+        AmazonInfo amazonInfo = getAmazonInfo(zone, instanceHostName);
         instanceBuilder.setDataCenterInfo(amazonInfo);
         instanceBuilder.setMetadata(amazonInfo.getMetadata());
         instanceBuilder.setLeaseInfo(LeaseInfo.Builder.newBuilder().build());

--- a/eureka-client/src/test/java/com/netflix/discovery/BackUpRegistryTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/BackUpRegistryTest.java
@@ -122,6 +122,14 @@ public class BackUpRegistryTest {
         Assert.assertEquals("Remote region apps not present.", REMOTE_REGION_APP_NAME, registeredApplications.get(0).getName());
     }
 
+    @Test
+    public void testAppsHashCode() throws Exception {
+        setUp(true);
+        Applications applications = client.getApplications();
+
+        Assert.assertEquals("UP_1_", applications.getAppsHashCode());
+    }
+
     private void setupBackupMock() {
         Application localApp = createLocalApps();
         Applications localApps = new Applications();

--- a/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientRegistryTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientRegistryTest.java
@@ -44,8 +44,10 @@ public class DiscoveryClientRegistryTest extends AbstractDiscoveryClientTester {
 
     @Test
     public void testGetInvalidVIPForRemoteRegion() throws Exception {
-        List<InstanceInfo> instancesByVipAddress = client.getInstancesByVipAddress("XYZ", false, REMOTE_REGION);
-        Assert.assertEquals("Unexpected number of instances found for local region.", 0, instancesByVipAddress.size());
+        List<InstanceInfo> instancesByVipAddress = client.getInstancesByVipAddress("XYZ", false,
+                                                                                   REMOTE_REGION);
+        Assert.assertEquals("Unexpected number of instances found for local region.", 0,
+                            instancesByVipAddress.size());
     }
 
     @Test
@@ -64,6 +66,16 @@ public class DiscoveryClientRegistryTest extends AbstractDiscoveryClientTester {
                                   LOCAL_REGION_INSTANCE_2_HOSTNAME);
         checkInstancesFromARegion(REMOTE_REGION, REMOTE_REGION_INSTANCE_1_HOSTNAME,
                                   REMOTE_REGION_INSTANCE_2_HOSTNAME);
+    }
+
+    @Test
+    public void testAppsHashCodeAfterRefresh() throws Exception {
+        Assert.assertEquals("UP_2_", client.getApplications().getAppsHashCode());
+
+        addLocalAppDelta();
+        mockLocalEurekaServer.waitForDeltaToBeRetrieved(CLIENT_REFRESH_RATE);
+
+        Assert.assertEquals("UP_3_", client.getApplications().getAppsHashCode());
     }
 
     private void checkInstancesFromARegion(String region, String instance1Hostname, String instance2Hostname) {

--- a/eureka-core/src/main/java/com/netflix/eureka/RemoteRegionRegistry.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/RemoteRegionRegistry.java
@@ -197,9 +197,10 @@ public class RemoteRegionRegistry implements LookupService<String> {
 
                         }
                     }
-                    logTotalInstances();
                 }
             }
+            logTotalInstances();
+
             logger.debug("Remote Registry Fetch Status : {}", null == response ? null : response.getStatus());
         } catch (Throwable e) {
             logger.error(

--- a/eureka-core/src/test/java/com/netflix/eureka/InstanceRegistryTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/InstanceRegistryTest.java
@@ -51,6 +51,16 @@ public class InstanceRegistryTest extends AbstractTester {
                             remApplication.getInstances().size());
     }
 
+    @Test
+    public void testAppsHashCodeAfterRefresh() throws InterruptedException {
+        Assert.assertEquals("UP_1_", registry.getApplicationsFromAllRemoteRegions().getAppsHashCode());
+
+        registerInstanceLocally(createLocalInstance(LOCAL_REGION_INSTANCE_2_HOSTNAME));
+        waitForDeltaToBeRetrieved();
+
+        Assert.assertEquals("UP_2_", registry.getApplicationsFromAllRemoteRegions().getAppsHashCode());
+    }
+
     private void waitForDeltaToBeRetrieved() throws InterruptedException {
         int count = 0;
         while (count < 3 && !mockRemoteEurekaServer.isSentDelta()) {


### PR DESCRIPTION
Eureka client would only log the number of UP instances but with the
deceiving message:

logger.debug("The total number of instances in the client now is {}",
                totInstances);
