### PR TITLE
2.x client fixes

### DIFF
--- a/eureka2-client/src/main/java/com/netflix/eureka2/client/interest/InterestHandlerImpl.java
+++ b/eureka2-client/src/main/java/com/netflix/eureka2/client/interest/InterestHandlerImpl.java
@@ -8,6 +8,8 @@ import com.netflix.eureka2.interests.ChangeNotification;
 import com.netflix.eureka2.interests.Interest;
 import com.netflix.eureka2.interests.SourcedChangeNotification;
 import com.netflix.eureka2.interests.SourcedModifyNotification;
+import com.netflix.eureka2.registry.Source;
+import com.netflix.eureka2.registry.Sourced;
 import com.netflix.eureka2.registry.SourcedEurekaRegistry;
 import com.netflix.eureka2.registry.instance.InstanceInfo;
 import com.netflix.eureka2.utils.rx.RetryStrategyFunc;
@@ -50,7 +52,7 @@ public class InterestHandlerImpl implements InterestHandler {
         this(registry, channelFactory, DEFAULT_RETRY_WAIT_MILLIS);
     }
 
-    /* visible for testing*/ InterestHandlerImpl(SourcedEurekaRegistry<InstanceInfo> registry,
+    /* visible for testing*/ InterestHandlerImpl(final SourcedEurekaRegistry<InstanceInfo> registry,
                                                  ChannelFactory<InterestChannel> channelFactory,
                                                  int retryWaitMillis) {
         this.registry = registry;
@@ -70,6 +72,36 @@ public class InterestHandlerImpl implements InterestHandler {
                     }
                 });
 
+        // subscribe to the base interest channels to do cleanup on every channel refresh.
+        retryableConnection.getChannelObservable()
+                .flatMap(new Func1<InterestChannel, Observable<Long>>() {
+                    @Override
+                    public Observable<Long> call(InterestChannel interestChannel) {
+                        if (interestChannel instanceof Sourced) {
+                            Source toRetain = ((Sourced) interestChannel).getSource();
+                            return registry.evictAllExcept(toRetain);
+                        }
+                       return Observable.empty();
+                    }
+                })
+                .subscribe(new Subscriber<Long>() {
+                    @Override
+                    public void onCompleted() {
+                        logger.info("Completed one round of eviction due to a new interestChannel creation");
+                    }
+
+                    @Override
+                    public void onError(Throwable e) {
+                        logger.warn("OnError in one round of eviction due to a new interestChannel creation");
+                    }
+
+                    @Override
+                    public void onNext(Long aLong) {
+                        logger.info("Evicted {} instances in one round of eviction due to a new interestChannel creation", aLong);
+                    }
+                });
+
+        // subscribe to the lifecycle to initiate the interest subscription
         retryableConnection.getRetryableLifecycle()
                 .retryWhen(new RetryStrategyFunc(retryWaitMillis))
                 .subscribe(new Subscriber<Void>() {

--- a/eureka2-client/src/test/java/com/netflix/eureka2/client/interest/InterestHandlerTest.java
+++ b/eureka2-client/src/test/java/com/netflix/eureka2/client/interest/InterestHandlerTest.java
@@ -13,19 +13,26 @@ import com.netflix.eureka2.interests.Interests;
 import com.netflix.eureka2.interests.MultipleInterests;
 import com.netflix.eureka2.metric.EurekaRegistryMetricFactory;
 import com.netflix.eureka2.metric.InterestChannelMetrics;
+import com.netflix.eureka2.registry.PreservableEurekaRegistry;
 import com.netflix.eureka2.registry.Source;
+import com.netflix.eureka2.registry.Sourced;
 import com.netflix.eureka2.registry.SourcedEurekaRegistry;
 import com.netflix.eureka2.registry.SourcedEurekaRegistryImpl;
+import com.netflix.eureka2.registry.eviction.EvictionQueue;
+import com.netflix.eureka2.registry.eviction.EvictionQueueImpl;
+import com.netflix.eureka2.registry.eviction.PercentageDropEvictionStrategy;
 import com.netflix.eureka2.registry.instance.InstanceInfo;
 import com.netflix.eureka2.rx.ExtTestSubscriber;
 import com.netflix.eureka2.testkit.data.builder.SampleChangeNotification;
 import com.netflix.eureka2.testkit.data.builder.SampleInstanceInfo;
 import com.netflix.eureka2.testkit.data.builder.SampleInterest;
+import com.netflix.eureka2.testkit.junit.EurekaMatchers;
 import com.netflix.eureka2.transport.MessageConnection;
 import com.netflix.eureka2.transport.TransportClient;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -43,14 +50,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.argThat;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * @author David Liu
@@ -58,10 +62,9 @@ import static org.mockito.Mockito.when;
 public class InterestHandlerTest {
 
     private static final int RETRY_WAIT_MILLIS = 10;
-    private final int failAfterMillis = 10;
+    private static final long EVICTION_TIMEOUT_MS = 30*1000;
+    private static final int EVICTION_ALLOWED_PERCENTAGE_DROP_THRESHOLD = 50;//%
     private final AtomicInteger channelId = new AtomicInteger(0);
-
-    private MessageConnection messageConnection;
 
     private TransportClient transportClient;
 
@@ -74,7 +77,9 @@ public class InterestHandlerTest {
     private List<InstanceInfo> allInfos;
 
     private TestScheduler registryScheduler;
-    private SourcedEurekaRegistry<InstanceInfo> registry;
+    private TestScheduler evictionScheduler;
+    private PreservableEurekaRegistry registry;
+    private EvictionQueue evictionQueue;
 
     private ChannelFactory<InterestChannel> mockFactory;
     private TestChannelFactory<InterestChannel> factory;
@@ -86,7 +91,7 @@ public class InterestHandlerTest {
 
     @Before
     public void setUp() {
-        messageConnection = mock(MessageConnection.class);
+        MessageConnection messageConnection = mock(MessageConnection.class);
         final ReplaySubject<Void> lifecycleSubject = ReplaySubject.create();
         when(messageConnection.lifecycleObservable()).thenReturn(lifecycleSubject);
         when(messageConnection.submitWithAck(anyObject())).thenReturn(Observable.<Void>empty());
@@ -115,7 +120,17 @@ public class InterestHandlerTest {
         allInfos.addAll(zuulInfos);
 
         registryScheduler = Schedulers.test();
-        registry = new SourcedEurekaRegistryImpl(EurekaRegistryMetricFactory.registryMetrics(), registryScheduler);
+        evictionScheduler = Schedulers.test();
+        evictionQueue = spy(new EvictionQueueImpl(EVICTION_TIMEOUT_MS, EurekaRegistryMetricFactory.registryMetrics(), evictionScheduler));
+
+        SourcedEurekaRegistry<InstanceInfo> delegateRegistry
+                = new SourcedEurekaRegistryImpl(EurekaRegistryMetricFactory.registryMetrics(), registryScheduler);
+        registry = spy(new PreservableEurekaRegistry(
+                delegateRegistry,
+                        evictionQueue,
+                        new PercentageDropEvictionStrategy(EVICTION_ALLOWED_PERCENTAGE_DROP_THRESHOLD),
+                        EurekaRegistryMetricFactory.registryMetrics()));
+
         mockFactory = mock(InterestChannelFactory.class);
         factory = new TestChannelFactory<>(mockFactory);
 
@@ -394,13 +409,100 @@ public class InterestHandlerTest {
         assertThat(compositeOutput, containsInAnyOrder(compositeExpected.toArray()));
     }
 
+    @Test
+    public void testNewChannelCreationEvictAllOlderSourcedRegistryData() throws Exception {
+        when(mockFactory.newChannel()).then(new Answer<InterestChannel>() {
+            @Override
+            public InterestChannel answer(InvocationOnMock invocation) throws Throwable {
+                if (channelId.get() == 0) {
+                    return newSendingInterestFailChannel(channelId.getAndIncrement());
+                }
+                return newAlwaysSuccessChannel(channelId.getAndIncrement());
+            }
+        });
 
-    private InterestChannel newAlwaysSuccessChannel(Integer id) {
-        InterestChannel channel = spy(new InterestChannelImpl(registry, transportClient, mock(InterestChannelMetrics.class)));
+        handler = new InterestHandlerImpl(registry, factory, RETRY_WAIT_MILLIS);
+
+        List<ChangeNotification<InstanceInfo>> expected = Arrays.asList(
+                SampleChangeNotification.DiscoveryAdd.newNotification(discoveryInfos.get(0)),
+                SampleChangeNotification.DiscoveryAdd.newNotification(discoveryInfos.get(1)),
+                SampleChangeNotification.DiscoveryAdd.newNotification(discoveryInfos.get(2))
+        );
+
+        ArgumentCaptor<InstanceInfo> infoCaptor = ArgumentCaptor.forClass(InstanceInfo.class);
+        ArgumentCaptor<Source> sourceCaptor = ArgumentCaptor.forClass(Source.class);
+
+        handler.forInterest(discoveryInterest).subscribe(discoverySubscriber);
+
+        discoverySubscriber.assertProducesInAnyOrder(expected, new Func1<ChangeNotification<InstanceInfo>, ChangeNotification<InstanceInfo>>() {
+            @Override
+            public ChangeNotification<InstanceInfo> call(ChangeNotification<InstanceInfo> notification) {
+                return notification;
+            }
+        }, 10, TimeUnit.SECONDS);
+
+        assertThat(factory.getAllChannels().size(), is(2));
+
+        TestInterestChannel channel0 = (TestInterestChannel) factory.getAllChannels().get(0);
+        assertThat(channel0.id, is(0));
+        assertThat(channel0.operations.size(), is(1));
+        assertThat(channel0.closeCalled, is(true));
+        assertThat(matchInterests(channel0.operations.iterator().next(), discoveryInterest), is(true));
+
+        TestInterestChannel channel1 = (TestInterestChannel) factory.getAllChannels().get(1);
+        assertThat(channel1.id, is(1));
+        assertThat(channel1.operations.size(), is(1));
+        assertThat(channel1.closeCalled, is(false));
+        assertThat(matchInterests(channel1.operations.iterator().next(), discoveryInterest), is(true));
+
+        assertThat(evictionQueue.size(), is(2));  // 2 stuck in queue (because we have not yet advanced the evictionQueue scheduler
+
+        verify(evictionQueue, times(2)).add(infoCaptor.capture(), sourceCaptor.capture());
+
+        assertThat(infoCaptor.getAllValues(), containsInAnyOrder(discoveryInfos.subList(0, 2).toArray()));
+        Source channel0Source = channel0.getSource();
+        assertThat(sourceCaptor.getAllValues().get(0), is(channel0Source));
+        assertThat(sourceCaptor.getAllValues().get(1), is(channel0Source));
+        assertThat(sourceCaptor.getAllValues().size(), is(2));
+
+        evictionScheduler.advanceTimeBy(EVICTION_TIMEOUT_MS + 1, TimeUnit.MILLISECONDS);
+        registryScheduler.advanceTimeBy(EVICTION_TIMEOUT_MS + 1, TimeUnit.MILLISECONDS);  // need to advance the registry scheduler to execute the unregisters from eviction
+
+        evictionScheduler.advanceTimeBy(EVICTION_TIMEOUT_MS + 1, TimeUnit.MILLISECONDS);
+        registryScheduler.advanceTimeBy(EVICTION_TIMEOUT_MS + 1, TimeUnit.MILLISECONDS);
+
+        assertThat(evictionQueue.size(), is(0));  // all gone
+
+        // verify that a new subscriber can subscribe and see latest changes
+        ExtTestSubscriber<ChangeNotification<InstanceInfo>> newSubscriber = new ExtTestSubscriber<>();
+        handler.forInterest(discoveryInterest).subscribe(newSubscriber);
+
+        newSubscriber.assertProducesInAnyOrder(expected, new Func1<ChangeNotification<InstanceInfo>, ChangeNotification<InstanceInfo>>() {
+            @Override
+            public ChangeNotification<InstanceInfo> call(ChangeNotification<InstanceInfo> notification) {
+                return notification;
+            }
+        }, 10, TimeUnit.SECONDS);
+
+        InstanceInfo update = new InstanceInfo.Builder().withInstanceInfo(discoveryInfos.get(0))
+                .withStatus(InstanceInfo.Status.OUT_OF_SERVICE)
+                .build();
+
+        registry.register(update, channel1.getSource()).subscribe();
+        registryScheduler.triggerActions();
+
+        assertThat(newSubscriber.takeNext(1, 5, TimeUnit.SECONDS).get(0), EurekaMatchers.modifyChangeNotificationOf(update));
+    }
+
+
+    // -----------------------------------------------------------------------------
+
+    private TestInterestChannel newAlwaysSuccessChannel(Integer id) {
+        final InterestChannel channel = spy(new InterestChannelImpl(registry, transportClient, mock(InterestChannelMetrics.class)));
         when(channel.change(argThat(new InterestMatcher(discoveryInterest)))).thenAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
-                registerAll(discoveryInfos);
+                registerAll(discoveryInfos, ((Sourced)channel).getSource());
                 return Observable.empty();
             }
         });
@@ -408,7 +510,7 @@ public class InterestHandlerTest {
         when(channel.change(argThat(new InterestMatcher(zuulInterest)))).thenAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
-                registerAll(zuulInfos);
+                registerAll(zuulInfos, ((Sourced)channel).getSource());
                 return Observable.empty();
             }
         });
@@ -416,7 +518,7 @@ public class InterestHandlerTest {
         when(channel.change(argThat(new InterestMatcher(allInterest)))).thenAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
-                registerAll(allInfos);
+                registerAll(allInfos, ((Sourced)channel).getSource());
                 return Observable.empty();
             }
         });
@@ -424,7 +526,7 @@ public class InterestHandlerTest {
         when(channel.change(argThat(new InterestMatcher(Interests.forFullRegistry())))).thenAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
-                registerAll(allInfos);
+                registerAll(allInfos, ((Sourced)channel).getSource());
                 return Observable.empty();
             }
         });
@@ -432,7 +534,7 @@ public class InterestHandlerTest {
         return new TestInterestChannel(channel, id);
     }
 
-    private InterestChannel newAlwaysFailChannel(Integer id) {
+    private TestInterestChannel newAlwaysFailChannel(Integer id) {
         InterestChannel channel = spy(new InterestChannelImpl(registry, transportClient, mock(InterestChannelMetrics.class)));
         when(channel.change(any(Interest.class))).thenReturn(Observable.<Void>error(new Exception("test: operation error")));
         when(channel.change(any(MultipleInterests.class))).thenReturn(Observable.<Void>error(new Exception("test: operation error")));
@@ -440,16 +542,17 @@ public class InterestHandlerTest {
         return new TestInterestChannel(channel, id);
     }
 
-    private InterestChannel newSendingInterestFailChannel(Integer id) {
+    private TestInterestChannel newSendingInterestFailChannel(Integer id) {
         final InterestChannel channel = spy(new InterestChannelImpl(registry, transportClient, mock(InterestChannelMetrics.class)));
         when(channel.change(argThat(new InterestMatcher(discoveryInterest)))).thenAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
-                registerAll(discoveryInfos.subList(0, 1));
+                registerAll(discoveryInfos.subList(0, 2), ((Sourced)channel).getSource());
                 return Observable.empty();
             }
         });
 
+        int failAfterMillis = 10;
         Observable.empty().delay(failAfterMillis, TimeUnit.MILLISECONDS).subscribe(new Subscriber<Object>() {
             @Override
             public void onCompleted() {
@@ -468,8 +571,7 @@ public class InterestHandlerTest {
         return new TestInterestChannel(channel, id);
     }
 
-    private void registerAll(List<InstanceInfo> infos) {
-        Source source = new Source(Source.Origin.LOCAL);
+    private void registerAll(List<InstanceInfo> infos, Source source) {
         for (InstanceInfo info : infos) {
             registry.register(info, source).subscribe();
             registryScheduler.triggerActions();
@@ -500,4 +602,6 @@ public class InterestHandlerTest {
             return false;
         }
     }
+
 }
+

--- a/eureka2-core/src/main/java/com/netflix/eureka2/channel/AbstractClientChannel.java
+++ b/eureka2-core/src/main/java/com/netflix/eureka2/channel/AbstractClientChannel.java
@@ -6,6 +6,7 @@ import com.netflix.eureka2.transport.MessageConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;
+import rx.Subscriber;
 import rx.functions.Action1;
 import rx.functions.Func1;
 
@@ -55,7 +56,22 @@ public abstract class AbstractClientChannel<STATE extends Enum<STATE>> extends A
     }
 
     private void subscribeToConnectionLifecycle(MessageConnection connection) {
-        connection.lifecycleObservable().subscribe(lifecycle);
+        connection.lifecycleObservable().subscribe(new Subscriber<Void>() {
+            @Override
+            public void onCompleted() {
+                AbstractClientChannel.this.close();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                AbstractClientChannel.this.close(e);
+            }
+
+            @Override
+            public void onNext(Void aVoid) {
+                // no-op
+            }
+        });
     }
 
     /**

--- a/eureka2-core/src/main/java/com/netflix/eureka2/registry/SourcedEurekaRegistry.java
+++ b/eureka2-core/src/main/java/com/netflix/eureka2/registry/SourcedEurekaRegistry.java
@@ -48,16 +48,10 @@ public interface SourcedEurekaRegistry<T> {
     Observable<ChangeNotification<T>> forInterest(Interest<T> interest, Source.Matcher sourceMatcher);
 
     /**
-     * Evict all registry info with the given source
+     * Evict all registry info for all sources except the single specified source
      * @return an observable of long denoting the number of holder items touched for the eviction
      */
-    Observable<Long> evictAll(Source source);
-
-    /**
-     * Evict all registry info for all sources
-     * @return an observable of long denoting the number of holder items touched for the eviction
-     */
-    Observable<Long> evictAll();
+    Observable<Long> evictAllExcept(Source source);
 
     Observable<? extends MultiSourcedDataHolder<T>> getHolders();
 

--- a/eureka2-read-server/src/main/java/com/netflix/eureka2/server/registry/EurekaReadServerRegistry.java
+++ b/eureka2-read-server/src/main/java/com/netflix/eureka2/server/registry/EurekaReadServerRegistry.java
@@ -91,13 +91,8 @@ public class EurekaReadServerRegistry implements SourcedEurekaRegistry<InstanceI
     }
 
     @Override
-    public Observable<Long> evictAll(Source source) {
-        throw new UnsupportedOperationException("evictAll not supported by EurekaReadServerRegistry");
-    }
-
-    @Override
-    public Observable<Long> evictAll() {
-        throw new UnsupportedOperationException("evictAll not supported by EurekaReadServerRegistry");
+    public Observable<Long> evictAllExcept(Source source) {
+        throw new UnsupportedOperationException("evictAllExcept not supported by EurekaReadServerRegistry");
     }
 
     @Override

--- a/eureka2-test-utils/src/main/java/com/netflix/eureka2/channel/TestInterestChannel.java
+++ b/eureka2-test-utils/src/main/java/com/netflix/eureka2/channel/TestInterestChannel.java
@@ -1,13 +1,15 @@
 package com.netflix.eureka2.channel;
 
 import com.netflix.eureka2.interests.Interest;
+import com.netflix.eureka2.registry.Source;
+import com.netflix.eureka2.registry.Sourced;
 import com.netflix.eureka2.registry.instance.InstanceInfo;
 import rx.Observable;
 
 /**
  * @author David Liu
  */
-public class TestInterestChannel extends TestChannel<InterestChannel, Interest<InstanceInfo>> implements InterestChannel {
+public class TestInterestChannel extends TestChannel<InterestChannel, Interest<InstanceInfo>> implements InterestChannel, Sourced {
     public TestInterestChannel(InterestChannel delegate, Integer id) {
         super(delegate, id);
     }
@@ -16,5 +18,13 @@ public class TestInterestChannel extends TestChannel<InterestChannel, Interest<I
     public Observable<Void> change(Interest<InstanceInfo> newInterest) {
         operations.add(newInterest);
         return delegate.change(newInterest);
+    }
+
+    @Override
+    public Source getSource() {
+        if (delegate instanceof Sourced) {
+            return ((Sourced) delegate).getSource();
+        }
+        return null;
     }
 }


### PR DESCRIPTION
- client interestChannel now evict older entries once new channel is available
- AbstractClientChannel properly handle connection lifecycle