### PR TITLE
2.x DnsResolver query dns on-demand per resolve()

### DIFF
--- a/eureka2-client/src/main/java/com/netflix/eureka2/client/resolver/DnsResolverStep.java
+++ b/eureka2-client/src/main/java/com/netflix/eureka2/client/resolver/DnsResolverStep.java
@@ -45,13 +45,12 @@ public class DnsResolverStep implements HostResolverStep {
                     subscriber.onError(e);
                 }
             }
-        });
+        }).subscribeOn(dnsLoadScheduler);   // async subscribe on an io scheduler
     }
 
     @Override
     public ServerResolver withPort(final int port) {
-        final Observable<ChangeNotification<String>> dnsChangeNotificationSource = createDnsChangeNotificationSource()
-                .subscribeOn(dnsLoadScheduler);   // async subscribe on an io scheduler
+        final Observable<ChangeNotification<String>> dnsChangeNotificationSource = createDnsChangeNotificationSource();
 
         final Observable<ChangeNotification<Server>> serverSource = dnsChangeNotificationSource
                 .map(new Func1<ChangeNotification<String>, ChangeNotification<Server>>() {

--- a/eureka2-client/src/main/java/com/netflix/eureka2/client/resolver/DnsResolverStep.java
+++ b/eureka2-client/src/main/java/com/netflix/eureka2/client/resolver/DnsResolverStep.java
@@ -3,14 +3,12 @@ package com.netflix.eureka2.client.resolver;
 import com.netflix.eureka2.Server;
 import com.netflix.eureka2.interests.ChangeNotification;
 import com.netflix.eureka2.interests.ChangeNotification.Kind;
-import com.netflix.eureka2.interests.ChangeNotificationSource;
-import com.netflix.eureka2.interests.host.DnsChangeNotificationSource;
+import com.netflix.eureka2.interests.host.DnsResolver;
 import rx.Observable;
-import rx.Scheduler;
+import rx.Subscriber;
 import rx.functions.Func1;
-import rx.schedulers.Schedulers;
 
-import java.util.concurrent.TimeUnit;
+import java.util.Set;
 
 /**
  * @author David Liu
@@ -18,123 +16,64 @@ import java.util.concurrent.TimeUnit;
 public class DnsResolverStep implements HostResolverStep {
 
     private final String dnsName;
-    private final Configuration configuration;
 
     DnsResolverStep(String dnsName) {
-        this(dnsName, new Configuration());
-    }
-
-    DnsResolverStep(String dnsName, Configuration configuration) {
         this.dnsName = dnsName;
-        this.configuration = configuration;
     }
 
-    public DnsResolverStep configureReload(int reloadInterval, int idleTimeout, TimeUnit timeUnit) {
-        Configuration updatedConfig = configuration
-                .copy()
-                .withReloadInterval(reloadInterval)
-                .withIdleTimeout(idleTimeout)
-                .withTimeUnit(timeUnit);
-
-        return new DnsResolverStep(dnsName, updatedConfig);
-    }
-
-    public DnsResolverStep configureReloadScheduler(Scheduler scheduler) {
-        Configuration updatedConfig = configuration
-                .copy()
-                .withScheduler(scheduler);
-
-        return new DnsResolverStep(dnsName, updatedConfig);
-    }
-
-    /* visible for testing */ DnsResolverStep configureChangeNotificationSource(final ChangeNotificationSource<String> changeNotificationSource) {
-        return new DnsResolverStep(dnsName, configuration) {
+    /* visible for testing */ DnsResolverStep configureDnsNameSource(final Observable<ChangeNotification<String>> changeNotificationSource) {
+        return new DnsResolverStep(dnsName) {
             @Override
-            protected ChangeNotificationSource<String> createDnsChangeNotificationSource() {
+            protected Observable<ChangeNotification<String>> createDnsChangeNotificationSource() {
                 return changeNotificationSource;
             }
         };
     }
 
-
-    protected ChangeNotificationSource<String> createDnsChangeNotificationSource() {
-        return new DnsChangeNotificationSource(
-                dnsName,
-                configuration.reloadInterval,
-                configuration.idleTimeout,
-                configuration.timeUnit,
-                configuration.scheduler
-        );
+    protected Observable<ChangeNotification<String>> createDnsChangeNotificationSource() {
+        return Observable.create(new Observable.OnSubscribe<ChangeNotification<String>>() {
+            @Override
+            public void call(Subscriber<? super ChangeNotification<String>> subscriber) {
+                try {
+                    Set<ChangeNotification<String>> names = DnsResolver.resolveServerDN(dnsName);
+                    Observable.from(names).subscribe(subscriber);
+                } catch (Exception e) {
+                    subscriber.onError(e);
+                }
+            }
+        });
     }
 
     @Override
     public ServerResolver withPort(final int port) {
-        final ChangeNotificationSource<String> dnsChangeNotificationSource = createDnsChangeNotificationSource();
+        final Observable<ChangeNotification<String>> dnsChangeNotificationSource = createDnsChangeNotificationSource();
 
-        final Observable<ChangeNotification<Server>> serverSource =
-                dnsChangeNotificationSource.forInterest(null)
-                        .map(new Func1<ChangeNotification<String>, ChangeNotification<Server>>() {
-                            @Override
-                            public ChangeNotification<Server> call(ChangeNotification<String> notification) {
-                                switch (notification.getKind()) {
-                                    case BufferSentinel:
-                                        return ChangeNotification.bufferSentinel();  // type change
-                                    case Add:
-                                        return new ChangeNotification<>(Kind.Add, new Server(notification.getData(), port));
-                                    case Delete:
-                                        return new ChangeNotification<>(Kind.Delete, new Server(notification.getData(), port));
-                                    default:
-                                        // do nothing. This include Type.Modify, which is not supported for dns
-                                }
-                                return null;
-                            }
-                        })
-                        .filter(new Func1<ChangeNotification<Server>, Boolean>() {
-                            @Override
-                            public Boolean call(ChangeNotification<Server> notification) {
-                                return notification != null;
-                            }
-                        });
+        final Observable<ChangeNotification<Server>> serverSource = dnsChangeNotificationSource
+                .map(new Func1<ChangeNotification<String>, ChangeNotification<Server>>() {
+                    @Override
+                    public ChangeNotification<Server> call(ChangeNotification<String> notification) {
+                        switch (notification.getKind()) {
+                            case BufferSentinel:
+                                return ChangeNotification.bufferSentinel();  // type change
+                            case Add:
+                                return new ChangeNotification<>(Kind.Add, new Server(notification.getData(), port));
+                            case Delete:
+                                return new ChangeNotification<>(Kind.Delete, new Server(notification.getData(), port));
+                            default:
+                                // do nothing. This include Type.Modify, which is not supported for dns
+                        }
+                        return null;
+                    }
+                })
+                .filter(new Func1<ChangeNotification<Server>, Boolean>() {
+                    @Override
+                    public Boolean call(ChangeNotification<Server> notification) {
+                        return notification != null;
+                    }
+                });
 
         ServerResolver resolver = new OcelliServerResolver(serverSource);
 
         return resolver;
-    }
-
-
-    protected static class Configuration {
-        // mutable fields set to defaults
-        long reloadInterval = DnsChangeNotificationSource.DNS_LOOKUP_INTERVAL;
-        long idleTimeout = DnsChangeNotificationSource.IDLE_TIMEOUT;
-        TimeUnit timeUnit = TimeUnit.MILLISECONDS;
-        Scheduler scheduler = Schedulers.computation();
-
-        public Configuration copy() {
-            return new Configuration()
-                    .withReloadInterval(this.reloadInterval)
-                    .withIdleTimeout(this.idleTimeout)
-                    .withTimeUnit(this.timeUnit)
-                    .withScheduler(this.scheduler);
-        }
-
-        public Configuration withReloadInterval(long reloadInterval) {
-            this.reloadInterval = reloadInterval;
-            return this;
-        }
-
-        public Configuration withIdleTimeout(long idleTimeout) {
-            this.idleTimeout = idleTimeout;
-            return this;
-        }
-
-        public Configuration withTimeUnit(TimeUnit reloadUnit) {
-            this.timeUnit = reloadUnit;
-            return this;
-        }
-
-        public Configuration withScheduler(Scheduler scheduler) {
-            this.scheduler = scheduler;
-            return this;
-        }
     }
 }

--- a/eureka2-client/src/main/java/com/netflix/eureka2/client/resolver/OcelliServerResolver.java
+++ b/eureka2-client/src/main/java/com/netflix/eureka2/client/resolver/OcelliServerResolver.java
@@ -108,8 +108,7 @@ public class OcelliServerResolver implements ServerResolver {
                     @Override
                     public Observable<? extends LoadBalancer<Server>> call(Throwable throwable) {
                         if (!(throwable instanceof TimeoutException)) {
-                            logger.warn("Exception thrown when connecting serverSource to load balancer", throwable);
-
+                            logger.warn("Exception thrown when connecting serverSource to load balancer, using backup values", throwable);
                         }
                         return Observable.just(loadBalancer);
                     }

--- a/eureka2-client/src/test/java/com/netflix/eureka2/client/resolver/DnsServerResolverTest.java
+++ b/eureka2-client/src/test/java/com/netflix/eureka2/client/resolver/DnsServerResolverTest.java
@@ -1,60 +1,36 @@
 package com.netflix.eureka2.client.resolver;
 
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.netflix.eureka2.interests.ChangeNotification;
 import com.netflix.eureka2.interests.ChangeNotification.Kind;
-import com.netflix.eureka2.interests.ChangeNotificationSource;
 import com.netflix.eureka2.Server;
 import org.junit.Test;
 import rx.Observable;
+import rx.Subscriber;
 import rx.functions.Action0;
-import rx.schedulers.Schedulers;
 import rx.subjects.PublishSubject;
 
 import static com.netflix.eureka2.utils.ExtCollections.asSet;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * @author Tomasz Bak
  */
 public class DnsServerResolverTest extends AbstractResolverTest {
 
-    private final ChangeNotificationSource<String> dnsChangeNotificationSource = mock(ChangeNotificationSource.class);
-
-    @Test(timeout = 10000)
-    public void testBuilderWithoutDefaults() throws Exception {
-        ServerResolver resolver = ServerResolvers
-                .fromDnsName("my.domain")
-                .configureReload(1000, 2000, TimeUnit.MILLISECONDS)
-                .configureReloadScheduler(Schedulers.test())
-                .withPort(80);
-
-        assertThat(resolver, is(notNullValue()));
-    }
-
-    @Test(timeout = 10000)
-    public void testBuilderWithDefaults() throws Exception {
-        ServerResolver resolver = ServerResolvers
-                .fromDnsName("my.domain")
-                .withPort(80);
-
-        assertThat(resolver, is(notNullValue()));
-    }
-
     @Test(timeout = 10000)
     public void testReturnsDnsChangeUpdates() throws Exception {
         final PublishSubject<ChangeNotification<String>> dnsUpdatesSubject = PublishSubject.create();
 
-        when(dnsChangeNotificationSource.forInterest(null)).thenReturn(dnsUpdatesSubject);
-
         ServerResolver resolver = ServerResolvers
                 .fromDnsName("my.domain")
-                .configureChangeNotificationSource(dnsChangeNotificationSource)
+                .configureDnsNameSource(dnsUpdatesSubject)
                 .withPort(80);
 
         Server actual = takeNextWithEmits(resolver, new Action0() {
@@ -91,20 +67,55 @@ public class DnsServerResolverTest extends AbstractResolverTest {
                 new ChangeNotification<>(Kind.Add, "host1"),
                 new ChangeNotification<>(Kind.Delete, "host1"),
                 new ChangeNotification<>(Kind.Add, "host2"),
-                new ChangeNotification<>(Kind.Add, "host3"),
-                ChangeNotification.<String>bufferSentinel()
+                new ChangeNotification<>(Kind.Add, "host3")
         );
-
-        when(dnsChangeNotificationSource.forInterest(null)).thenReturn(dnsSource);
 
         ServerResolver resolver = ServerResolvers
                 .fromDnsName("my.domain")
-                .configureChangeNotificationSource(dnsChangeNotificationSource)
+                .configureDnsNameSource(dnsSource)
                 .withPort(80);
 
         Set<Server> expected = asSet(new Server("host2", 80), new Server("host3", 80));
         Set<Server> actual = asSet(takeNext(resolver), takeNext(resolver), takeNext(resolver));
 
         assertThat(actual, is(equalTo(expected)));
+    }
+
+    @Test(timeout = 60000)
+    public void testErrorLoadingDnsFallbackToCachedServerList() throws Exception {
+        final AtomicInteger emitErrorCount = new AtomicInteger(3);
+        final AtomicBoolean errorEmitted = new AtomicBoolean(false);
+        final Observable<ChangeNotification<String>> dnsUpdateSource = Observable.create(new Observable.OnSubscribe<ChangeNotification<String>>() {
+            @Override
+            public void call(Subscriber<? super ChangeNotification<String>> subscriber) {
+                if (emitErrorCount.getAndDecrement() > 0) {
+                    subscriber.onNext(new ChangeNotification<>(Kind.Add, "host1"));
+                    subscriber.onNext(new ChangeNotification<>(Kind.Add, "host2"));
+                    subscriber.onCompleted();
+                } else {
+                    errorEmitted.set(true);
+                    subscriber.onError(new Exception("fake unit test error"));
+                }
+            }
+        });
+
+        ServerResolver resolver = ServerResolvers
+                .fromDnsName("my.domain")
+                .configureDnsNameSource(dnsUpdateSource)
+                .withPort(80);
+
+        Collection<Server> resolvedServers = new HashSet<>();
+        resolvedServers.add(resolver.resolve().toBlocking().firstOrDefault(null));
+        resolvedServers.add(resolver.resolve().toBlocking().firstOrDefault(null));
+        resolvedServers.add(resolver.resolve().toBlocking().firstOrDefault(null));
+
+        assertThat(resolvedServers, containsInAnyOrder(new Server("host1", 80), new Server("host2", 80)));
+
+        Server server1 = resolver.resolve().toBlocking().firstOrDefault(null);
+        Server server2 = resolver.resolve().toBlocking().firstOrDefault(null);
+        assertThat(server1, isIn(resolvedServers));
+        assertThat(server2, isIn(resolvedServers));
+        assertThat(server1, is(not(equalTo(server2))));
+        assertThat(errorEmitted.get(), is(true));
     }
 }

--- a/eureka2-core/src/main/java/com/netflix/eureka2/interests/host/DnsResolver.java
+++ b/eureka2-core/src/main/java/com/netflix/eureka2/interests/host/DnsResolver.java
@@ -1,0 +1,93 @@
+package com.netflix.eureka2.interests.host;
+
+import com.netflix.eureka2.interests.ChangeNotification;
+
+import javax.naming.Context;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.InitialDirContext;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Hashtable;
+import java.util.Set;
+
+/**
+ * Unit tested indirectly via DnsChangeNotificationSourceTest
+ *
+ * @author David Liu
+ */
+public class DnsResolver {
+
+    public static Set<ChangeNotification<String>> resolveServerDN(String domainName) throws NamingException {
+        Hashtable<String, String> env = new Hashtable<>();
+        env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.dns.DnsContextFactory");
+        DirContext dirContext = new InitialDirContext(env);
+        try {
+            return resolveName(dirContext, domainName);
+        } finally {
+            dirContext.close();
+        }
+    }
+
+    /**
+     * For A records, resolve and return.
+     * For CNAME, just return;
+     * For TXT, assume it is a list of hostnames and/or ip addresses and return them.
+     */
+    private static Set<ChangeNotification<String>> resolveName(DirContext dirContext, String targetDN) throws NamingException {
+        Attributes attrs = dirContext.getAttributes(targetDN, new String[]{"A", "CNAME", "TXT"});
+        // handle A records
+        Set<ChangeNotification<String>> addresses = new HashSet<>();
+        addresses.addAll(toSetOfServerEntries(attrs, "A"));
+        if (!addresses.isEmpty()) {
+            return addresses;
+        }
+
+        // handle CNAME
+        addresses.addAll(toSetOfServerEntries(attrs, "CNAME"));
+        if (!addresses.isEmpty()) {
+            return addresses;
+        }
+
+        // handle TXT (assuming a list of hostnames as txt records)
+        addresses.addAll(toSetOfServerEntries(attrs, "TXT"));
+        if (!addresses.isEmpty()) {
+            return addresses;
+        }
+
+        return addresses;
+    }
+
+    // will never return null
+    private static Set<String> toSetOfString(Attributes attrs, String attrName) throws NamingException {
+        Attribute attr = attrs.get(attrName);
+        if (attr == null) {
+            return Collections.emptySet();
+        }
+        Set<String> resultSet = new HashSet<>();
+        NamingEnumeration<?> it = attr.getAll();
+        while (it.hasMore()) {
+            Object value = it.next();
+            resultSet.add(value.toString());
+        }
+        return resultSet;
+    }
+
+    // will never return null
+    private static Set<ChangeNotification<String>> toSetOfServerEntries(Attributes attrs, String attrName) throws NamingException {
+        Attribute attr = attrs.get(attrName);
+        if (attr == null) {
+            return Collections.emptySet();
+        }
+        Set<ChangeNotification<String>> resultSet = new HashSet<>();
+        NamingEnumeration<?> it = attr.getAll();
+        while (it.hasMore()) {
+            Object value = it.next();
+            resultSet.add(new ChangeNotification<>(ChangeNotification.Kind.Add, String.valueOf(value)));
+        }
+        return resultSet;
+    }
+}


### PR DESCRIPTION
DnsResolver query dns on-demand per resolve() call instead of maintaining a background task to constantly poll dns.