### PR TITLE
2.x Implement custom EurekaInterestClient for Eureka Read server.

### DIFF
--- a/eureka2-client/src/main/java/com/netflix/eureka2/client/interest/AbstractInterestClient.java
+++ b/eureka2-client/src/main/java/com/netflix/eureka2/client/interest/AbstractInterestClient.java
@@ -1,0 +1,106 @@
+package com.netflix.eureka2.client.interest;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.netflix.eureka2.channel.InterestChannel;
+import com.netflix.eureka2.connection.RetryableConnection;
+import com.netflix.eureka2.registry.Source;
+import com.netflix.eureka2.registry.Sourced;
+import com.netflix.eureka2.registry.SourcedEurekaRegistry;
+import com.netflix.eureka2.registry.instance.InstanceInfo;
+import com.netflix.eureka2.utils.rx.RetryStrategyFunc;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import rx.Observable;
+import rx.Subscriber;
+import rx.functions.Func1;
+
+/**
+ * Skeleton implementation of {@link EurekaInterestClient}, that provides common functions for code
+ * reuse.
+ *
+ * @author Tomasz Bak
+ */
+public abstract class AbstractInterestClient implements EurekaInterestClient {
+
+    private static final Logger logger = LoggerFactory.getLogger(AbstractInterestClient.class);
+
+    public static final int DEFAULT_RETRY_WAIT_MILLIS = 500;
+
+    protected final SourcedEurekaRegistry<InstanceInfo> registry;
+    protected final int retryWaitMillis;
+    protected final AtomicBoolean isShutdown;
+
+    protected AbstractInterestClient(final SourcedEurekaRegistry<InstanceInfo> registry,
+                                     int retryWaitMillis) {
+        this.registry = registry;
+        this.retryWaitMillis = retryWaitMillis;
+        this.isShutdown = new AtomicBoolean(false);
+    }
+
+    @Override
+    public void shutdown() {
+        if (isShutdown.compareAndSet(false, true)) {
+            logger.info("Shutting down InterestClient");
+            if (getRetryableConnection() != null) {
+                getRetryableConnection().close();
+            }
+            registry.shutdown();
+        }
+    }
+
+    protected abstract RetryableConnection<InterestChannel> getRetryableConnection();
+
+    protected void registryEvictionSubscribe(RetryableConnection<InterestChannel> retryableConnection) {
+        // subscribe to the base interest channels to do cleanup on every channel refresh.
+        retryableConnection.getChannelObservable()
+                .flatMap(new Func1<InterestChannel, Observable<Long>>() {
+                    @Override
+                    public Observable<Long> call(InterestChannel interestChannel) {
+                        if (interestChannel instanceof Sourced) {
+                            Source toRetain = ((Sourced) interestChannel).getSource();
+                            return registry.evictAllExcept(toRetain);
+                        }
+                        return Observable.empty();
+                    }
+                })
+                .subscribe(new Subscriber<Long>() {
+                    @Override
+                    public void onCompleted() {
+                        logger.info("Completed one round of eviction due to a new interestChannel creation");
+                    }
+
+                    @Override
+                    public void onError(Throwable e) {
+                        logger.warn("OnError in one round of eviction due to a new interestChannel creation");
+                    }
+
+                    @Override
+                    public void onNext(Long aLong) {
+                        logger.info("Evicted {} instances in one round of eviction due to a new interestChannel creation", aLong);
+                    }
+                });
+    }
+
+    protected void lifecycleSubscribe(RetryableConnection<InterestChannel> retryableConnection) {
+        // subscribe to the lifecycle to initiate the interest subscription
+        retryableConnection.getRetryableLifecycle()
+                .retryWhen(new RetryStrategyFunc(retryWaitMillis))
+                .subscribe(new Subscriber<Void>() {
+                    @Override
+                    public void onCompleted() {
+                        logger.info("channel onCompleted");
+                    }
+
+                    @Override
+                    public void onError(Throwable e) {
+                        logger.error("Lifecycle closed with an error");
+                    }
+
+                    @Override
+                    public void onNext(Void aVoid) {
+
+                    }
+                });
+    }
+}

--- a/eureka2-client/src/main/java/com/netflix/eureka2/client/interest/EurekaInterestClientImpl.java
+++ b/eureka2-client/src/main/java/com/netflix/eureka2/client/interest/EurekaInterestClientImpl.java
@@ -1,7 +1,6 @@
 package com.netflix.eureka2.client.interest;
 
 import javax.inject.Inject;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.netflix.eureka2.channel.ChannelFactory;
 import com.netflix.eureka2.channel.InterestChannel;
@@ -9,17 +8,11 @@ import com.netflix.eureka2.connection.RetryableConnection;
 import com.netflix.eureka2.connection.RetryableConnectionFactory;
 import com.netflix.eureka2.interests.ChangeNotification;
 import com.netflix.eureka2.interests.Interest;
-import com.netflix.eureka2.registry.Source;
-import com.netflix.eureka2.registry.Sourced;
 import com.netflix.eureka2.registry.SourcedEurekaRegistry;
 import com.netflix.eureka2.registry.instance.InstanceInfo;
-import com.netflix.eureka2.utils.rx.RetryStrategyFunc;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import rx.Observable;
 import rx.Subscriber;
 import rx.functions.Action0;
-import rx.functions.Func1;
 import rx.functions.Func2;
 
 /**
@@ -33,15 +26,9 @@ import rx.functions.Func2;
  *
  * @author David Liu
  */
-public class EurekaInterestClientImpl implements EurekaInterestClient {
-    private static final Logger logger = LoggerFactory.getLogger(EurekaInterestClientImpl.class);
+public class EurekaInterestClientImpl extends AbstractInterestClient {
 
-    private static final int DEFAULT_RETRY_WAIT_MILLIS = 500;
-
-    private final AtomicBoolean isShutdown;
-    private final SourcedEurekaRegistry<InstanceInfo> registry;
     private final InterestTracker interestTracker;
-
     private final RetryableConnection<InterestChannel> retryableConnection;
 
     @Inject
@@ -53,9 +40,8 @@ public class EurekaInterestClientImpl implements EurekaInterestClient {
     /* visible for testing*/ EurekaInterestClientImpl(final SourcedEurekaRegistry<InstanceInfo> registry,
                                                       ChannelFactory<InterestChannel> channelFactory,
                                                       int retryWaitMillis) {
-        this.registry = registry;
+        super(registry, retryWaitMillis);
         this.interestTracker = new InterestTracker();
-        this.isShutdown = new AtomicBoolean(false);
 
 
         RetryableConnectionFactory<InterestChannel> retryableConnectionFactory
@@ -71,54 +57,8 @@ public class EurekaInterestClientImpl implements EurekaInterestClient {
 
         this.retryableConnection = retryableConnectionFactory.singleOpConnection(opStream, executeOnChannel);
 
-        // subscribe to the base interest channels to do cleanup on every channel refresh.
-        retryableConnection.getChannelObservable()
-                .flatMap(new Func1<InterestChannel, Observable<Long>>() {
-                    @Override
-                    public Observable<Long> call(InterestChannel interestChannel) {
-                        if (interestChannel instanceof Sourced) {
-                            Source toRetain = ((Sourced) interestChannel).getSource();
-                            return registry.evictAllExcept(toRetain);
-                        }
-                        return Observable.empty();
-                    }
-                })
-                .subscribe(new Subscriber<Long>() {
-                    @Override
-                    public void onCompleted() {
-                        logger.info("Completed one round of eviction due to a new interestChannel creation");
-                    }
-
-                    @Override
-                    public void onError(Throwable e) {
-                        logger.warn("OnError in one round of eviction due to a new interestChannel creation");
-                    }
-
-                    @Override
-                    public void onNext(Long aLong) {
-                        logger.info("Evicted {} instances in one round of eviction due to a new interestChannel creation", aLong);
-                    }
-                });
-
-        // subscribe to the lifecycle to initiate the interest subscription
-        retryableConnection.getRetryableLifecycle()
-                .retryWhen(new RetryStrategyFunc(retryWaitMillis))
-                .subscribe(new Subscriber<Void>() {
-                    @Override
-                    public void onCompleted() {
-                        logger.info("channel onCompleted");
-                    }
-
-                    @Override
-                    public void onError(Throwable e) {
-                        logger.error("Lifecycle closed with an error");
-                    }
-
-                    @Override
-                    public void onNext(Void aVoid) {
-
-                    }
-                });
+        registryEvictionSubscribe(retryableConnection);
+        lifecycleSubscribe(retryableConnection);
     }
 
     /**
@@ -154,11 +94,7 @@ public class EurekaInterestClientImpl implements EurekaInterestClient {
     }
 
     @Override
-    public void shutdown() {
-        if (isShutdown.compareAndSet(false, true)) {
-            logger.info("Shutting down InterestClient");
-            retryableConnection.close();
-            registry.shutdown();
-        }
+    protected RetryableConnection<InterestChannel> getRetryableConnection() {
+        return retryableConnection;
     }
 }

--- a/eureka2-core/src/main/java/com/netflix/eureka2/interests/FullRegistryInterest.java
+++ b/eureka2-core/src/main/java/com/netflix/eureka2/interests/FullRegistryInterest.java
@@ -1,22 +1,20 @@
 package com.netflix.eureka2.interests;
 
-import com.netflix.eureka2.registry.instance.InstanceInfo;
-
 /**
  * @author Nitesh Kant
  */
-public class FullRegistryInterest extends Interest<InstanceInfo> {
+public class FullRegistryInterest<T> extends Interest<T> {
 
-    private static final FullRegistryInterest DEFAULT_INSTANCE = new FullRegistryInterest();
+    private static final FullRegistryInterest<?> DEFAULT_INSTANCE = new FullRegistryInterest<>();
 
     private static final int HASH = 234234128;
 
-    public static FullRegistryInterest getInstance() {
-        return DEFAULT_INSTANCE;
+    public static <T> FullRegistryInterest<T> getInstance() {
+        return (FullRegistryInterest<T>) DEFAULT_INSTANCE;
     }
 
     @Override
-    public boolean matches(InstanceInfo data) {
+    public boolean matches(T data) {
         return true;
     }
 
@@ -29,5 +27,4 @@ public class FullRegistryInterest extends Interest<InstanceInfo> {
     public boolean equals(Object o) {
         return o instanceof FullRegistryInterest;
     }
-
 }

--- a/eureka2-external-server/src/main/java/com/netflix/eureka2/server/RegistrationClientProvider.java
+++ b/eureka2-external-server/src/main/java/com/netflix/eureka2/server/RegistrationClientProvider.java
@@ -1,0 +1,40 @@
+package com.netflix.eureka2.server;
+
+import javax.inject.Provider;
+
+import com.google.inject.Inject;
+import com.netflix.eureka2.client.EurekaClientBuilder;
+import com.netflix.eureka2.client.registration.EurekaRegistrationClient;
+import com.netflix.eureka2.client.resolver.ServerResolver;
+import com.netflix.eureka2.metric.EurekaRegistryMetricFactory;
+import com.netflix.eureka2.metric.client.EurekaClientMetricFactory;
+import com.netflix.eureka2.server.config.EurekaCommonConfig;
+
+/**
+ * @author Tomasz Bak
+ */
+public class RegistrationClientProvider implements Provider<EurekaRegistrationClient> {
+
+    private final EurekaCommonConfig config;
+    private final EurekaClientMetricFactory clientMetricFactory;
+    private final EurekaRegistryMetricFactory registryMetricFactory;
+
+    @Inject
+    public RegistrationClientProvider(EurekaCommonConfig config,
+                                      EurekaClientMetricFactory clientMetricFactory,
+                                      EurekaRegistryMetricFactory registryMetricFactory) {
+        this.config = config;
+        this.clientMetricFactory = clientMetricFactory;
+        this.registryMetricFactory = registryMetricFactory;
+    }
+
+    @Override
+    public EurekaRegistrationClient get() {
+        ServerResolver registrationResolver = WriteClusterResolvers.createRegistrationResolver(config);
+        return EurekaClientBuilder.registrationBuilder()
+                .withClientMetricFactory(clientMetricFactory)
+                .withWriteServerResolver(registrationResolver)
+                .withRegistryMetricFactory(registryMetricFactory)
+                .build();
+    }
+}

--- a/eureka2-external-server/src/main/java/com/netflix/eureka2/server/WriteClusterResolvers.java
+++ b/eureka2-external-server/src/main/java/com/netflix/eureka2/server/WriteClusterResolvers.java
@@ -1,0 +1,73 @@
+package com.netflix.eureka2.server;
+
+import com.netflix.eureka2.Server;
+import com.netflix.eureka2.client.resolver.ServerResolver;
+import com.netflix.eureka2.client.resolver.ServerResolvers;
+import com.netflix.eureka2.server.config.EurekaCommonConfig;
+import com.netflix.eureka2.server.config.EurekaCommonConfig.ResolverType;
+import com.netflix.eureka2.server.config.EurekaCommonConfig.ServerBootstrap;
+import rx.functions.Func1;
+
+/**
+ * @author Tomasz Bak
+ */
+public final class WriteClusterResolvers {
+
+    private WriteClusterResolvers() {
+    }
+
+    public static ServerResolver createRegistrationResolver(EurekaCommonConfig config) {
+        return createWriteServerResolver(config,
+                new Func1<ServerBootstrap, Integer>() {
+                    @Override
+                    public Integer call(ServerBootstrap server) {
+                        return server.getRegistrationPort();
+                    }
+                }
+        );
+    }
+
+    public static ServerResolver createInterestResolver(EurekaCommonConfig config) {
+        return createWriteServerResolver(config,
+                new Func1<ServerBootstrap, Integer>() {
+                    @Override
+                    public Integer call(ServerBootstrap server) {
+                        return server.getDiscoveryPort();
+                    }
+                }
+        );
+    }
+
+    public static ServerResolver createWriteServerResolver(EurekaCommonConfig config, Func1<ServerBootstrap, Integer> getPortFunc) {
+        EurekaCommonConfig.ResolverType resolverType = config.getServerResolverType();
+        if (resolverType == null) {
+            throw new IllegalArgumentException("Write cluster resolver type not defined");
+        }
+
+        ServerResolver resolver;
+
+        ServerBootstrap[] bootstraps = ServerBootstrap.from(config.getServerList());
+
+        if (resolverType == ResolverType.dns) {
+            resolver = forDNS(bootstraps, getPortFunc);
+        } else {
+            resolver = forFixed(bootstraps, getPortFunc);
+        }
+        return resolver;
+    }
+
+    private static ServerResolver forDNS(ServerBootstrap[] bootstraps, Func1<ServerBootstrap, Integer> getPortFunc) {
+        if (bootstraps.length != 1) {
+            throw new IllegalArgumentException("Expected one DNS name for server resolver, while got " + bootstraps.length);
+        }
+        return ServerResolvers.forDnsName(bootstraps[0].getHostname(), getPortFunc.call(bootstraps[0]));
+    }
+
+    private static ServerResolver forFixed(ServerBootstrap[] bootstraps, Func1<ServerBootstrap, Integer> getPortFunc) {
+        Server[] servers = new Server[bootstraps.length];
+        for (int i = 0; i < bootstraps.length; i++) {
+            servers[i] = new Server(bootstraps[i].getHostname(), getPortFunc.call(bootstraps[i]));
+        }
+        return ServerResolvers.from(servers);
+    }
+}

--- a/eureka2-read-server/src/main/java/com/netflix/eureka2/server/FullFetchInterestClientProvider.java
+++ b/eureka2-read-server/src/main/java/com/netflix/eureka2/server/FullFetchInterestClientProvider.java
@@ -1,0 +1,72 @@
+package com.netflix.eureka2.server;
+
+
+import javax.inject.Provider;
+
+import com.google.inject.Inject;
+import com.netflix.eureka2.channel.InterestChannel;
+import com.netflix.eureka2.client.channel.ClientChannelFactory;
+import com.netflix.eureka2.client.channel.InterestChannelFactory;
+import com.netflix.eureka2.client.interest.BatchAwareIndexRegistry;
+import com.netflix.eureka2.client.interest.BatchingRegistry;
+import com.netflix.eureka2.client.interest.EurekaInterestClient;
+import com.netflix.eureka2.client.resolver.ServerResolver;
+import com.netflix.eureka2.config.BasicEurekaRegistryConfig;
+import com.netflix.eureka2.config.BasicEurekaRegistryConfig.Builder;
+import com.netflix.eureka2.config.BasicEurekaTransportConfig;
+import com.netflix.eureka2.interests.IndexRegistryImpl;
+import com.netflix.eureka2.metric.EurekaRegistryMetricFactory;
+import com.netflix.eureka2.metric.client.EurekaClientMetricFactory;
+import com.netflix.eureka2.registry.PreservableEurekaRegistry;
+import com.netflix.eureka2.registry.SourcedEurekaRegistryImpl;
+import com.netflix.eureka2.registry.instance.InstanceInfo;
+import com.netflix.eureka2.server.config.EurekaCommonConfig;
+import com.netflix.eureka2.server.interest.FullFetchBatchingRegistry;
+import com.netflix.eureka2.server.interest.FullFetchInterestClient;
+
+/**
+ * @author Tomasz Bak
+ */
+public class FullFetchInterestClientProvider implements Provider<EurekaInterestClient> {
+
+    private final EurekaCommonConfig config;
+    private final EurekaClientMetricFactory clientMetricFactory;
+    private final EurekaRegistryMetricFactory registryMetricFactory;
+
+    @Inject
+    public FullFetchInterestClientProvider(EurekaCommonConfig config,
+                                           EurekaClientMetricFactory clientMetricFactory,
+                                           EurekaRegistryMetricFactory registryMetricFactory) {
+        this.config = config;
+        this.clientMetricFactory = clientMetricFactory;
+        this.registryMetricFactory = registryMetricFactory;
+    }
+
+    @Override
+    public EurekaInterestClient get() {
+        BatchingRegistry<InstanceInfo> remoteBatchingRegistry = new FullFetchBatchingRegistry<>();
+        BatchAwareIndexRegistry<InstanceInfo> indexRegistry = new BatchAwareIndexRegistry<>(
+                new IndexRegistryImpl<InstanceInfo>(), remoteBatchingRegistry);
+
+        BasicEurekaRegistryConfig registryConfig = new Builder().build();
+        BasicEurekaTransportConfig transportConfig = new BasicEurekaTransportConfig.Builder().build();
+
+        PreservableEurekaRegistry registry = new PreservableEurekaRegistry(
+                new SourcedEurekaRegistryImpl(indexRegistry, registryMetricFactory),
+                registryConfig,
+                registryMetricFactory
+        );
+
+        ServerResolver discoveryResolver = WriteClusterResolvers.createInterestResolver(config);
+
+        ClientChannelFactory<InterestChannel> channelFactory = new InterestChannelFactory(
+                transportConfig,
+                discoveryResolver,
+                registry,
+                remoteBatchingRegistry,
+                clientMetricFactory
+        );
+
+        return new FullFetchInterestClient(registry, channelFactory);
+    }
+}

--- a/eureka2-read-server/src/main/java/com/netflix/eureka2/server/interest/FullFetchBatchingRegistry.java
+++ b/eureka2-read-server/src/main/java/com/netflix/eureka2/server/interest/FullFetchBatchingRegistry.java
@@ -1,0 +1,34 @@
+package com.netflix.eureka2.server.interest;
+
+import com.netflix.eureka2.client.interest.BatchingRegistry;
+import com.netflix.eureka2.client.interest.BatchingRegistryImpl;
+import com.netflix.eureka2.interests.FullRegistryInterest;
+import com.netflix.eureka2.interests.Interest;
+import com.netflix.eureka2.interests.StreamStateNotification.BufferState;
+import rx.Observable;
+
+/**
+ * A special implementation of {@link BatchingRegistry}, where client interest channel contains
+ * single full registry fetch subscription, and thus fine grain, atomic interest streams are not
+ * available.
+ * <p>
+ * Batch markers are generated from full registry fetch stream, and are shared by all
+ * subscribers, irrespective of their interest subscriptions. The only adverse effect on the end
+ * client is possible extra delay incurred, before buffer sentinel is generated.
+ *
+ * @author Tomasz Bak
+ */
+public class FullFetchBatchingRegistry<T> extends BatchingRegistryImpl<T> {
+
+    private final FullRegistryInterest<T> fullRegistryInterest = FullRegistryInterest.getInstance();
+
+    @Override
+    public Observable<BufferState> forInterest(Interest<T> interest) {
+        return super.forInterest(fullRegistryInterest);
+    }
+
+    @Override
+    public BufferState shouldBatch(Interest<T> interest) {
+        return super.shouldBatch(fullRegistryInterest);
+    }
+}

--- a/eureka2-read-server/src/main/java/com/netflix/eureka2/server/interest/FullFetchInterestClient.java
+++ b/eureka2-read-server/src/main/java/com/netflix/eureka2/server/interest/FullFetchInterestClient.java
@@ -1,0 +1,70 @@
+package com.netflix.eureka2.server.interest;
+
+import javax.inject.Inject;
+
+import com.netflix.eureka2.channel.ChannelFactory;
+import com.netflix.eureka2.channel.InterestChannel;
+import com.netflix.eureka2.client.interest.AbstractInterestClient;
+import com.netflix.eureka2.client.interest.EurekaInterestClient;
+import com.netflix.eureka2.connection.RetryableConnection;
+import com.netflix.eureka2.connection.RetryableConnectionFactory;
+import com.netflix.eureka2.interests.ChangeNotification;
+import com.netflix.eureka2.interests.Interest;
+import com.netflix.eureka2.interests.Interests;
+import com.netflix.eureka2.registry.SourcedEurekaRegistry;
+import com.netflix.eureka2.registry.instance.InstanceInfo;
+import rx.Observable;
+import rx.functions.Func1;
+
+/**
+ * {@link EurekaInterestClient} implementation with single full registry fetch subscription.
+ * Client interest subscriptions are not propagated to the channel, as the registry is already eagerly
+ * subscribed to the full content.
+ *
+ * @author Tomasz Bak
+ */
+public class FullFetchInterestClient extends AbstractInterestClient {
+
+    private final RetryableConnection<InterestChannel> retryableConnection;
+
+    @Inject
+    public FullFetchInterestClient(SourcedEurekaRegistry<InstanceInfo> registry,
+                                   ChannelFactory<InterestChannel> channelFactory) {
+        this(registry, channelFactory, DEFAULT_RETRY_WAIT_MILLIS);
+    }
+
+    /* visible for testing*/ FullFetchInterestClient(final SourcedEurekaRegistry<InstanceInfo> registry,
+                                                     ChannelFactory<InterestChannel> channelFactory,
+                                                     int retryWaitMillis) {
+        super(registry, retryWaitMillis);
+
+
+        RetryableConnectionFactory<InterestChannel> retryableConnectionFactory
+                = new RetryableConnectionFactory<>(channelFactory);
+
+        Func1<InterestChannel, Observable<Void>> executeOnChannel = new Func1<InterestChannel, Observable<Void>>() {
+            @Override
+            public Observable<Void> call(InterestChannel interestChannel) {
+                return interestChannel.change(Interests.forFullRegistry());
+            }
+        };
+
+        this.retryableConnection = retryableConnectionFactory.zeroOpConnection(executeOnChannel);
+
+        registryEvictionSubscribe(retryableConnection);
+        lifecycleSubscribe(retryableConnection);
+    }
+
+    @Override
+    public Observable<ChangeNotification<InstanceInfo>> forInterest(final Interest<InstanceInfo> interest) {
+        if (isShutdown.get()) {
+            return Observable.error(new IllegalStateException("InterestHandler has shutdown"));
+        }
+        return registry.forInterest(interest);
+    }
+
+    @Override
+    protected RetryableConnection<InterestChannel> getRetryableConnection() {
+        return retryableConnection;
+    }
+}

--- a/eureka2-read-server/src/main/java/com/netflix/eureka2/server/registry/EurekaReadServerRegistry.java
+++ b/eureka2-read-server/src/main/java/com/netflix/eureka2/server/registry/EurekaReadServerRegistry.java
@@ -87,6 +87,9 @@ public class EurekaReadServerRegistry implements SourcedEurekaRegistry<InstanceI
         throw new UnsupportedOperationException("method not supported by EurekaReadServerRegistry");
     }
 
+    /**
+     * This class emits buffer start/end markers used internally by the interest channels/transport.
+     */
     @Override
     public Observable<ChangeNotification<InstanceInfo>> forInterest(final Interest<InstanceInfo> interest) {
         return interestClient.forInterest(interest).flatMap(bufferStartEndDelineateFun(interest));
@@ -144,9 +147,7 @@ public class EurekaReadServerRegistry implements SourcedEurekaRegistry<InstanceI
                 } else {
                     List<ChangeNotification<InstanceInfo>> batch = new ArrayList<>(2 + buffer.size());
                     batch.add(bufferStartNotification);
-                    for (ChangeNotification<InstanceInfo> item : buffer) {
-                        batch.add(item);
-                    }
+                    batch.addAll(buffer);
                     batch.add(bufferEndNotification);
                     result = Observable.from(batch);
                 }

--- a/eureka2-read-server/src/main/java/com/netflix/eureka2/server/registry/EurekaReadServerRegistry.java
+++ b/eureka2-read-server/src/main/java/com/netflix/eureka2/server/registry/EurekaReadServerRegistry.java
@@ -16,20 +16,24 @@
 
 package com.netflix.eureka2.server.registry;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.google.inject.Inject;
 import com.netflix.eureka2.channel.InterestChannel;
 import com.netflix.eureka2.channel.ServiceChannel;
 import com.netflix.eureka2.client.EurekaClient;
+import com.netflix.eureka2.client.interest.EurekaInterestClient;
 import com.netflix.eureka2.interests.ChangeNotification;
+import com.netflix.eureka2.interests.ChangeNotification.Kind;
 import com.netflix.eureka2.interests.Interest;
+import com.netflix.eureka2.interests.StreamStateNotification;
 import com.netflix.eureka2.registry.MultiSourcedDataHolder;
 import com.netflix.eureka2.registry.Source;
 import com.netflix.eureka2.registry.SourcedEurekaRegistry;
 import com.netflix.eureka2.registry.instance.InstanceInfo;
 import rx.Observable;
 import rx.functions.Func1;
-
-import static com.netflix.eureka2.utils.rx.RxFunctions.filterNullValuesFunc;
 
 /**
  * Registry implemented on top of eureka-client. It does not story anything, just
@@ -51,11 +55,11 @@ import static com.netflix.eureka2.utils.rx.RxFunctions.filterNullValuesFunc;
  */
 public class EurekaReadServerRegistry implements SourcedEurekaRegistry<InstanceInfo> {
 
-    private final EurekaClient eurekaClient;
+    private final EurekaInterestClient interestClient;
 
     @Inject
-    public EurekaReadServerRegistry(EurekaClient eurekaClient) {
-        this.eurekaClient = eurekaClient;
+    public EurekaReadServerRegistry(EurekaInterestClient interestClient) {
+        this.interestClient = interestClient;
     }
 
     @Override
@@ -83,19 +87,9 @@ public class EurekaReadServerRegistry implements SourcedEurekaRegistry<InstanceI
         throw new UnsupportedOperationException("method not supported by EurekaReadServerRegistry");
     }
 
-    // TODO As read server is based on client API, and is doing fullRegistryFetch from write server, we cannot generate batch markers4
-    // TODO This is one of the reasons why we cannot depend on Eureka client API in the read server.
     @Override
     public Observable<ChangeNotification<InstanceInfo>> forInterest(final Interest<InstanceInfo> interest) {
-        return eurekaClient.forInterest(interest).map(new Func1<ChangeNotification<InstanceInfo>, ChangeNotification<InstanceInfo>>() {
-            @Override
-            public ChangeNotification<InstanceInfo> call(ChangeNotification<InstanceInfo> notification) {
-                if (notification.isDataNotification()) {
-                    return notification;
-                }
-                return null;
-            }
-        }).filter(filterNullValuesFunc());
+        return interestClient.forInterest(interest).flatMap(bufferStartEndDelineateFun(interest));
     }
 
     @Override
@@ -125,6 +119,40 @@ public class EurekaReadServerRegistry implements SourcedEurekaRegistry<InstanceI
 
     @Override
     public String toString() {
-        return eurekaClient.toString();
+        return interestClient.toString();
+    }
+
+    static Func1<ChangeNotification<InstanceInfo>, Observable<ChangeNotification<InstanceInfo>>> bufferStartEndDelineateFun(Interest<InstanceInfo> interest) {
+
+        final ChangeNotification<InstanceInfo> bufferStartNotification = StreamStateNotification.bufferStartNotification(interest);
+        final ChangeNotification<InstanceInfo> bufferEndNotification = StreamStateNotification.bufferEndNotification(interest);
+
+        final List<ChangeNotification<InstanceInfo>> buffer = new ArrayList<>();
+        return new Func1<ChangeNotification<InstanceInfo>, Observable<ChangeNotification<InstanceInfo>>>() {
+            @Override
+            public Observable<ChangeNotification<InstanceInfo>> call(ChangeNotification<InstanceInfo> notification) {
+                if (notification.getKind() != Kind.BufferSentinel) {
+                    buffer.add(notification);
+                    return Observable.empty();
+                }
+                if (buffer.isEmpty()) {
+                    return Observable.empty();
+                }
+                Observable<ChangeNotification<InstanceInfo>> result;
+                if (buffer.size() == 1) {
+                    result = Observable.just(buffer.get(0));
+                } else {
+                    List<ChangeNotification<InstanceInfo>> batch = new ArrayList<>(2 + buffer.size());
+                    batch.add(bufferStartNotification);
+                    for (ChangeNotification<InstanceInfo> item : buffer) {
+                        batch.add(item);
+                    }
+                    batch.add(bufferEndNotification);
+                    result = Observable.from(batch);
+                }
+                buffer.clear();
+                return result;
+            }
+        };
     }
 }

--- a/eureka2-read-server/src/main/java/com/netflix/eureka2/server/service/EurekaReadServerSelfRegistrationService.java
+++ b/eureka2-read-server/src/main/java/com/netflix/eureka2/server/service/EurekaReadServerSelfRegistrationService.java
@@ -1,12 +1,12 @@
 package com.netflix.eureka2.server.service;
 
-import com.netflix.eureka2.client.EurekaClient;
-import com.netflix.eureka2.registry.instance.InstanceInfo;
-import rx.Observable;
-
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+
+import com.netflix.eureka2.client.registration.EurekaRegistrationClient;
+import com.netflix.eureka2.registry.instance.InstanceInfo;
+import rx.Observable;
 
 /**
  * @author David Liu
@@ -14,12 +14,12 @@ import javax.inject.Singleton;
 @Singleton
 public class EurekaReadServerSelfRegistrationService extends SelfRegistrationService {
 
-    private final EurekaClient eurekaClient;
+    private final EurekaRegistrationClient registrationClient;
 
     @Inject
-    public EurekaReadServerSelfRegistrationService(SelfInfoResolver resolver, EurekaClient eurekaClient) {
+    public EurekaReadServerSelfRegistrationService(SelfInfoResolver resolver, EurekaRegistrationClient registrationClient) {
         super(resolver);
-        this.eurekaClient = eurekaClient;
+        this.registrationClient = registrationClient;
     }
 
     @PostConstruct
@@ -30,11 +30,11 @@ public class EurekaReadServerSelfRegistrationService extends SelfRegistrationSer
 
     @Override
     public void cleanUpResources() {
-        eurekaClient.shutdown();
+        registrationClient.shutdown();
     }
 
     @Override
     public Observable<Void> connect(Observable<InstanceInfo> registrant) {
-        return eurekaClient.register(registrant);
+        return registrationClient.register(registrant);
     }
 }

--- a/eureka2-read-server/src/test/java/com/netflix/eureka2/server/interest/FullFetchInterestClientTest.java
+++ b/eureka2-read-server/src/test/java/com/netflix/eureka2/server/interest/FullFetchInterestClientTest.java
@@ -1,0 +1,114 @@
+package com.netflix.eureka2.server.interest;
+
+import com.netflix.eureka2.channel.ChannelFactory;
+import com.netflix.eureka2.channel.InterestChannel;
+import com.netflix.eureka2.client.interest.BatchAwareIndexRegistry;
+import com.netflix.eureka2.client.interest.BatchingRegistry;
+import com.netflix.eureka2.interests.ChangeNotification;
+import com.netflix.eureka2.interests.ChangeNotification.Kind;
+import com.netflix.eureka2.interests.IndexRegistry;
+import com.netflix.eureka2.interests.IndexRegistryImpl;
+import com.netflix.eureka2.interests.Interest;
+import com.netflix.eureka2.interests.Interests;
+import com.netflix.eureka2.interests.StreamStateNotification;
+import com.netflix.eureka2.registry.Source;
+import com.netflix.eureka2.registry.Source.Origin;
+import com.netflix.eureka2.registry.SourcedEurekaRegistry;
+import com.netflix.eureka2.registry.SourcedEurekaRegistryImpl;
+import com.netflix.eureka2.registry.instance.InstanceInfo;
+import com.netflix.eureka2.rx.ExtTestSubscriber;
+import com.netflix.eureka2.testkit.data.builder.SampleInstanceInfo;
+import org.junit.Before;
+import org.junit.Test;
+import rx.schedulers.Schedulers;
+import rx.schedulers.TestScheduler;
+import rx.subjects.PublishSubject;
+
+import static com.netflix.eureka2.metric.EurekaRegistryMetricFactory.registryMetrics;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Tomasz Bak
+ */
+public class FullFetchInterestClientTest {
+
+    private static final ChangeNotification<InstanceInfo> ADD_INSTANCE_1 = new ChangeNotification<>(Kind.Add, SampleInstanceInfo.EurekaWriteServer.build());
+    private static final ChangeNotification<InstanceInfo> ADD_INSTANCE_2 = new ChangeNotification<>(Kind.Add, SampleInstanceInfo.EurekaWriteServer.build());
+    private static final ChangeNotification<InstanceInfo> ADD_ANOTHER_VIP = new ChangeNotification<>(Kind.Add, SampleInstanceInfo.EurekaReadServer.build());
+
+    private static final Interest<InstanceInfo> INTEREST = Interests.forVips(ADD_INSTANCE_1.getData().getVipAddress());
+
+    private static final ChangeNotification<InstanceInfo> BUFFER_BEGIN = StreamStateNotification.bufferStartNotification(Interests.forFullRegistry());
+    private static final ChangeNotification<InstanceInfo> BUFFER_END = StreamStateNotification.bufferEndNotification(Interests.forFullRegistry());
+
+    private static final Source SOURCE = new Source(Origin.INTERESTED, "test");
+
+    private final TestScheduler testScheduler = Schedulers.test();
+
+    private final BatchingRegistry<InstanceInfo> remoteBatchingRegistry = new FullFetchBatchingRegistry<>();
+    private final IndexRegistry<InstanceInfo> indexRegistry = new BatchAwareIndexRegistry<>(
+            new IndexRegistryImpl<InstanceInfo>(),
+            remoteBatchingRegistry
+    );
+    private final SourcedEurekaRegistry<InstanceInfo> registry = new SourcedEurekaRegistryImpl(indexRegistry, registryMetrics(), testScheduler);
+
+    private final ChannelFactory<InterestChannel> channelFactory = mock(ChannelFactory.class);
+
+    private final ExtTestSubscriber<ChangeNotification<InstanceInfo>> testSubscriber = new ExtTestSubscriber<>();
+    private final InterestChannel interestChannel = mock(InterestChannel.class);
+    private final PublishSubject<ChangeNotification<InstanceInfo>> notificationsSubject = PublishSubject.create();
+
+    @Before
+    public void setUp() throws Exception {
+        when(channelFactory.newChannel()).thenReturn(interestChannel);
+        remoteBatchingRegistry.connectTo(notificationsSubject);
+    }
+
+    @Test
+    public void testChannelHasSingleFullRegistryFetchSubscription() throws Exception {
+        new FullFetchInterestClient(registry, channelFactory).forInterest(INTEREST).subscribe(testSubscriber);
+        testScheduler.triggerActions();
+
+        verify(interestChannel, times(1)).change(Interests.forFullRegistry());
+        verify(interestChannel, times(0)).change(INTEREST);
+    }
+
+    @Test
+    public void testBufferMarkersFromTheChannelArePropagatedToSubscriber() throws Exception {
+        new FullFetchInterestClient(registry, channelFactory).forInterest(INTEREST).subscribe(testSubscriber);
+
+        notificationsSubject.onNext(BUFFER_BEGIN);
+        testScheduler.triggerActions();
+
+        registry.register(ADD_INSTANCE_1.getData(), SOURCE).subscribe();
+        registry.register(ADD_INSTANCE_2.getData(), SOURCE).subscribe();
+        testScheduler.triggerActions();
+
+        notificationsSubject.onNext(BUFFER_END);
+        testScheduler.triggerActions();
+
+        assertThat(testSubscriber.takeNext(), is(equalTo(ADD_INSTANCE_1)));
+        assertThat(testSubscriber.takeNext(), is(equalTo(ADD_INSTANCE_2)));
+        assertThat(testSubscriber.takeNext(), is(equalTo(ChangeNotification.<InstanceInfo>bufferSentinel())));
+    }
+
+    @Test
+    public void testBufferMarkersFromRegistryArePropagatedToSubscribers() throws Exception {
+        registry.register(ADD_INSTANCE_1.getData(), SOURCE).subscribe();
+        registry.register(ADD_INSTANCE_2.getData(), SOURCE).subscribe();
+        registry.register(ADD_ANOTHER_VIP.getData(), SOURCE).subscribe();
+        testScheduler.triggerActions();
+
+        new FullFetchInterestClient(registry, channelFactory).forInterest(INTEREST).subscribe(testSubscriber);
+
+        assertThat(testSubscriber.takeNext(2), containsInAnyOrder(ADD_INSTANCE_1, ADD_INSTANCE_2));
+        assertThat(testSubscriber.takeNext(), is(equalTo(ChangeNotification.<InstanceInfo>bufferSentinel())));
+    }
+}

--- a/eureka2-read-server/src/test/java/com/netflix/eureka2/server/registry/EurekaReadServerRegistryTest.java
+++ b/eureka2-read-server/src/test/java/com/netflix/eureka2/server/registry/EurekaReadServerRegistryTest.java
@@ -1,0 +1,77 @@
+package com.netflix.eureka2.server.registry;
+
+import com.netflix.eureka2.client.interest.EurekaInterestClient;
+import com.netflix.eureka2.interests.ChangeNotification;
+import com.netflix.eureka2.interests.ChangeNotification.Kind;
+import com.netflix.eureka2.interests.Interest;
+import com.netflix.eureka2.interests.Interests;
+import com.netflix.eureka2.interests.StreamStateNotification;
+import com.netflix.eureka2.registry.instance.InstanceInfo;
+import com.netflix.eureka2.rx.ExtTestSubscriber;
+import com.netflix.eureka2.testkit.data.builder.SampleInstanceInfo;
+import org.junit.Before;
+import org.junit.Test;
+import rx.subjects.PublishSubject;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Tomasz Bak
+ */
+public class EurekaReadServerRegistryTest {
+
+    private static final Interest<InstanceInfo> INTEREST = Interests.forVips("testVip");
+    private static final ChangeNotification<InstanceInfo> BUFFER_START = StreamStateNotification.bufferStartNotification(INTEREST);
+    private static final ChangeNotification<InstanceInfo> BUFFER_END = StreamStateNotification.bufferEndNotification(INTEREST);
+
+    private static final ChangeNotification<InstanceInfo> ADD_INSTANCE_1 = new ChangeNotification<>(Kind.Add, SampleInstanceInfo.EurekaWriteServer.build());
+    private static final ChangeNotification<InstanceInfo> ADD_INSTANCE_2 = new ChangeNotification<>(Kind.Add, SampleInstanceInfo.EurekaWriteServer.build());
+
+    private final EurekaInterestClient interestClient = mock(EurekaInterestClient.class);
+    private final PublishSubject<ChangeNotification<InstanceInfo>> interestSubject = PublishSubject.create();
+
+    private final EurekaReadServerRegistry registry = new EurekaReadServerRegistry(interestClient);
+
+    private final ExtTestSubscriber<ChangeNotification<InstanceInfo>> testSubscriber = new ExtTestSubscriber<>();
+
+    @Before
+    public void setUp() throws Exception {
+        when(interestClient.forInterest(any(Interest.class))).thenReturn(interestSubject);
+        registry.forInterest(INTEREST).subscribe(testSubscriber);
+    }
+
+    @Test
+    public void testVoidBufferSentinelsAreIgnored() throws Exception {
+        // Buffer sentinel with no data ahead of it shall be swallowed
+        interestSubject.onNext(ChangeNotification.<InstanceInfo>bufferSentinel());
+        assertThat(testSubscriber.takeNext(), is(nullValue()));
+    }
+
+    @Test
+    public void testBufferSentinelsAfterSingleItemDoNotGenerateBufferStartEndMarkers() throws Exception {
+        // Buffer sentinel after single item doesn't generate buffer delineation
+        interestSubject.onNext(ADD_INSTANCE_1);
+        interestSubject.onNext(ChangeNotification.<InstanceInfo>bufferSentinel());
+        assertThat(testSubscriber.takeNext(), is(ADD_INSTANCE_1));
+        assertThat(testSubscriber.takeNext(), is(nullValue()));
+    }
+
+    @Test
+    public void testBufferSentinelsAreTransformedToBufferStartEndMarkers() throws Exception {
+        // Buffer sentinel after two or more items creates delineation markers
+        interestSubject.onNext(ADD_INSTANCE_1);
+        interestSubject.onNext(ADD_INSTANCE_2);
+        interestSubject.onNext(ChangeNotification.<InstanceInfo>bufferSentinel());
+
+        assertThat(testSubscriber.takeNext(), is(equalTo(BUFFER_START)));
+        assertThat(testSubscriber.takeNext(), is(equalTo(ADD_INSTANCE_1)));
+        assertThat(testSubscriber.takeNext(), is(equalTo(ADD_INSTANCE_2)));
+        assertThat(testSubscriber.takeNext(), is(equalTo(BUFFER_END)));
+    }
+}

--- a/eureka2-testkit/src/main/java/com/netflix/eureka2/testkit/embedded/server/EmbeddedReadServer.java
+++ b/eureka2-testkit/src/main/java/com/netflix/eureka2/testkit/embedded/server/EmbeddedReadServer.java
@@ -3,14 +3,32 @@ package com.netflix.eureka2.testkit.embedded.server;
 import java.util.Properties;
 
 import com.google.inject.Module;
-import com.netflix.eureka2.client.Eureka;
-import com.netflix.eureka2.client.EurekaClient;
+import com.netflix.eureka2.channel.InterestChannel;
+import com.netflix.eureka2.client.EurekaClientBuilder;
+import com.netflix.eureka2.client.channel.ClientChannelFactory;
+import com.netflix.eureka2.client.channel.InterestChannelFactory;
+import com.netflix.eureka2.client.interest.BatchAwareIndexRegistry;
+import com.netflix.eureka2.client.interest.BatchingRegistry;
+import com.netflix.eureka2.client.interest.EurekaInterestClient;
+import com.netflix.eureka2.client.registration.EurekaRegistrationClient;
 import com.netflix.eureka2.client.resolver.ServerResolver;
 import com.netflix.eureka2.client.resolver.ServerResolvers;
+import com.netflix.eureka2.config.BasicEurekaRegistryConfig;
+import com.netflix.eureka2.config.BasicEurekaRegistryConfig.Builder;
+import com.netflix.eureka2.config.BasicEurekaTransportConfig;
+import com.netflix.eureka2.interests.IndexRegistryImpl;
+import com.netflix.eureka2.registry.PreservableEurekaRegistry;
+import com.netflix.eureka2.registry.SourcedEurekaRegistryImpl;
+import com.netflix.eureka2.registry.instance.InstanceInfo;
 import com.netflix.eureka2.server.EurekaReadServerModule;
 import com.netflix.eureka2.server.config.EurekaServerConfig;
+import com.netflix.eureka2.server.interest.FullFetchBatchingRegistry;
+import com.netflix.eureka2.server.interest.FullFetchInterestClient;
 import com.netflix.eureka2.server.transport.tcp.discovery.TcpDiscoveryServer;
 import com.netflix.eureka2.testkit.embedded.server.EmbeddedReadServer.ReadServerReport;
+
+import static com.netflix.eureka2.metric.EurekaRegistryMetricFactory.registryMetrics;
+import static com.netflix.eureka2.metric.client.EurekaClientMetricFactory.clientMetrics;
 
 /**
  * @author Tomasz Bak
@@ -31,11 +49,37 @@ public class EmbeddedReadServer extends EmbeddedEurekaServer<EurekaServerConfig,
 
     @Override
     public void start() {
-        final EurekaClient eurekaClient = Eureka.newClientBuilder(discoveryResolver, registrationResolver)
-                .withTransportConfig(config)
+        EurekaRegistrationClient registrationClient = EurekaClientBuilder
+                .registrationBuilder()
+                .withWriteServerResolver(registrationResolver)
                 .build();
+
+        // TODO We need to better encapsulate EurekaInterestClient construction
+        BatchingRegistry<InstanceInfo> remoteBatchingRegistry = new FullFetchBatchingRegistry<>();
+        BatchAwareIndexRegistry<InstanceInfo> indexRegistry = new BatchAwareIndexRegistry<>(
+                new IndexRegistryImpl<InstanceInfo>(), remoteBatchingRegistry);
+
+        BasicEurekaRegistryConfig registryConfig = new Builder().build();
+        BasicEurekaTransportConfig transportConfig = new BasicEurekaTransportConfig.Builder().build();
+
+        PreservableEurekaRegistry registry = new PreservableEurekaRegistry(
+                new SourcedEurekaRegistryImpl(indexRegistry, registryMetrics()),
+                registryConfig,
+                registryMetrics()
+        );
+
+        ClientChannelFactory<InterestChannel> channelFactory = new InterestChannelFactory(
+                transportConfig,
+                discoveryResolver,
+                registry,
+                remoteBatchingRegistry,
+                clientMetrics()
+        );
+
+        EurekaInterestClient interestClient = new FullFetchInterestClient(registry, channelFactory);
+
         Module[] modules = {
-                new EurekaReadServerModule(config, eurekaClient)
+                new EurekaReadServerModule(config, registrationClient, interestClient)
         };
 
         setup(modules);


### PR DESCRIPTION
The custom client uses single subscription (fullRegistryFetch), and propagates properly channel level buffer markers to interest subscribers.