### PR TITLE
Require re-registration when instance status is UNKNOWN, after override removal.

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/InstanceRegistry.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/InstanceRegistry.java
@@ -314,7 +314,7 @@ public abstract class InstanceRegistry implements LeaseManager<InstanceInfo>,
         if (leaseToRenew == null) {
             RENEW_NOT_FOUND.increment(isReplication);
             logger.warn("DS: Registry: lease doesn't exist, registering resource: "
-                        + appName + " - " + id);
+                    + appName + " - " + id);
             return false;
         } else {
             InstanceInfo instanceInfo = leaseToRenew.getHolder();
@@ -323,8 +323,12 @@ public abstract class InstanceRegistry implements LeaseManager<InstanceInfo>,
                 InstanceStatus overriddenInstanceStatus = this
                         .getOverriddenInstanceStatus(instanceInfo,
                                 leaseToRenew, isReplication);
-                // InstanceStatus overriddenInstanceStatus =
-                // instanceInfo.getStatus();
+                if(overriddenInstanceStatus == InstanceStatus.UNKNOWN) {
+                    logger.info("Instance status UNKNOWN possibly due to deleted override for instance {}"
+                            + "; re-register required", instanceInfo.getId());
+                    RENEW_NOT_FOUND.increment(isReplication);
+                    return false;
+                }
                 if (!instanceInfo.getStatus().equals(overriddenInstanceStatus)) {
                     Object[] args = {instanceInfo.getStatus().name(),
                                      instanceInfo.getOverriddenStatus().name(),


### PR DESCRIPTION
This is bug fix for PR #412.
Require re-registration when instance status is UNKNOWN, after override removal.
This does not change the current behavior when new status is set as part of the DELETE request.