### PR TITLE
2.x Use interface base names as metrics class tag value.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ atlassian-ide-plugin.xml
 
 # NetBeans specific files/directories
 .nbattrs
+
+# Other
+**/deps

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ ext {
 allprojects {
     repositories {
         jcenter()
+        maven { url 'http://oss.jfrog.org/oss-snapshot-local' } // Make it default until first rc release
     }
 
     if (project.hasProperty('useMavenLocal')) {

--- a/eureka2-metrics-spectator/build.gradle
+++ b/eureka2-metrics-spectator/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compile "com.netflix.spectator:spectator-api:${spectator_version}"
     compile "com.netflix.spectator:spectator-reg-metrics3:${spectator_version}"
     compile "javax.inject:javax.inject:1"
-//    testCompile project(':eureka2-test-utils')
+    testCompile project(':eureka2-test-utils')
 }
 
 jar {

--- a/eureka2-metrics-spectator/src/main/java/com/netflix/eureka2/metric/SpectatorEurekaMetrics.java
+++ b/eureka2-metrics-spectator/src/main/java/com/netflix/eureka2/metric/SpectatorEurekaMetrics.java
@@ -38,9 +38,17 @@ public abstract class SpectatorEurekaMetrics {
     }
 
     protected Id newId(String name) {
+        // We use metrics interface as class tag, if one can be found
+        String className = getClass().getSimpleName();
+        for (Class<?> c : getClass().getInterfaces()) {
+            if (c.getSimpleName().endsWith("Metrics")) {
+                className = c.getSimpleName();
+            }
+        }
+
         return registry.createId(name)
                 .withTag("id", id)
-                .withTag("class", getClass().getSimpleName());
+                .withTag("class", className);
     }
 
     protected Counter newCounter(String name) {

--- a/eureka2-metrics-spectator/src/test/java/com/netflix/eureka2/metric/SpectatorEurekaMetricsTest.java
+++ b/eureka2-metrics-spectator/src/test/java/com/netflix/eureka2/metric/SpectatorEurekaMetricsTest.java
@@ -1,0 +1,26 @@
+package com.netflix.eureka2.metric;
+
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Spectator;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Tomasz Bak
+ */
+public class SpectatorEurekaMetricsTest {
+    @Test
+    public void testMetricsClassIdIsDerivedFromInterfaceName() throws Exception {
+        SpectatorEurekaRegistryMetrics eurekaMetrics = new SpectatorEurekaRegistryMetrics(Spectator.registry());
+        Id actualId = eurekaMetrics.newId("testName");
+
+        Id expectedId = Spectator.registry().createId("testName")
+                .withTag("id", "eurekaServerRegistry")
+                .withTag("class", EurekaRegistryMetrics.class.getSimpleName());
+
+        assertThat(actualId, is(equalTo(expectedId)));
+    }
+}


### PR DESCRIPTION
+ use bintray snapshot repo by default, till we do first eureka2 RC release.