### PR TITLE
Skipping doclint if building with Java 8. It breaks the build due to err...

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,13 @@ subprojects {
     }
 }
 
+if (JavaVersion.current().isJava8Compatible()) {
+    allprojects {
+        tasks.withType(Javadoc) {
+            options.addStringOption('Xdoclint:none', '-quiet')
+        }
+    }
+}
 
 project(':eureka-client') {
     dependencies {

--- a/gradle/convention.gradle
+++ b/gradle/convention.gradle
@@ -66,14 +66,6 @@ subprojects { project ->
 
 apply plugin: 'github-pages' // Used to create publishGhPages task
 
-if (JavaVersion.current().isJava8Compatible()) {
-    allprojects {
-        tasks.withType(Javadoc) {
-            options.addStringOption('Xdoclint:none', '-quiet')
-        }
-    }
-}
-
 def docTasks = [:]
 [Javadoc,ScalaDoc,Groovydoc].each{ Class docClass ->
     def allSources = allprojects.tasks*.withType(docClass).flatten()*.source


### PR DESCRIPTION
...ors in eureka javadoc (this strict doclint checking affects whole world really).

I'm a casual gradle user so the solution might not be the best one for this particular project. I just copied (and tested) solution posted on Stephen Colebourne's blog: http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html
