### PR TITLE
Fix logging string

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
@@ -605,7 +605,7 @@ public class DiscoveryClient implements LookupService {
             availZones = new String[1];
             availZones[0] = "default";
         }
-        logger.debug("The availability zone for the given region {} are %s",
+        logger.debug("The availability zone for the given region {} are {}",
                 region, Arrays.toString(availZones));
         int myZoneOffset = getZoneOffset(instanceZone, preferSameZone,
                 availZones);


### PR DESCRIPTION
Just getting it to log the availability zones correctly. Previously:

2014-08-20 06:28:02,249 DEBUG com.netflix.discovery.DiscoveryClient:522 [DiscoveryClient_ServiceURLUpdater] [getEurekaServiceUrlsFromConfig] The availability zone for the given region us-east-1 are %s
