### PR TITLE
Enabling registration for non-amazon datacenters on server startup.

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/PeerAwareInstanceRegistry.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/PeerAwareInstanceRegistry.java
@@ -707,7 +707,7 @@ public class PeerAwareInstanceRegistry extends InstanceRegistry {
                 return true;
             }
         }
-        return false;
+        return true; // Everything non-amazon is registrable.
     }
 
     /**


### PR DESCRIPTION
`PeerAwareInstanceRegistry` disregards any non-amazon instances got from a peer on initial startup. This change enabled the registration.

Changes were discussed as part of pull request: https://github.com/Netflix/eureka/pull/134
