### PR TITLE
update dependency versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,11 +4,12 @@ plugins {
 
 ext {
     githubProjectName = 'eureka'
+    awsVersion='1.9.3'
     servletVersion='2.5'
     jerseyVersion='1.11'
-    governatorVersion='1.2.10'
-    archaiusVersion='0.6.0'
-    ribbonVersion='2.0-RC9'
+    governatorVersion='1.3.3'
+    archaiusVersion='0.6.5'
+    ribbonVersion='2.0.0'
     blitzVersion='1.34'
 }
 

--- a/eureka-client/build.gradle
+++ b/eureka-client/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     compile 'com.thoughtworks.xstream:xstream:1.4.2'
     compile "com.netflix.archaius:archaius-core:$archaiusVersion"
     compile 'javax.ws.rs:jsr311-api:1.1.1'
-    compile 'com.netflix.servo:servo-core:0.7.4'
+    compile 'com.netflix.servo:servo-core:0.8.3'
     compile "com.sun.jersey:jersey-core:$jerseyVersion"
     compile "com.sun.jersey:jersey-client:$jerseyVersion"
     compile 'com.sun.jersey.contribs:jersey-apache-client4:1.11'

--- a/eureka-core/build.gradle
+++ b/eureka-core/build.gradle
@@ -1,7 +1,9 @@
 dependencies {
     compile project(':eureka-client')
 
-    compile 'com.amazonaws:aws-java-sdk:1.3.27'
+    compile "com.amazonaws:aws-java-sdk-core:$awsVersion"
+    compile "com.amazonaws:aws-java-sdk-ec2:$awsVersion"
+    compile "com.amazonaws:aws-java-sdk-autoscaling:$awsVersion"
     compile "javax.servlet:servlet-api:$servletVersion"
     compile 'com.thoughtworks.xstream:xstream:1.4.2'
     compile 'javax.ws.rs:jsr311-api:1.1.1'
@@ -10,6 +12,6 @@ dependencies {
     testCompile 'junit:junit:4.10'
     testCompile 'org.mortbay.jetty:jetty:6.1H.22'
     testCompile 'org.mockito:mockito-all:1.8.5'
-    testRuntime 'org.slf4j:slf4j-simple:1.7.0'
+    testRuntime 'org.slf4j:slf4j-simple:1.7.10'
     testCompile project(':eureka-client')
 }


### PR DESCRIPTION
The primary one that matters to me is ribbon. The older
version is still pulling in 'com.netflix.rxjava:rxjava-core'
which conflicts with classes in 'io.reactivex:rxjava'.

This change also changes the aws dependency to only pull
in the parts that are actually used by eureka client.