### PR TITLE
Adding initial implementations to partially implemented model classes

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/registry/EurekaRegistryException.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/EurekaRegistryException.java
@@ -1,0 +1,23 @@
+package com.netflix.eureka.registry;
+
+/**
+ * @author David Liu
+ */
+public class EurekaRegistryException extends Exception {
+
+    public EurekaRegistryException(Throwable th) {
+        super(th);
+    }
+
+    public EurekaRegistryException(String msg) {
+        super(msg);
+    }
+
+    public EurekaRegistryException(String msg, Throwable th) {
+        super(msg, th);
+    }
+
+    public static EurekaRegistryException instanceNotFound(String instanceId) {
+        return new EurekaRegistryException("Instance " + instanceId + "cannot be found");
+    }
+}

--- a/eureka-core/src/main/java/com/netflix/eureka/registry/Index.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/Index.java
@@ -17,6 +17,7 @@
 package com.netflix.eureka.registry;
 
 /**
+ * TODO make this better
  * @author David Liu
  */
 public enum Index {

--- a/eureka-core/src/main/java/com/netflix/eureka/registry/InstanceInfo.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/InstanceInfo.java
@@ -47,6 +47,7 @@ public class InstanceInfo implements Item, Serializable {
     @Nullable private String statusPageUrl;
     @Nullable private HashSet<String> healthCheckUrls;
 
+    // for serializers
     public InstanceInfo() {}
 
     /**
@@ -141,7 +142,7 @@ public class InstanceInfo implements Item, Serializable {
     /**
      * @return the port numbers that is used for servicing requests
      */
-    public Set<Integer> getPorts() {
+    public HashSet<Integer> getPorts() {
         return ports;
     }
 
@@ -152,7 +153,7 @@ public class InstanceInfo implements Item, Serializable {
     /**
      * @return the secure port numbers that is used for servicing requests
      */
-    public Set<Integer> getSecurePorts() {
+    public HashSet<Integer> getSecurePorts() {
         return securePorts;
     }
 
@@ -201,7 +202,7 @@ public class InstanceInfo implements Item, Serializable {
      * @return A Set containing the string representation of health check urls
      *         for secure and non secure protocols
      */
-    public Set<String> getHealthCheckUrls() {
+    public HashSet<String> getHealthCheckUrls() {
         return healthCheckUrls;
     }
 
@@ -325,6 +326,21 @@ public class InstanceInfo implements Item, Serializable {
         }
     }
 
+    public String valueForIndex(Index index) {
+        switch (index) {
+            case AppGroup:
+                return getAppGroup();
+            case App:
+                return getApp();
+            case Asg:
+                return getAsg();
+            case VipAddress:
+                return getVipAddress();
+            default:
+                return null;
+        }
+    }
+
     // ------------------------------------------
     // Instance Status
     // ------------------------------------------
@@ -358,10 +374,22 @@ public class InstanceInfo implements Item, Serializable {
             info = new InstanceInfo();
         }
 
-        // copy builder
-        public Builder(InstanceInfo another) {
-            this();
-            // copy another into info;
+        public Builder withInstanceInfo(InstanceInfo another) {
+            info.setId(another.getId());
+            info.setAppGroup(another.getAppGroup());
+            info.setApp(another.getApp());
+            info.setAsg(another.getAsg());
+            info.setVipAddress(another.getVipAddress());
+            info.setSecureVipAddress(another.getSecureVipAddress());
+            info.setHostname(another.getHostname());
+            info.setIp(another.getIp());
+            info.setPorts(another.getPorts());
+            info.setSecurePorts(another.getSecurePorts());
+            info.setStatus(another.getStatus());
+            info.setHomePageUrl(another.getHomePageUrl());
+            info.setStatusPageUrl(another.getStatusPageUrl());
+            info.setHealthCheckUrls(another.getHealthCheckUrls());
+            return this;
         }
 
         public Builder withId(String id) {

--- a/eureka-core/src/main/java/com/netflix/eureka/registry/Lease.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/Lease.java
@@ -16,31 +16,66 @@
 
 package com.netflix.eureka.registry;
 
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
 /**
  * Represent a lease over an element E
+ * This object should be thread safe
+ * TODO: figure out a way to sync time between write servers (or even if necessary)
  * @author David Liu
  */
 public class Lease<E> {
 
-    private final E holder;
+    public static final int DEFAULT_LEASE_DURATION_MILLIS = 90 * 1000;  // TODO: get default via config
+
+    private final AtomicReference<E> holderRef;
+
+    private final AtomicLong lastRenewalTimestamp;  // timestamp of last renewal
+    private final AtomicLong leaseDurationMillis;  // duration of this lease in millis
 
     public Lease(E holder) {
-        this.holder = holder;
+        this(holder, DEFAULT_LEASE_DURATION_MILLIS);
+    }
+
+    public Lease(E holder, long durationMillis) {
+        holderRef = new AtomicReference<E>(holder);
+
+        lastRenewalTimestamp = new AtomicLong(System.currentTimeMillis());
+        leaseDurationMillis = new AtomicLong(durationMillis);
+    }
+
+    // TODO make this less expensive than a full compare on InstanceInfo
+    public boolean compareAndSet(E expected, E update) {
+        return holderRef.compareAndSet(expected, update);
     }
 
     public E getHolder() {
-        return holder;
+        return holderRef.get();
+    }
+
+    public long getLastRenewalTimestamp() {
+        return lastRenewalTimestamp.get();
+    }
+
+    public long getLeaseDurationMillis() {
+        return leaseDurationMillis.get();
+    }
+
+    public void renew() {
+        lastRenewalTimestamp.set(System.currentTimeMillis());
     }
 
     public void renew(long durationMillis) {
-
+        leaseDurationMillis.set(durationMillis);
+        renew();
     }
 
     public boolean hasExpired() {
-        return false;
+        return System.currentTimeMillis() > (lastRenewalTimestamp.get() + leaseDurationMillis.get());
     }
 
     public void cancel() {
-
+        // TODO necessary?
     }
 }

--- a/eureka-core/src/test/java/com/netflix/eureka/interests/RegistryIndexTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/interests/RegistryIndexTest.java
@@ -1,6 +1,7 @@
 package com.netflix.eureka.interests;
 
 import com.netflix.eureka.ChangeNotifications;
+import com.netflix.eureka.SampleChangeNotification;
 import com.netflix.eureka.SampleInstanceInfo;
 import com.netflix.eureka.registry.EurekaRegistry;
 import com.netflix.eureka.registry.EurekaRegistryImpl;
@@ -42,7 +43,10 @@ public class RegistryIndexTest {
     public void testBasicIndex() throws Exception {
         final List<ChangeNotification<InstanceInfo>> notifications = new ArrayList<ChangeNotification<InstanceInfo>>();
 
-        registry.register(SampleInstanceInfo.DiscoveryServer.build()).toBlocking().lastOrDefault(null);
+        InstanceInfo discoveryServer = SampleInstanceInfo.DiscoveryServer.build();
+        InstanceInfo zuulServer = SampleInstanceInfo.ZuulServer.build();
+
+        registry.register(discoveryServer).toBlocking().lastOrDefault(null);
         registry.forInterest(Interests.forFullRegistry())
                 .subscribe(new Action1<ChangeNotification<InstanceInfo>>() {
                     @Override
@@ -51,10 +55,11 @@ public class RegistryIndexTest {
                         notifications.add(notification);
                     }
                 });
-        registry.register(SampleInstanceInfo.ZuulServer.build()).toBlocking().lastOrDefault(null);
+        registry.register(zuulServer).toBlocking().lastOrDefault(null);
 
         assertThat(notifications, hasSize(2));
-        assertThat(notifications, contains(ChangeNotifications.DiscoveryAddNotification,
-                                           ChangeNotifications.ZuulAddNotification)); // Checks the order of notifications.
+        assertThat(notifications,
+                contains(SampleChangeNotification.DiscoveryAddNotification.newNotification(discoveryServer),
+                         SampleChangeNotification.ZuulAddNotification.newNotification(zuulServer))); // Checks the order of notifications.
     }
 }

--- a/eureka-core/src/test/java/com/netflix/eureka/registry/InstanceInfoTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/registry/InstanceInfoTest.java
@@ -2,6 +2,7 @@ package com.netflix.eureka.registry;
 
 import static org.junit.Assert.*;
 
+import com.netflix.eureka.SampleInstanceInfo;
 import org.apache.avro.Schema;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.DatumWriter;
@@ -15,7 +16,6 @@ import org.apache.avro.reflect.ReflectDatumWriter;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
-import java.util.HashSet;
 
 /**
  * @author David Liu
@@ -24,17 +24,7 @@ public class InstanceInfoTest {
 
     @Test
     public void testInstanceInfoSerializationWithAvro() throws Exception {
-        HashSet<Integer> ports = new HashSet<Integer>();
-        ports.add(7001);
-        ports.add(8077);
-
-        InstanceInfo instanceInfo = new InstanceInfo.Builder()
-                .withId("test")
-                .withAppGroup("appGroup")
-                .withApp("app")
-                .withPorts(ports)
-                .withStatus(InstanceInfo.Status.DOWN)
-                .build();
+        InstanceInfo instanceInfo = SampleInstanceInfo.DiscoveryServer.build();
 
         Schema schema = ReflectData.get().getSchema(InstanceInfo.class);
 
@@ -50,10 +40,6 @@ public class InstanceInfoTest {
         Decoder decoder = DecoderFactory.get().binaryDecoder(bos.toByteArray(), null);
         InstanceInfo newInstanceInfo = datumReader.read(null, decoder);
 
-        assertEquals(instanceInfo.getId(), newInstanceInfo.getId());
-        assertEquals(instanceInfo.getAppGroup(), newInstanceInfo.getAppGroup());
-        assertEquals(instanceInfo.getApp(), newInstanceInfo.getApp());
-        assertEquals(instanceInfo.getPorts(), newInstanceInfo.getPorts());
-        assertEquals(instanceInfo.getStatus(), newInstanceInfo.getStatus());
+        assertEquals(instanceInfo, newInstanceInfo);
     }
 }

--- a/eureka-core/src/test/java/com/netflix/eureka/registry/LeaseTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/registry/LeaseTest.java
@@ -1,0 +1,49 @@
+package com.netflix.eureka.registry;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+/**
+ * @author David Liu
+ * TODO more concurrency tests
+ */
+public class LeaseTest {
+
+    @Test
+    public void testLeaseNotYetExpired() {
+        Lease<String> lease = new Lease<String>("abc", 5000);
+        assertFalse(lease.hasExpired());
+    }
+
+    @Test
+    public void testLeaseHasExpired() throws Exception {
+        Lease<String> lease = new Lease<String>("abc", 1);
+        Thread.sleep(10);  // sleep a tiny bit for time to progress
+        assertTrue(lease.hasExpired());
+    }
+
+    @Test
+    public void testCompareAndSetLeaseHolder() {
+        Lease<String> lease = new Lease<String>("abc", 5000);
+        String current = lease.getHolder();
+        assertTrue(current.equals("abc"));
+
+        String str1 = "foo";
+        String str2 = "bar";
+        assertTrue(lease.compareAndSet(current, str1));
+        assertFalse(lease.compareAndSet(current, str2));
+    }
+
+    @Test
+    public void testRenewalWithDuration() throws Exception {
+        Lease<String> lease = new Lease<String>("abc", 1);
+        Thread.sleep(10);
+        assertTrue(lease.hasExpired());
+
+        lease.renew(2000);
+        Thread.sleep(10);
+        assertFalse(lease.hasExpired());
+    }
+
+}

--- a/eureka-test-utils/src/main/java/com/netflix/eureka/SampleChangeNotification.java
+++ b/eureka-test-utils/src/main/java/com/netflix/eureka/SampleChangeNotification.java
@@ -1,0 +1,59 @@
+package com.netflix.eureka;
+
+import com.netflix.eureka.interests.ChangeNotification;
+import com.netflix.eureka.registry.InstanceInfo;
+
+/**
+ * @author David Liu
+ */
+public enum SampleChangeNotification {
+
+    ZuulAddNotification() {
+        @Override
+        public ChangeNotification<InstanceInfo> newNotification() {
+            return newNotification(SampleInstanceInfo.ZuulServer.build());
+        }
+
+        @Override
+        public ChangeNotification<InstanceInfo> newNotification(InstanceInfo seed) {
+            return new ChangeNotification<InstanceInfo>(ChangeNotification.Kind.Add, seed);
+        }
+    },
+    ZuulDeleteNotification() {
+        @Override
+        public ChangeNotification<InstanceInfo> newNotification() {
+            return newNotification(SampleInstanceInfo.ZuulServer.build());
+        }
+
+        @Override
+        public ChangeNotification<InstanceInfo> newNotification(InstanceInfo seed) {
+            return new ChangeNotification<InstanceInfo>(ChangeNotification.Kind.Delete, seed);
+        }
+    },
+    DiscoveryAddNotification() {
+        @Override
+        public ChangeNotification<InstanceInfo> newNotification() {
+            return newNotification(SampleInstanceInfo.DiscoveryServer.build());
+        }
+
+        @Override
+        public ChangeNotification<InstanceInfo> newNotification(InstanceInfo seed) {
+            return new ChangeNotification<InstanceInfo>(ChangeNotification.Kind.Add, seed);
+        }
+    },
+    DiscoveryDeleteNotification() {
+        @Override
+        public ChangeNotification<InstanceInfo> newNotification() {
+            return newNotification(SampleInstanceInfo.DiscoveryServer.build());
+        }
+
+        @Override
+        public ChangeNotification<InstanceInfo> newNotification(InstanceInfo seed) {
+            return new ChangeNotification<InstanceInfo>(ChangeNotification.Kind.Delete, seed);
+        }
+    };
+
+    public abstract ChangeNotification<InstanceInfo> newNotification();
+    public abstract ChangeNotification<InstanceInfo> newNotification(InstanceInfo seed);
+
+}

--- a/eureka-test-utils/src/main/java/com/netflix/eureka/SampleInstanceInfo.java
+++ b/eureka-test-utils/src/main/java/com/netflix/eureka/SampleInstanceInfo.java
@@ -1,5 +1,6 @@
 package com.netflix.eureka;
 
+import com.netflix.eureka.registry.Index;
 import com.netflix.eureka.registry.InstanceInfo;
 import com.netflix.eureka.registry.InstanceInfo.Builder;
 import com.netflix.eureka.registry.InstanceInfo.Status;
@@ -8,6 +9,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
+import java.util.UUID;
 
 /**
  * @author Tomasz Bak
@@ -27,13 +29,13 @@ public enum SampleInstanceInfo {
             securePorts.add(443);
             securePorts.add(8443);
             return new Builder()
+                    .withId("id#ZuulServer"+UUID.randomUUID().toString())
                     .withApp("app#ZuulServer")
                     .withAppGroup("group#ZuulServer")
                     .withAsg("asg#ZuulServer")
                     .withHealthCheckUrls(healthCheckUrls)
                     .withHomePageUrl("http://eureka/home/ZuulServer")
                     .withHostname("ZuulServer.test")
-                    .withId("id#ZuulServer")
                     .withIp("192.168.0.1")
                     .withPorts(ports)
                     .withSecurePorts(securePorts)
@@ -41,6 +43,22 @@ public enum SampleInstanceInfo {
                     .withStatus(Status.UP)
                     .withStatusPageUrl("http://eureka/status/ZuulServer")
                     .withVipAddress("vip#ZuulServer");
+        }
+
+        @Override
+        public String valueForIndex(Index index) {
+            switch (index) {
+                case AppGroup:
+                    return "group#ZuulServer";
+                case App:
+                    return "app#ZuulServer";
+                case Asg:
+                    return "asg#ZuulServer";
+                case VipAddress:
+                    return "vip#ZuulServer";
+                default:
+                    return null;
+            }
         }
     },
     DiscoveryServer() {
@@ -56,13 +74,13 @@ public enum SampleInstanceInfo {
             securePorts.add(443);
             securePorts.add(8443);
             return new Builder()
+                    .withId("id#DiscoveryServer"+UUID.randomUUID().toString())
                     .withApp("app#DiscoveryServer")
                     .withAppGroup("group#DiscoveryServer")
                     .withAsg("asg#DiscoveryServer")
                     .withHealthCheckUrls(healthCheckUrls)
                     .withHomePageUrl("http://eureka/home/DiscoveryServer")
                     .withHostname("DiscoveryServer.test")
-                    .withId("id#DiscoveryServer")
                     .withIp("192.168.0.1")
                     .withPorts(ports)
                     .withSecurePorts(securePorts)
@@ -71,9 +89,27 @@ public enum SampleInstanceInfo {
                     .withStatusPageUrl("http://eureka/status/DiscoveryServer")
                     .withVipAddress("vip#DiscoveryServer");
         }
+
+        @Override
+        public String valueForIndex(Index index) {
+            switch (index) {
+                case AppGroup:
+                    return "group#DiscoveryServer";
+                case App:
+                    return "app#DiscoveryServer";
+                case Asg:
+                    return "asg#DiscoveryServer";
+                case VipAddress:
+                    return "vip#DiscoveryServer";
+                default:
+                    return null;
+            }
+        }
     };
 
     public abstract Builder builder();
+
+    abstract String valueForIndex(Index index);
 
     public InstanceInfo build() {
         return builder().build();


### PR DESCRIPTION
Changes to common classes:
- added an unique UUID to instanceInfo id in SampleInstanceInfo
- added a parallel SampleChangeNotification in the same style as SampleInstanceInfo that can also take a seed instanceInfo to creating notifications (so that the id can stay constant)
