### PR TITLE
1.x Make TimedSupervisorTask thread pool configurable for remote region replication

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/DefaultEurekaServerConfig.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/DefaultEurekaServerConfig.java
@@ -519,6 +519,13 @@ public class DefaultEurekaServerConfig implements EurekaServerConfig {
     }
 
     @Override
+    public int getRemoteRegionFetchThreadPoolSize() {
+        return configInstance.getIntProperty(
+                namespace + "remoteRegion.fetchThreadPoolSize", 20)
+                .get();
+    }
+
+    @Override
     public String getRemoteRegionTrustStore() {
         return configInstance.getStringProperty(
                 namespace + "remoteRegion.trustStoreFileName", "").get();

--- a/eureka-core/src/main/java/com/netflix/eureka/EurekaServerConfig.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/EurekaServerConfig.java
@@ -482,6 +482,12 @@ public interface EurekaServerConfig {
     int getRemoteRegionRegistryFetchInterval();
 
     /**
+     * Size of a thread pool used to execute remote region registry fetch requests. Delegating these requests
+     * to internal threads is necessary workaround to https://bugs.openjdk.java.net/browse/JDK-8049846 bug.
+     */
+    int getRemoteRegionFetchThreadPoolSize();
+
+    /**
      * Gets the fully qualified trust store file that will be used for remote region registry fetches.
      * @return
      */

--- a/eureka-core/src/main/java/com/netflix/eureka/RemoteRegionRegistry.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/RemoteRegionRegistry.java
@@ -167,7 +167,7 @@ public class RemoteRegionRegistry implements LookupService<String> {
         };
 
         ThreadPoolExecutor remoteRegionFetchExecutor = new ThreadPoolExecutor(
-                1, 2, 0, TimeUnit.SECONDS, new SynchronousQueue<Runnable>());  // use direct handoff
+                1, EUREKA_SERVER_CONFIG.getRemoteRegionFetchThreadPoolSize(), 0, TimeUnit.SECONDS, new SynchronousQueue<Runnable>());  // use direct handoff
 
         scheduler = Executors.newScheduledThreadPool(1,
                 new ThreadFactoryBuilder()


### PR DESCRIPTION
Add thread pool level gauge for observing current thread usage level.