### PR TITLE
Adding back the modified public constructor to DiscoveryClient

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
@@ -192,7 +192,11 @@ public class DiscoveryClient implements LookupService {
     }
 
     public DiscoveryClient(InstanceInfo myInfo, EurekaClientConfig config) {
-        this(myInfo, config, null, new Provider<BackupRegistry>() {
+        this(myInfo, config, null);
+    }
+
+    public DiscoveryClient(InstanceInfo myInfo, EurekaClientConfig config, DiscoveryClientOptionalArgs args) {
+        this(myInfo, config, args, new Provider<BackupRegistry>() {
             @Override
             public BackupRegistry get() {
                 String backupRegistryClassName = clientConfig.getBackupRegistryImpl();
@@ -215,8 +219,8 @@ public class DiscoveryClient implements LookupService {
     }
 
     @Inject
-    public DiscoveryClient(InstanceInfo myInfo, EurekaClientConfig config, DiscoveryClientOptionalArgs args,
-                           Provider<BackupRegistry> backupRegistryProvider) {
+    DiscoveryClient(InstanceInfo myInfo, EurekaClientConfig config, DiscoveryClientOptionalArgs args,
+                              Provider<BackupRegistry> backupRegistryProvider) {
         if (args != null) {
             healthCheckHandlerProvider = args.healthCheckHandlerProvider;
             healthCheckCallbackProvider = args.healthCheckCallbackProvider;


### PR DESCRIPTION
Fix for issue #174 added another argument to the constructor used by guice.
This was considering the fact that code should not be using the @Inject constructor directly. However, some code inside Netflix was dependent on it.

 Adding the old constructor back and making the @Inject constructor package private.
