### PR TITLE
2.x Replication fix

### DIFF
--- a/eureka2-bridge/src/main/java/com/netflix/eureka2/server/channel/BridgeChannelImpl.java
+++ b/eureka2-bridge/src/main/java/com/netflix/eureka2/server/channel/BridgeChannelImpl.java
@@ -185,7 +185,6 @@ public class BridgeChannelImpl extends AbstractHandlerChannel<STATE> implements 
     @Override
     protected void _close() {
         discoveryClient.shutdown();
-        registry.shutdown();
         lifecycle.onCompleted();
     }
 }

--- a/eureka2-bridge/src/main/java/com/netflix/eureka2/server/service/BridgeService.java
+++ b/eureka2-bridge/src/main/java/com/netflix/eureka2/server/service/BridgeService.java
@@ -51,7 +51,7 @@ public class BridgeService {
     @SuppressWarnings("unchecked")
     @PostConstruct
     public void connect() {
-        selfIdentityService.resolve().subscribe(new Subscriber<InstanceInfo>() {
+        selfIdentityService.resolve().take(1).subscribe(new Subscriber<InstanceInfo>() {
             @Override
             public void onCompleted() {
             }

--- a/eureka2-client/src/test/java/com/netflix/eureka2/client/interest/EurekaInterestClientImplTest.java
+++ b/eureka2-client/src/test/java/com/netflix/eureka2/client/interest/EurekaInterestClientImplTest.java
@@ -537,9 +537,23 @@ public class EurekaInterestClientImplTest {
     }
 
     private TestInterestChannel newAlwaysFailChannel(Integer id) {
+        final Exception e = new Exception("test: operation error");
+
         final InterestChannel channel = createInterestChannel();
-        when(channel.change(any(Interest.class))).thenReturn(Observable.<Void>error(new Exception("test: operation error")));
-        when(channel.change(any(MultipleInterests.class))).thenReturn(Observable.<Void>error(new Exception("test: operation error")));
+        when(channel.change(any(Interest.class))).thenAnswer(new Answer<Observable<Void>>() {
+            @Override
+            public Observable<Void> answer(InvocationOnMock invocation) throws Throwable {
+                channel.close(e);  // link up with the channel lifecycle as we can't mock that
+                return Observable.error(e);
+            }
+        });
+        when(channel.change(any(MultipleInterests.class))).thenAnswer(new Answer<Observable<Void>>() {
+            @Override
+            public Observable<Void> answer(InvocationOnMock invocation) throws Throwable {
+                channel.close(e);  // link up with the channel lifecycle as we can't mock that
+                return Observable.error(e);
+            }
+        });
 
         return new TestInterestChannel(channel, id);
     }

--- a/eureka2-core/src/main/java/com/netflix/eureka2/connection/RetryableConnectionFactory.java
+++ b/eureka2-core/src/main/java/com/netflix/eureka2/connection/RetryableConnectionFactory.java
@@ -81,23 +81,25 @@ public class RetryableConnectionFactory<CHANNEL extends ServiceChannel> {
                     @Override
                     public Observable<Void> call(final CHANNEL channel, OP op) {
                         logger.debug("executing on channel {} op {}", channel.toString(), op.toString());
-                        Observable<Void> channelExecute = executeOnChannel.call(channel, op)
-                                .doOnCompleted(new Action0() {
-                                    @Override
-                                    public void call() {
-                                        if (initialConnect.compareAndSet(true, false)) {
-                                            initSubject.onCompleted();
-                                        }
-                                    }
-                                })
-                                .doOnError(new Action1<Throwable>() {
-                                    @Override
-                                    public void call(Throwable throwable) {
-                                        channel.close();
-                                    }
-                                });
+                        executeOnChannel.call(channel, op).subscribe(new Subscriber<Void>() {
+                            @Override
+                            public void onCompleted() {
+                                if (initialConnect.compareAndSet(true, false)) {
+                                    initSubject.onCompleted();
+                                }
+                            }
 
-                        return channel.asLifecycleObservable().mergeWith(channelExecute);
+                            @Override
+                            public void onError(Throwable e) {
+                                channel.close(e);
+                            }
+
+                            @Override
+                            public void onNext(Void aVoid) {
+                            }
+                        });
+
+                        return channel.asLifecycleObservable();
                     }
                 })
                 .flatMap(new Func1<Observable<Void>, Observable<Void>>() {  // flatmap from Ob<Ob<Void> to Ob<Void>

--- a/eureka2-write-server/src/main/java/com/netflix/eureka2/server/channel/ReceiverReplicationChannel.java
+++ b/eureka2-write-server/src/main/java/com/netflix/eureka2/server/channel/ReceiverReplicationChannel.java
@@ -77,9 +77,9 @@ public class ReceiverReplicationChannel extends AbstractHandlerChannel<STATE> im
 
             private void evict() {
                 if (!replicationLoop) {
-                    logger.info("Replication channel disconnected; putting all registrations from the channel in the eviction queue");
+                    logger.info("{}: Replication channel disconnected; putting all registrations from the channel in the eviction queue", replicationSource.getId());
                     for (InstanceInfo instanceInfo : instanceInfoById.values()) {
-                        logger.info("Replication channel disconnected; adding instance {} to the eviction queue", instanceInfo.getId());
+                        logger.info("{}: Replication channel disconnected; adding instance {} to the eviction queue", replicationSource.getId(), instanceInfo.getId());
                         evictionQueue.add(instanceInfo, replicationSource);
                     }
                 }
@@ -95,6 +95,7 @@ public class ReceiverReplicationChannel extends AbstractHandlerChannel<STATE> im
     protected void dispatchMessageFromClient(final Object message) {
         Observable<?> reply;
         if (message instanceof ReplicationHello) {
+            logger.info("Received Hello from {}", ((ReplicationHello) message).getSourceId());
             reply = hello((ReplicationHello) message);
         } else if (message instanceof RegisterCopy) {
             InstanceInfo instanceInfo = ((RegisterCopy) message).getInstanceInfo();

--- a/eureka2-write-server/src/main/java/com/netflix/eureka2/server/channel/ReceiverReplicationChannel.java
+++ b/eureka2-write-server/src/main/java/com/netflix/eureka2/server/channel/ReceiverReplicationChannel.java
@@ -77,9 +77,9 @@ public class ReceiverReplicationChannel extends AbstractHandlerChannel<STATE> im
 
             private void evict() {
                 if (!replicationLoop) {
-                    logger.info("{}: Replication channel disconnected; putting all registrations from the channel in the eviction queue", replicationSource.getId());
+                    logger.info("Replication channel disconnected; putting all registrations from the channel in the eviction queue");
                     for (InstanceInfo instanceInfo : instanceInfoById.values()) {
-                        logger.info("{}: Replication channel disconnected; adding instance {} to the eviction queue", replicationSource.getId(), instanceInfo.getId());
+                        logger.info("Replication channel disconnected; adding instance {} to the eviction queue", instanceInfo.getId());
                         evictionQueue.add(instanceInfo, replicationSource);
                     }
                 }


### PR DESCRIPTION
- handler should subscribe to lifecycle and operation with same subscriber for retries
- retryableChannelFactory merge internal channel op with lifecycle instead of independent subscribe