### PR TITLE
2.x Use concatMap instead of flatMap for sending interest and replication messages

### DIFF
--- a/eureka2-client/src/main/java/com/netflix/eureka2/client/interest/AbstractInterestClient.java
+++ b/eureka2-client/src/main/java/com/netflix/eureka2/client/interest/AbstractInterestClient.java
@@ -26,7 +26,7 @@ public abstract class AbstractInterestClient implements EurekaInterestClient {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractInterestClient.class);
 
-    public static final int DEFAULT_RETRY_WAIT_MILLIS = 500;
+    public static final int DEFAULT_RETRY_WAIT_MILLIS = 1000;
 
     protected final SourcedEurekaRegistry<InstanceInfo> registry;
     protected final int retryWaitMillis;

--- a/eureka2-client/src/main/java/com/netflix/eureka2/client/registration/EurekaRegistrationClientImpl.java
+++ b/eureka2-client/src/main/java/com/netflix/eureka2/client/registration/EurekaRegistrationClientImpl.java
@@ -26,7 +26,7 @@ public class EurekaRegistrationClientImpl implements EurekaRegistrationClient {
 
     private static final Logger logger = LoggerFactory.getLogger(EurekaRegistrationClientImpl.class);
 
-    private static final int DEFAULT_RETRY_WAIT_MILLIS = 500;
+    private static final int DEFAULT_RETRY_WAIT_MILLIS = 1000;
 
     private final RetryableConnectionFactory<RegistrationChannel> retryableConnectionFactory;
     private final int retryWaitMillis;

--- a/eureka2-client/src/test/java/com/netflix/eureka2/client/resolver/OcelliServerResolverTest.java
+++ b/eureka2-client/src/test/java/com/netflix/eureka2/client/resolver/OcelliServerResolverTest.java
@@ -69,7 +69,6 @@ public class OcelliServerResolverTest extends AbstractResolverTest {
         final List<ChangeNotification<Server>> batchOne = Arrays.asList(
                 new ChangeNotification<>(ChangeNotification.Kind.Add, SERVER_A),
                 new ChangeNotification<>(ChangeNotification.Kind.Add, SERVER_B),
-                new ChangeNotification<>(ChangeNotification.Kind.Modify, SERVER_C),
                 ChangeNotification.<Server>bufferSentinel()
         );
 

--- a/eureka2-write-server/src/main/java/com/netflix/eureka2/server/service/replication/ReplicationHandlerImpl.java
+++ b/eureka2-write-server/src/main/java/com/netflix/eureka2/server/service/replication/ReplicationHandlerImpl.java
@@ -87,7 +87,7 @@ public class ReplicationHandlerImpl implements ReplicationHandler {
                                 return channel != null;
                             }
                         })
-                        .flatMap(new ReplicateFunc(registry));
+                        .concatMap(new ReplicateFunc(registry));
             }
         });
 
@@ -140,7 +140,7 @@ public class ReplicationHandlerImpl implements ReplicationHandler {
         @Override
         public Observable<Void> call(final ReplicationChannel channel) {
             return registry.forInterest(Interests.forFullRegistry(), Source.matcherFor(Source.Origin.LOCAL))
-                    .flatMap(new Func1<ChangeNotification<InstanceInfo>, Observable<Void>>() {
+                    .concatMap(new Func1<ChangeNotification<InstanceInfo>, Observable<Void>>() {
                         @Override
                         public Observable<Void> call(ChangeNotification<InstanceInfo> notification) {
                             switch (notification.getKind()) {


### PR DESCRIPTION
- use concatMap instead of flatMap for sending interest and replication messages
- update channel retries to default at 1s instead of 500ms