### PR TITLE
Improved locking for periodic registry refreshes

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
@@ -1153,6 +1153,8 @@ public class DiscoveryClient implements LookupService {
             		clientConfig.getInitialInstanceInfoReplicationIntervalSeconds(),
                     clientConfig.getInstanceInfoReplicationIntervalSeconds(), TimeUnit.SECONDS);
 
+        } else {
+            logger.info("Not registering with Eureka server per configuration");
         }
     }
 


### PR DESCRIPTION
In the very unlikely case where applying registry updates take > than the update periodicity, a subsequent update thread can trample the previous (still updating) thread.
