### PR TITLE
1.x Exclude servlet-api jar from eureka.war

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
 ext {
     githubProjectName = 'eureka'
+    servletVersion='2.5'
     jerseyVersion='1.11'
     governatorVersion='1.2.10'
     archaiusVersion='0.6.0'

--- a/eureka-core/build.gradle
+++ b/eureka-core/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     compile project(':eureka-client')
 
     compile 'com.amazonaws:aws-java-sdk:1.3.27'
-    compile 'javax.servlet:servlet-api:2.4'
+    compile "javax.servlet:servlet-api:$servletVersion"
     compile 'com.thoughtworks.xstream:xstream:1.4.2'
     compile 'javax.ws.rs:jsr311-api:1.1.1'
     compile "com.netflix.blitz4j:blitz4j:$blitzVersion"

--- a/eureka-server/build.gradle
+++ b/eureka-server/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compile "com.sun.jersey:jersey-servlet:$jerseyVersion"
     compile 'org.slf4j:slf4j-log4j12:1.6.1'
     runtime 'org.codehaus.jettison:jettison:1.2' 
-    providedCompile 'javax.servlet:servlet-api:2.4'
+    providedCompile "javax.servlet:servlet-api:$servletVersion"
 }
 
 task copyLibs(type: Copy) {


### PR DESCRIPTION
Because of the transitive dependencies we had two servlet-api jar
versions in the dependency tree. Eureka depended directly on
version 2.4 that was properly marked as provided. This version was
however shadowed by the one from the transitive dependency (2.5),
and as it was not marked as provided nor excluded, it was added to
war file. That caused compatibility issue when running on tomcat 8.0.