### PR TITLE
Remove statics requiring bootstrapping from JAX-RS resources

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/resources/ApplicationResource.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/resources/ApplicationResource.java
@@ -49,7 +49,7 @@ public class ApplicationResource {
     private static final Logger logger = LoggerFactory
             .getLogger(ApplicationResource.class);
 
-    private static final PeerAwareInstanceRegistry registry = PeerAwareInstanceRegistry
+    private final PeerAwareInstanceRegistry registry = PeerAwareInstanceRegistry
             .getInstance();
 
     String appName;

--- a/eureka-core/src/main/java/com/netflix/eureka/resources/ApplicationsResource.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/resources/ApplicationsResource.java
@@ -54,7 +54,7 @@ public class ApplicationsResource {
     private static final String HEADER_CONTENT_ENCODING = "Content-Encoding";
     private static final String HEADER_GZIP_VALUE = "gzip";
     private static final String HEADER_JSON_VALUE = "json";
-    private static final EurekaServerConfig eurekaConfig = EurekaServerConfigurationManager
+    private final EurekaServerConfig eurekaConfig = EurekaServerConfigurationManager
     .getInstance().getConfiguration();
 
     /**

--- a/eureka-core/src/main/java/com/netflix/eureka/resources/InstanceResource.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/resources/InstanceResource.java
@@ -56,7 +56,7 @@ public class InstanceResource {
     private static final Logger logger = LoggerFactory
             .getLogger(InstanceResource.class);
 
-    private static final PeerAwareInstanceRegistry registry = PeerAwareInstanceRegistry
+    private final PeerAwareInstanceRegistry registry = PeerAwareInstanceRegistry
             .getInstance();
 
     String id;

--- a/eureka-core/src/main/java/com/netflix/eureka/resources/ResponseCache.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/resources/ResponseCache.java
@@ -79,7 +79,7 @@ public class ResponseCache {
 
     private static final Logger logger = LoggerFactory
             .getLogger(ResponseCache.class);
-    private static final EurekaServerConfig eurekaConfig = EurekaServerConfigurationManager
+    private final EurekaServerConfig eurekaConfig = EurekaServerConfigurationManager
             .getInstance().getConfiguration();
 
     public static final String ALL_APPS = "ALL_APPS";

--- a/eureka-core/src/main/java/com/netflix/eureka/resources/StatusResource.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/resources/StatusResource.java
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2012 Netflix, Inc.
  *
@@ -47,7 +48,7 @@ public class StatusResource {
     .getLogger(StatusResource.class);
     private static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss Z";
 
-    private static final PeerAwareInstanceRegistry registry = PeerAwareInstanceRegistry
+    private final PeerAwareInstanceRegistry registry = PeerAwareInstanceRegistry
     .getInstance();
 
     @GET


### PR DESCRIPTION
As per issue #190, Eureka JAX-RS resources currently assume that bootstrapping via the servlet context listener will have occured before their static initialization is driven.
