### PR TITLE
2.x Changes to MultiSourcedDataHolder implementation

### DIFF
--- a/eureka2-client/src/main/java/com/netflix/eureka2/client/channel/InterestChannelImpl.java
+++ b/eureka2-client/src/main/java/com/netflix/eureka2/client/channel/InterestChannelImpl.java
@@ -82,7 +82,7 @@ public class InterestChannelImpl extends AbstractClientChannel<STATE> implements
                                InterestChannelMetrics metrics) {
         super(STATE.Idle, client, metrics);
         this.remoteBatchingRegistry = remoteBatchingRegistry;
-        this.selfSource = new Source(Source.Origin.LOCAL);
+        this.selfSource = new Source(Source.Origin.INTERESTED);
         this.registry = registry;
         channelInterestSubscriber = new ChannelInterestSubscriber(registry);
         channelInterestStream = createInterestStream();

--- a/eureka2-client/src/main/java/com/netflix/eureka2/client/interest/EurekaInterestClientImpl.java
+++ b/eureka2-client/src/main/java/com/netflix/eureka2/client/interest/EurekaInterestClientImpl.java
@@ -78,7 +78,7 @@ public class EurekaInterestClientImpl implements EurekaInterestClient {
                     public Observable<Long> call(InterestChannel interestChannel) {
                         if (interestChannel instanceof Sourced) {
                             Source toRetain = ((Sourced) interestChannel).getSource();
-                            return registry.evictAllExcept(toRetain);
+                            return registry.evictAllExcept(Source.matcherFor(toRetain));
                         }
                         return Observable.empty();
                     }

--- a/eureka2-core/src/main/java/com/netflix/eureka2/registry/NotifyingInstanceInfoHolder.java
+++ b/eureka2-core/src/main/java/com/netflix/eureka2/registry/NotifyingInstanceInfoHolder.java
@@ -318,7 +318,7 @@ public class NotifyingInstanceInfoHolder implements MultiSourcedDataHolder<Insta
         }
 
         /**
-         * Matches sources on origin:name only.
+         * Matches sources on origin:name:id.
          * - If a matching source already exist in the sourceMap, and has the same id as the input source, do removal
          * - If a matching source already exist in the sourceMap, but have a different id as the input source, no-op
          * - Otherwise, no-op

--- a/eureka2-core/src/main/java/com/netflix/eureka2/registry/PreservableEurekaRegistry.java
+++ b/eureka2-core/src/main/java/com/netflix/eureka2/registry/PreservableEurekaRegistry.java
@@ -156,13 +156,13 @@ public class PreservableEurekaRegistry implements SourcedEurekaRegistry<Instance
      * Evict by sending to the evictionQueue instead of directly.
      */
     @Override
-    public Observable<Long> evictAllExcept(final Source toRetain) {
+    public Observable<Long> evictAllExcept(final Source.Matcher retainMatcher) {
         return eurekaRegistry.getHolders()
                 .doOnNext(new Action1<MultiSourcedDataHolder<InstanceInfo>>() {
                     @Override
                     public void call(MultiSourcedDataHolder<InstanceInfo> holder) {
                         for (Source source : holder.getAllSources()) {
-                            if (!source.equals(toRetain)) {
+                            if (!retainMatcher.match(source)) {
                                 evictionQueue.add(holder.get(source), source);
                             }
                         }

--- a/eureka2-core/src/main/java/com/netflix/eureka2/registry/PreservableEurekaRegistry.java
+++ b/eureka2-core/src/main/java/com/netflix/eureka2/registry/PreservableEurekaRegistry.java
@@ -129,7 +129,7 @@ public class PreservableEurekaRegistry implements SourcedEurekaRegistry<Instance
     }
 
     @Override
-    public Observable<InstanceInfo> forSnapshot(Interest<InstanceInfo> interest, Source.Matcher sourceMatcher) {
+    public Observable<InstanceInfo> forSnapshot(Interest<InstanceInfo> interest, Source.SourceMatcher sourceMatcher) {
         return eurekaRegistry.forSnapshot(interest, sourceMatcher);
     }
 
@@ -139,7 +139,7 @@ public class PreservableEurekaRegistry implements SourcedEurekaRegistry<Instance
     }
 
     @Override
-    public Observable<ChangeNotification<InstanceInfo>> forInterest(Interest<InstanceInfo> interest, Source.Matcher sourceMatcher) {
+    public Observable<ChangeNotification<InstanceInfo>> forInterest(Interest<InstanceInfo> interest, Source.SourceMatcher sourceMatcher) {
         return eurekaRegistry.forInterest(interest, sourceMatcher);
     }
 
@@ -156,7 +156,7 @@ public class PreservableEurekaRegistry implements SourcedEurekaRegistry<Instance
      * Evict by sending to the evictionQueue instead of directly.
      */
     @Override
-    public Observable<Long> evictAllExcept(final Source.Matcher retainMatcher) {
+    public Observable<Long> evictAllExcept(final Source.SourceMatcher retainMatcher) {
         return eurekaRegistry.getHolders()
                 .doOnNext(new Action1<MultiSourcedDataHolder<InstanceInfo>>() {
                     @Override

--- a/eureka2-core/src/main/java/com/netflix/eureka2/registry/Source.java
+++ b/eureka2-core/src/main/java/com/netflix/eureka2/registry/Source.java
@@ -76,8 +76,8 @@ public class Source {
                 '}';
     }
 
-    public static Matcher matcherFor(final Source source) {
-        return new Matcher() {
+    public static SourceMatcher matcherFor(final Source source) {
+        return new SourceMatcher() {
             @Override
             public boolean match(Source another) {
                 return (source == null)
@@ -87,8 +87,8 @@ public class Source {
         };
     }
 
-    public static Matcher matcherFor(final Origin origin) {
-        return new Matcher() {
+    public static SourceMatcher matcherFor(final Origin origin) {
+        return new SourceMatcher() {
             @Override
             public boolean match(Source another) {
                 if (another == null) {
@@ -99,8 +99,8 @@ public class Source {
         };
     }
 
-    public static Matcher matcherFor(final Origin origin, final String name) {
-        return new Matcher() {
+    public static SourceMatcher matcherFor(final Origin origin, final String name) {
+        return new SourceMatcher() {
             @Override
             public boolean match(Source another) {
                 if (another == null) {
@@ -115,7 +115,7 @@ public class Source {
         };
     }
 
-    public static abstract class Matcher {
+    public static abstract class SourceMatcher {
         public abstract boolean match(Source another);
     }
 }

--- a/eureka2-core/src/main/java/com/netflix/eureka2/registry/Source.java
+++ b/eureka2-core/src/main/java/com/netflix/eureka2/registry/Source.java
@@ -80,7 +80,9 @@ public class Source {
         return new Matcher() {
             @Override
             public boolean match(Source another) {
-                return source.equals(another);
+                return (source == null)
+                        ? (another == null)
+                        : source.equals(another);
             }
         };
     }
@@ -104,7 +106,11 @@ public class Source {
                 if (another == null) {
                     return false;
                 }
-                return origin.equals(another.origin) && name.equals(another.name);
+                boolean originMatches = origin.equals(another.origin);
+                boolean nameMatches = (name == null)
+                        ? (another.name == null)
+                        : name.equals(another.name);
+                return originMatches && nameMatches;
             }
         };
     }

--- a/eureka2-core/src/main/java/com/netflix/eureka2/registry/SourcedEurekaRegistry.java
+++ b/eureka2-core/src/main/java/com/netflix/eureka2/registry/SourcedEurekaRegistry.java
@@ -48,10 +48,10 @@ public interface SourcedEurekaRegistry<T> {
     Observable<ChangeNotification<T>> forInterest(Interest<T> interest, Source.Matcher sourceMatcher);
 
     /**
-     * Evict all registry info for all sources except the single specified source
+     * Evict all registry info for all sources except those that matches the matcher
      * @return an observable of long denoting the number of holder items touched for the eviction
      */
-    Observable<Long> evictAllExcept(Source source);
+    Observable<Long> evictAllExcept(Source.Matcher retainMatcher);
 
     Observable<? extends MultiSourcedDataHolder<T>> getHolders();
 

--- a/eureka2-core/src/main/java/com/netflix/eureka2/registry/SourcedEurekaRegistry.java
+++ b/eureka2-core/src/main/java/com/netflix/eureka2/registry/SourcedEurekaRegistry.java
@@ -41,17 +41,17 @@ public interface SourcedEurekaRegistry<T> {
 
     Observable<T> forSnapshot(Interest<T> interest);
 
-    Observable<T> forSnapshot(Interest<T> interest, Source.Matcher sourceMatcher);
+    Observable<T> forSnapshot(Interest<T> interest, Source.SourceMatcher sourceMatcher);
 
     Observable<ChangeNotification<T>> forInterest(Interest<T> interest);
 
-    Observable<ChangeNotification<T>> forInterest(Interest<T> interest, Source.Matcher sourceMatcher);
+    Observable<ChangeNotification<T>> forInterest(Interest<T> interest, Source.SourceMatcher sourceMatcher);
 
     /**
      * Evict all registry info for all sources except those that matches the matcher
      * @return an observable of long denoting the number of holder items touched for the eviction
      */
-    Observable<Long> evictAllExcept(Source.Matcher retainMatcher);
+    Observable<Long> evictAllExcept(Source.SourceMatcher retainMatcher);
 
     Observable<? extends MultiSourcedDataHolder<T>> getHolders();
 

--- a/eureka2-core/src/main/java/com/netflix/eureka2/registry/SourcedEurekaRegistryImpl.java
+++ b/eureka2-core/src/main/java/com/netflix/eureka2/registry/SourcedEurekaRegistryImpl.java
@@ -219,7 +219,7 @@ public class SourcedEurekaRegistryImpl implements SourcedEurekaRegistry<Instance
     }
 
     @Override
-    public Observable<InstanceInfo> forSnapshot(final Interest<InstanceInfo> interest, final Source.Matcher sourceMatcher) {
+    public Observable<InstanceInfo> forSnapshot(final Interest<InstanceInfo> interest, final Source.SourceMatcher sourceMatcher) {
         return forSnapshot(interest).filter(new Func1<InstanceInfo, Boolean>() {
             @Override
             public Boolean call(InstanceInfo instanceInfo) {
@@ -254,7 +254,7 @@ public class SourcedEurekaRegistryImpl implements SourcedEurekaRegistry<Instance
     }
 
     @Override
-    public Observable<ChangeNotification<InstanceInfo>> forInterest(Interest<InstanceInfo> interest, final Source.Matcher sourceMatcher) {
+    public Observable<ChangeNotification<InstanceInfo>> forInterest(Interest<InstanceInfo> interest, final Source.SourceMatcher sourceMatcher) {
         return forInterest(interest).filter(new Func1<ChangeNotification<InstanceInfo>, Boolean>() {
             @Override
             public Boolean call(ChangeNotification<InstanceInfo> changeNotification) {
@@ -270,7 +270,7 @@ public class SourcedEurekaRegistryImpl implements SourcedEurekaRegistry<Instance
     }
 
     @Override
-    public Observable<Long> evictAllExcept(final Source.Matcher retainMatcher) {
+    public Observable<Long> evictAllExcept(final Source.SourceMatcher retainMatcher) {
         return getHolders()
                 .doOnNext(new Action1<MultiSourcedDataHolder<InstanceInfo>>() {
                     @Override

--- a/eureka2-core/src/main/java/com/netflix/eureka2/registry/SourcedEurekaRegistryImpl.java
+++ b/eureka2-core/src/main/java/com/netflix/eureka2/registry/SourcedEurekaRegistryImpl.java
@@ -270,13 +270,13 @@ public class SourcedEurekaRegistryImpl implements SourcedEurekaRegistry<Instance
     }
 
     @Override
-    public Observable<Long> evictAllExcept(final Source toRetain) {
+    public Observable<Long> evictAllExcept(final Source.Matcher retainMatcher) {
         return getHolders()
                 .doOnNext(new Action1<MultiSourcedDataHolder<InstanceInfo>>() {
                     @Override
                     public void call(MultiSourcedDataHolder<InstanceInfo> holder) {
                         for (Source source : holder.getAllSources()) {
-                            if (!source.equals(toRetain)) {
+                            if (!retainMatcher.match(source)) {
                                 holder.remove(source).subscribe(new NoOpSubscriber<MultiSourcedDataHolder.Status>());
                             }
                         }
@@ -286,13 +286,13 @@ public class SourcedEurekaRegistryImpl implements SourcedEurekaRegistry<Instance
                 .doOnError(new Action1<Throwable>() {
                     @Override
                     public void call(Throwable throwable) {
-                        logger.error("Error evicting registry while retaining source {}", toRetain, throwable);
+                        logger.error("Error evicting registry", throwable);
                     }
                 })
                 .doOnCompleted(new Action0() {
                     @Override
                     public void call() {
-                        logger.info("Completed evicting registry while retaining source {}", toRetain);
+                        logger.info("Completed evicting registry");
                     }
                 });
     }

--- a/eureka2-core/src/test/java/com/netflix/eureka2/registry/NotifyingInstanceInfoHolderDataStoreTest.java
+++ b/eureka2-core/src/test/java/com/netflix/eureka2/registry/NotifyingInstanceInfoHolderDataStoreTest.java
@@ -1,0 +1,182 @@
+package com.netflix.eureka2.registry;
+
+import com.netflix.eureka2.registry.instance.InstanceInfo;
+import com.netflix.eureka2.testkit.data.builder.SampleInstanceInfo;
+import org.junit.Before;
+import org.junit.Test;
+import com.netflix.eureka2.registry.NotifyingInstanceInfoHolder.DataStore;
+
+import java.util.Collection;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Have a dedicated test class for this inner class within NotifyingInstanceInfoHolder
+ * as it does some pretty critical (if straight forward) business logic.
+ *
+ * @author David Liu
+ */
+public class NotifyingInstanceInfoHolderDataStoreTest {
+
+    private final DataStore dataStore = new DataStore();
+
+    private final Source source1 = new Source(Source.Origin.REPLICATED, "replicationSourceId");
+    private final Source source2 = new Source(Source.Origin.LOCAL);
+
+    private final InstanceInfo info1 = SampleInstanceInfo.DiscoveryServer.build();
+    private final InstanceInfo info2 = SampleInstanceInfo.ZuulServer.build();
+
+    @Before
+    public void setUp() {
+        dataStore.put(source1, info1);
+        dataStore.put(source2, info2);
+
+        assertThat(dataStore.sourceMap.size(), is(2));
+        assertThat(dataStore.sourceMap.values(), containsInAnyOrder(source1, source2));
+
+        assertThat(dataStore.dataMap.size(), is(2));
+        assertThat(dataStore.dataMap.keySet(), containsInAnyOrder(source1, source2));
+        assertThat(dataStore.dataMap.values(), containsInAnyOrder(info1, info2));
+    }
+
+    @Test
+    public void testPut() {
+        // add for same source
+        InstanceInfo newInfo1 = SampleInstanceInfo.CliServer.build();
+        dataStore.put(source1, newInfo1);
+
+        verifySourceMapAndDataMapInSync();
+        assertThat(dataStore.dataMap.values(), containsInAnyOrder(newInfo1, info2));
+
+        // add a new source
+        Source source3 = new Source(Source.Origin.REPLICATED, "anotherReplicationSourceId");
+        InstanceInfo info3 = SampleInstanceInfo.EurekaReadServer.build();
+        dataStore.put(source3, info3);
+
+        verifySourceMapAndDataMapInSync();
+        assertThat(dataStore.sourceMap.values(), containsInAnyOrder(source1, source2, source3));
+        assertThat(dataStore.dataMap.values(), containsInAnyOrder(newInfo1, info2, info3));
+
+        // add for same source with different id
+        Source newSource2 = fromAnother(source2);
+        InstanceInfo newInfo2 = SampleInstanceInfo.EurekaWriteServer.build();
+        assertThat(source2, is(not(newSource2)));
+        dataStore.put(newSource2, newInfo2);
+
+        verifySourceMapAndDataMapInSync();
+        assertThat(dataStore.sourceMap.values(), containsInAnyOrder(source1, newSource2, source3));
+        assertThat(dataStore.dataMap.values(), containsInAnyOrder(newInfo1, newInfo2, info3));
+    }
+
+    @Test
+    public void testRemove() {
+        InstanceInfo removed;
+
+        // remove for non-existing source
+        Source source3 = new Source(Source.Origin.REPLICATED, "anotherReplicationSourceId");
+        removed = dataStore.remove(source3);
+        assertThat(removed, is(nullValue()));
+
+        // remove for existing sources with different id
+        Source newSource1 = fromAnother(source1);
+        removed = dataStore.remove(newSource1);
+        assertThat(removed, is(nullValue()));
+
+        Source newSource2 = fromAnother(source2);
+        removed = dataStore.remove(newSource2);
+        assertThat(removed, is(nullValue()));
+
+        verifySourceMapAndDataMapInSync();
+        assertThat(dataStore.sourceMap.size(), is(2));
+        assertThat(dataStore.dataMap.size(), is(2));
+
+        // remove for existing sources
+        removed = dataStore.remove(source1);
+        assertThat(removed, is(info1));
+
+        removed = dataStore.remove(source2);
+        assertThat(removed, is(info2));
+
+        verifySourceMapAndDataMapInSync();
+        assertThat(dataStore.sourceMap.size(), is(0));
+        assertThat(dataStore.dataMap.size(), is(0));
+    }
+
+    @Test
+    public void testGetMatching() {
+        InstanceInfo instanceInfo;
+        // get with non-existent source
+        Source source3 = new Source(Source.Origin.REPLICATED, "anotherReplicationSourceId");
+        instanceInfo = dataStore.getMatching(source3);
+        assertThat(instanceInfo, is(nullValue()));
+
+        // get with a source that matches an existing source's origin:name but have diff id
+        Source newSource1 = fromAnother(source1);
+        instanceInfo = dataStore.getMatching(newSource1);
+        assertThat(instanceInfo, is(info1));
+
+        Source newSource2 = fromAnother(source2);
+        instanceInfo = dataStore.getMatching(newSource2);
+        assertThat(instanceInfo, is(info2));
+
+        verifySourceMapAndDataMapInSync();
+        assertThat(dataStore.sourceMap.size(), is(2));
+        assertThat(dataStore.dataMap.size(), is(2));
+
+        // get with an existing source
+        instanceInfo = dataStore.getMatching(source1);
+        assertThat(instanceInfo, is(info1));
+
+        instanceInfo = dataStore.getMatching(source2);
+        assertThat(instanceInfo, is(info2));
+
+        verifySourceMapAndDataMapInSync();
+        assertThat(dataStore.sourceMap.size(), is(2));
+        assertThat(dataStore.dataMap.size(), is(2));
+    }
+
+    @Test
+    public void testGetExact() {
+        InstanceInfo instanceInfo;
+        // get with non-existent source
+        Source source3 = new Source(Source.Origin.REPLICATED, "anotherReplicationSourceId");
+        instanceInfo = dataStore.getExact(source3);
+        assertThat(instanceInfo, is(nullValue()));
+
+        // get with a source that matches an existing source's origin:name but have diff id
+        Source newSource1 = fromAnother(source1);
+        instanceInfo = dataStore.getExact(newSource1);
+        assertThat(instanceInfo, is(nullValue()));
+
+        Source newSource2 = fromAnother(source2);
+        instanceInfo = dataStore.getExact(newSource2);
+        assertThat(instanceInfo, is(nullValue()));
+
+        verifySourceMapAndDataMapInSync();
+        assertThat(dataStore.sourceMap.size(), is(2));
+        assertThat(dataStore.dataMap.size(), is(2));
+
+        // get with an existing source
+        instanceInfo = dataStore.getExact(source1);
+        assertThat(instanceInfo, is(info1));
+
+        instanceInfo = dataStore.getExact(source2);
+        assertThat(instanceInfo, is(info2));
+
+        verifySourceMapAndDataMapInSync();
+        assertThat(dataStore.sourceMap.size(), is(2));
+        assertThat(dataStore.dataMap.size(), is(2));
+    }
+
+    private void verifySourceMapAndDataMapInSync() {
+        Collection<Source> fromSourceMap = dataStore.sourceMap.values();
+        Collection<Source> fromDataMap = dataStore.dataMap.keySet();
+        assertThat(fromSourceMap, containsInAnyOrder(fromDataMap.toArray()));
+    }
+
+    // create a source from another with the same origin and name (but diff id as the id is created internally)
+    private Source fromAnother(Source source) {
+        return new Source(source.getOrigin(), source.getName());
+    }
+}

--- a/eureka2-core/src/test/java/com/netflix/eureka2/registry/PreservableEurekaRegistryTest.java
+++ b/eureka2-core/src/test/java/com/netflix/eureka2/registry/PreservableEurekaRegistryTest.java
@@ -186,7 +186,7 @@ public class PreservableEurekaRegistryTest {
         when(baseRegistry.forInterest(Interests.forFullRegistry())).thenReturn(notification1);
         assertSame(notification1, preservableRegistry.forInterest(Interests.forFullRegistry()));
 
-        Source.Matcher matcher = Source.matcherFor(remoteSource);
+        Source.SourceMatcher matcher = Source.matcherFor(remoteSource);
         Observable<ChangeNotification<InstanceInfo>> notification2 = Observable.just(new ChangeNotification<>(Kind.Add, DISCOVERY));
         when(baseRegistry.forInterest(Interests.forFullRegistry(), matcher)).thenReturn(notification2);
         assertSame(notification2, preservableRegistry.forInterest(Interests.forFullRegistry(), matcher));

--- a/eureka2-core/src/test/java/com/netflix/eureka2/registry/SourceTest.java
+++ b/eureka2-core/src/test/java/com/netflix/eureka2/registry/SourceTest.java
@@ -2,7 +2,6 @@ package com.netflix.eureka2.registry;
 
 import org.junit.Test;
 
-import com.netflix.eureka2.registry.Source.Matcher;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 
@@ -22,7 +21,7 @@ public class SourceTest {
 
     @Test
     public void testMatcherForSource() {
-        Matcher matcher = Source.matcherFor(originOnly1);
+        Source.SourceMatcher matcher = Source.matcherFor(originOnly1);
 
         assertTrue(matcher.match(originOnly1));
         assertFalse(matcher.match(originAndName1));
@@ -31,14 +30,14 @@ public class SourceTest {
         assertFalse(matcher.match(originAndName3));
         assertFalse(matcher.match(null));
 
-        Matcher nullMatcher = Source.matcherFor((Source)null);
+        Source.SourceMatcher nullMatcher = Source.matcherFor((Source)null);
         assertFalse(nullMatcher.match(originOnly1));  // just test a couple
         assertFalse(nullMatcher.match(originAndName1));
     }
 
     @Test
     public void testMatcherForOrigin() {
-        Matcher matcher = Source.matcherFor(originOnly1.getOrigin());
+        Source.SourceMatcher matcher = Source.matcherFor(originOnly1.getOrigin());
 
         assertTrue(matcher.match(originOnly1));
         assertTrue(matcher.match(originAndName1));
@@ -50,7 +49,7 @@ public class SourceTest {
 
     @Test
     public void testMatcherForOriginAndName() {
-        Matcher matcher = Source.matcherFor(originAndName1.getOrigin(), originAndName1.getName());
+        Source.SourceMatcher matcher = Source.matcherFor(originAndName1.getOrigin(), originAndName1.getName());
 
         assertFalse(matcher.match(originOnly1));
         assertTrue(matcher.match(originAndName1));

--- a/eureka2-core/src/test/java/com/netflix/eureka2/registry/SourceTest.java
+++ b/eureka2-core/src/test/java/com/netflix/eureka2/registry/SourceTest.java
@@ -1,0 +1,63 @@
+package com.netflix.eureka2.registry;
+
+import org.junit.Test;
+
+import com.netflix.eureka2.registry.Source.Matcher;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Mainly for testing the matchers
+ *
+ * @author David Liu
+ */
+public class SourceTest {
+
+    private final Source originOnly1 = new Source(Source.Origin.REPLICATED);
+    private final Source originOnly2 = new Source(Source.Origin.INTERESTED);
+
+    private final Source originAndName1 = new Source(Source.Origin.REPLICATED, "someId");
+    private final Source originAndName2 = new Source(Source.Origin.REPLICATED, "someOtherId");
+    private final Source originAndName3 = new Source(Source.Origin.INTERESTED, "someId");
+
+    @Test
+    public void testMatcherForSource() {
+        Matcher matcher = Source.matcherFor(originOnly1);
+
+        assertTrue(matcher.match(originOnly1));
+        assertFalse(matcher.match(originAndName1));
+        assertFalse(matcher.match(originAndName2));
+        assertFalse(matcher.match(originOnly2));
+        assertFalse(matcher.match(originAndName3));
+        assertFalse(matcher.match(null));
+
+        Matcher nullMatcher = Source.matcherFor((Source)null);
+        assertFalse(nullMatcher.match(originOnly1));  // just test a couple
+        assertFalse(nullMatcher.match(originAndName1));
+    }
+
+    @Test
+    public void testMatcherForOrigin() {
+        Matcher matcher = Source.matcherFor(originOnly1.getOrigin());
+
+        assertTrue(matcher.match(originOnly1));
+        assertTrue(matcher.match(originAndName1));
+        assertTrue(matcher.match(originAndName2));
+        assertFalse(matcher.match(originOnly2));
+        assertFalse(matcher.match(originAndName3));
+        assertFalse(matcher.match(null));
+    }
+
+    @Test
+    public void testMatcherForOriginAndName() {
+        Matcher matcher = Source.matcherFor(originAndName1.getOrigin(), originAndName1.getName());
+
+        assertFalse(matcher.match(originOnly1));
+        assertTrue(matcher.match(originAndName1));
+        assertFalse(matcher.match(originAndName2));
+        assertFalse(matcher.match(originOnly2));
+        assertFalse(matcher.match(originAndName3));
+        assertFalse(matcher.match(null));
+    }
+
+}

--- a/eureka2-read-server/src/main/java/com/netflix/eureka2/server/registry/EurekaReadServerRegistry.java
+++ b/eureka2-read-server/src/main/java/com/netflix/eureka2/server/registry/EurekaReadServerRegistry.java
@@ -104,7 +104,7 @@ public class EurekaReadServerRegistry implements SourcedEurekaRegistry<InstanceI
     }
 
     @Override
-    public Observable<Long> evictAllExcept(Source source) {
+    public Observable<Long> evictAllExcept(Source.Matcher retainMatcher) {
         throw new UnsupportedOperationException("evictAllExcept not supported by EurekaReadServerRegistry");
     }
 

--- a/eureka2-read-server/src/main/java/com/netflix/eureka2/server/registry/EurekaReadServerRegistry.java
+++ b/eureka2-read-server/src/main/java/com/netflix/eureka2/server/registry/EurekaReadServerRegistry.java
@@ -79,7 +79,7 @@ public class EurekaReadServerRegistry implements SourcedEurekaRegistry<InstanceI
     }
 
     @Override
-    public Observable<InstanceInfo> forSnapshot(Interest<InstanceInfo> interest, Source.Matcher sourceMatcher) {
+    public Observable<InstanceInfo> forSnapshot(Interest<InstanceInfo> interest, Source.SourceMatcher sourceMatcher) {
         throw new UnsupportedOperationException("method not supported by EurekaReadServerRegistry");
     }
 
@@ -99,12 +99,12 @@ public class EurekaReadServerRegistry implements SourcedEurekaRegistry<InstanceI
     }
 
     @Override
-    public Observable<ChangeNotification<InstanceInfo>> forInterest(Interest<InstanceInfo> interest, Source.Matcher sourceMatcher) {
+    public Observable<ChangeNotification<InstanceInfo>> forInterest(Interest<InstanceInfo> interest, Source.SourceMatcher sourceMatcher) {
         throw new UnsupportedOperationException("Origin filtering not supported by EurekaReadServerRegistry");
     }
 
     @Override
-    public Observable<Long> evictAllExcept(Source.Matcher retainMatcher) {
+    public Observable<Long> evictAllExcept(Source.SourceMatcher retainMatcher) {
         throw new UnsupportedOperationException("evictAllExcept not supported by EurekaReadServerRegistry");
     }
 


### PR DESCRIPTION
- updates for the same origin:name Sources replace each other regardless of source.id
- deletes only execute when origin:name:id equals for the sources