### PR TITLE
Fix bug where shuffleVirtualHostNameMap isn't updated

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/shared/Applications.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/Applications.java
@@ -396,6 +396,8 @@ public class Applications {
                                   @Nullable InstanceRegionChecker instanceRegionChecker) {
         this.virtualHostNameAppMap.clear();
         this.secureVirtualHostNameAppMap.clear();
+        this.shuffleVirtualHostNameMap.clear();
+        this.shuffledSecureVirtualHostNameMap.clear();
         for (Application application : appNameApplicationMap.values()) {
             if (indexByRemoteRegions) {
                 application.shuffleAndStoreInstances(remoteRegionsRegistry, clientConfig, instanceRegionChecker);

--- a/eureka-client/src/test/java/com/netflix/discovery/shared/ApplicationsTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/shared/ApplicationsTest.java
@@ -1,0 +1,51 @@
+package com.netflix.discovery.shared;
+
+
+import com.google.common.collect.Iterables;
+import com.netflix.appinfo.DataCenterInfo;
+import com.netflix.appinfo.InstanceInfo;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static junit.framework.Assert.assertNull;
+import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+public class ApplicationsTest {
+
+    /**
+     * Test that instancesMap in Application and shuffleVirtualHostNameMap in Applications are
+     * correctly updated when the last instance is removed from an application and shuffleInstances
+     * has been run.
+     */
+    @Test
+    public void shuffleVirtualHostNameMapLastInstanceTest() {
+        DataCenterInfo myDCI = new DataCenterInfo(){
+            public DataCenterInfo.Name getName(){return DataCenterInfo.Name.MyOwn;}
+        };
+        InstanceInfo instanceInfo = InstanceInfo.Builder.newBuilder()
+                                                        .setAppName("test")
+                                                        .setVIPAddress("test.testname:1")
+                                                        .setDataCenterInfo(myDCI)
+                                                        .setHostName("test.hostname").build();
+
+        Application application = new Application("TestApp");
+        application.addInstance(instanceInfo);
+        Applications applications = new Applications();
+        applications.addApplication(application);
+        applications.shuffleInstances(true);
+        List<InstanceInfo> testApp = applications.getInstancesByVirtualHostName("test.testname:1");
+
+        assertEquals(Iterables.getOnlyElement(testApp),
+                     application.getByInstanceId("test.hostname"));
+
+        application.removeInstance(instanceInfo);
+        applications.shuffleInstances(true);
+        testApp = applications.getInstancesByVirtualHostName("test.testname:1");
+
+        assertNull(application.getByInstanceId("test.hostname"));
+        assertTrue(testApp.isEmpty());
+    }
+}


### PR DESCRIPTION
shuffleVirtualHostNameMap and shuffledSecureVirtualHostNameMap were
not being updated when the last instance was removed from an application.

Added unit test to illustrate the issue and fixed it by clearing the map
on every update, just as virtualHostNameAppMap gets cleared.
