### PR TITLE
Don't use String.toUpperCase()

### DIFF
--- a/eureka-client/src/main/java/com/netflix/appinfo/InstanceInfo.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/InstanceInfo.java
@@ -16,6 +16,7 @@
 package com.netflix.appinfo;
 
 import java.util.LinkedHashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -266,7 +267,7 @@ public class InstanceInfo {
          */
         public Builder setAppName(String appName) {
             if (appName != null) {
-                result.appName = appName.toUpperCase();
+                result.appName = appName.toUpperCase(Locale.ROOT);
             } else {
                 result.appName = null;
             }
@@ -275,7 +276,7 @@ public class InstanceInfo {
 
         public Builder setAppGroupName(String appGroupName) {
             if (appGroupName != null) {
-                result.appGroupName = appGroupName.toUpperCase();
+                result.appGroupName = appGroupName.toUpperCase(Locale.ROOT);
             } else {
                 result.appGroupName = null;
             }


### PR DESCRIPTION
InstanceInfo uses String.toUpperCase() without passing a Locale. This
is very dangerous as it relies on the default locale which might not
match the server's Locale. It is one of the APIs that are discouraged
for use, and it is better if it always passes a Locale.ROOT.