### PR TITLE
Add eureka2-eureka1-support module

### DIFF
--- a/eureka2-core/src/main/java/com/netflix/eureka2/registry/datacenter/AwsDataCenterInfoProvider.java
+++ b/eureka2-core/src/main/java/com/netflix/eureka2/registry/datacenter/AwsDataCenterInfoProvider.java
@@ -38,7 +38,7 @@ import java.util.regex.Pattern;
  */
 public class AwsDataCenterInfoProvider implements DataCenterInfoProvider {
 
-    private static final String AWS_API_VERSION = "latest";
+    private static final String AWS_API_VERSION = "latest/";
     private static final String AWS_METADATA_URI = "http://169.254.169.254/" + AWS_API_VERSION;
     private static final String INSTANCE_DATA = "meta-data/";
     private static final String DYNAMIC_DATA = "dynamic/";

--- a/eureka2-ext/eureka2-eureka1-rest-api/src/main/java/com/netflix/eureka2/eureka1/rest/query/Eureka2FullFetchWithDeltaView.java
+++ b/eureka2-ext/eureka2-eureka1-rest-api/src/main/java/com/netflix/eureka2/eureka1/rest/query/Eureka2FullFetchWithDeltaView.java
@@ -21,10 +21,10 @@ import rx.Subscription;
 import rx.functions.Func1;
 import rx.subjects.BehaviorSubject;
 
-import static com.netflix.eureka2.eureka1.rest.model.Eureka1ModelConverters.toEureka1xApplications;
-import static com.netflix.eureka2.eureka1.rest.model.Eureka1ModelConverters.toEureka1xInstanceInfo;
-import static com.netflix.eureka2.eureka1.rest.model.Eureka1ModelConverters.toEureka1xInstanceInfos;
-import static com.netflix.eureka2.eureka1.rest.model.Eureka1ModelConverters.v1InstanceIdentityComparator;
+import static com.netflix.eureka2.eureka1.utils.Eureka1ModelConverters.toEureka1xApplications;
+import static com.netflix.eureka2.eureka1.utils.Eureka1ModelConverters.toEureka1xInstanceInfo;
+import static com.netflix.eureka2.eureka1.utils.Eureka1ModelConverters.toEureka1xInstanceInfos;
+import static com.netflix.eureka2.eureka1.utils.Eureka1ModelConverters.v1InstanceIdentityComparator;
 import static com.netflix.eureka2.interests.ChangeNotifications.emitAndAggregateChanges;
 import static com.netflix.eureka2.interests.ChangeNotifications.collapseAndExtract;
 import static com.netflix.eureka2.interests.ChangeNotifications.instanceInfoIdentityComparator;

--- a/eureka2-ext/eureka2-eureka1-rest-api/src/main/java/com/netflix/eureka2/eureka1/rest/query/Eureka2RegistryViewCache.java
+++ b/eureka2-ext/eureka2-eureka1-rest-api/src/main/java/com/netflix/eureka2/eureka1/rest/query/Eureka2RegistryViewCache.java
@@ -18,7 +18,7 @@ import rx.Scheduler;
 import rx.functions.Func1;
 import rx.schedulers.Schedulers;
 
-import static com.netflix.eureka2.eureka1.rest.model.Eureka1ModelConverters.toEureka1xInstanceInfo;
+import static com.netflix.eureka2.eureka1.utils.Eureka1ModelConverters.toEureka1xInstanceInfo;
 
 /**
  * @author Tomasz Bak

--- a/eureka2-ext/eureka2-eureka1-rest-api/src/main/java/com/netflix/eureka2/eureka1/rest/registry/RegistrationHandler.java
+++ b/eureka2-ext/eureka2-eureka1-rest-api/src/main/java/com/netflix/eureka2/eureka1/rest/registry/RegistrationHandler.java
@@ -9,7 +9,7 @@ import rx.Subscriber;
 import rx.Subscription;
 import rx.subjects.PublishSubject;
 
-import static com.netflix.eureka2.eureka1.rest.model.Eureka1ModelConverters.toEureka2xInstanceInfo;
+import static com.netflix.eureka2.eureka1.utils.Eureka1ModelConverters.toEureka2xInstanceInfo;
 
 /**
  * @author Tomasz Bak

--- a/eureka2-ext/eureka2-eureka1-rest-api/src/test/java/com/netflix/eureka2/eureka1/rest/Eureka1QueryRequestHandlerTest.java
+++ b/eureka2-ext/eureka2-eureka1-rest-api/src/test/java/com/netflix/eureka2/eureka1/rest/Eureka1QueryRequestHandlerTest.java
@@ -27,7 +27,7 @@ import rx.functions.Func1;
 import rx.functions.Func2;
 
 import static com.netflix.eureka2.eureka1.rest.AbstractEureka1RequestHandler.ROOT_PATH;
-import static com.netflix.eureka2.eureka1.rest.model.Eureka1ModelConverters.toEureka1xInstanceInfo;
+import static com.netflix.eureka2.eureka1.utils.Eureka1ModelConverters.toEureka1xInstanceInfo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;

--- a/eureka2-ext/eureka2-eureka1-rest-api/src/test/java/com/netflix/eureka2/eureka1/rest/Eureka1RegistrationRequestHandlerTest.java
+++ b/eureka2-ext/eureka2-eureka1-rest-api/src/test/java/com/netflix/eureka2/eureka1/rest/Eureka1RegistrationRequestHandlerTest.java
@@ -28,7 +28,7 @@ import rx.Observable;
 import rx.functions.Func1;
 
 import static com.netflix.eureka2.eureka1.rest.AbstractEureka1RequestHandler.ROOT_PATH;
-import static com.netflix.eureka2.eureka1.rest.model.Eureka1ModelConverters.toEureka1xInstanceInfo;
+import static com.netflix.eureka2.eureka1.utils.Eureka1ModelConverters.toEureka1xInstanceInfo;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;

--- a/eureka2-ext/eureka2-eureka1-rest-api/src/test/java/com/netflix/eureka2/eureka1/rest/registry/Eureka1RegistryProxyImplTest.java
+++ b/eureka2-ext/eureka2-eureka1-rest-api/src/test/java/com/netflix/eureka2/eureka1/rest/registry/Eureka1RegistryProxyImplTest.java
@@ -14,7 +14,7 @@ import rx.Observable;
 import rx.schedulers.Schedulers;
 import rx.schedulers.TestScheduler;
 
-import static com.netflix.eureka2.eureka1.rest.model.Eureka1ModelConverters.*;
+import static com.netflix.eureka2.eureka1.utils.Eureka1ModelConverters.*;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;

--- a/eureka2-ext/eureka2-eureka1-support/build.gradle
+++ b/eureka2-ext/eureka2-eureka1-support/build.gradle
@@ -17,14 +17,14 @@
 apply plugin: 'osgi'
 
 dependencies {
-    compile project(':eureka2-external-server')
-    compile project(':eureka2-ext:eureka2-eureka1-support')
+    compile project(':eureka2-client')
+    compile "com.netflix.eureka:eureka-client:${eureka_v1_version}"
     testCompile project(':eureka2-test-utils')
 }
 
 jar {
     manifest {
-        name = 'eureka2-eureka1-rest-api'
+        name = 'eureka2-eureka1-utils'
         instruction 'Bundle-Vendor', 'Netflix'
         instruction 'Bundle-DocURL', 'https://github.com/Netflix/eureka'
         instruction 'Import-Package', '!org.junit,!junit.framework,!org.mockito.*,*'

--- a/eureka2-ext/eureka2-eureka1-support/src/main/java/com/netflix/eureka2/eureka1/utils/Eureka1ModelConverters.java
+++ b/eureka2-ext/eureka2-eureka1-support/src/main/java/com/netflix/eureka2/eureka1/utils/Eureka1ModelConverters.java
@@ -1,4 +1,4 @@
-package com.netflix.eureka2.eureka1.rest.model;
+package com.netflix.eureka2.eureka1.utils;
 
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/eureka2-ext/eureka2-eureka1-support/src/main/java/com/netflix/eureka2/eureka1/utils/ServerListReader.java
+++ b/eureka2-ext/eureka2-eureka1-support/src/main/java/com/netflix/eureka2/eureka1/utils/ServerListReader.java
@@ -1,0 +1,86 @@
+package com.netflix.eureka2.eureka1.utils;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.netflix.eureka2.client.EurekaInterestClient;
+import com.netflix.eureka2.client.Eurekas;
+import com.netflix.eureka2.client.functions.InterestFunctions;
+import com.netflix.eureka2.client.resolver.ServerResolver;
+import com.netflix.eureka2.interests.Interest;
+import com.netflix.eureka2.interests.Interests;
+import com.netflix.eureka2.registry.instance.InstanceInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import rx.Subscription;
+import rx.functions.Action1;
+
+import static com.netflix.eureka2.eureka1.utils.Eureka1ModelConverters.toEureka1xInstanceInfos;
+
+/**
+ * Helper class for integrating existing Eureka1 clients to Eureka2.
+ *
+ * @author Tomasz Bak
+ */
+public class ServerListReader {
+
+    private static final Logger logger = LoggerFactory.getLogger(ServerListReader.class);
+
+    public static final int FIRST_RESOLVE_TIMEOUT_SEC = 30;
+
+    private final EurekaInterestClient interestClient;
+    private final Subscription subscription;
+
+    private final AtomicReference<List<com.netflix.appinfo.InstanceInfo>> latestServerList =
+            new AtomicReference<List<com.netflix.appinfo.InstanceInfo>>(Collections.<com.netflix.appinfo.InstanceInfo>emptyList());
+
+    private final CountDownLatch firstBatchLatch = new CountDownLatch(1);
+
+    public ServerListReader(ServerResolver serverResolver, final String[] serviceVips, boolean isSecure) {
+        this.interestClient = Eurekas.newInterestClientBuilder().withServerResolver(serverResolver).build();
+        Interest<InstanceInfo> interest = isSecure ? Interests.forSecureVips(serviceVips) : Interests.forVips(serviceVips);
+        this.subscription = interestClient.forInterest(interest)
+                .compose(InterestFunctions.buffers())
+                .compose(InterestFunctions.snapshots())
+                .doOnNext(new Action1<LinkedHashSet<InstanceInfo>>() {
+                    @Override
+                    public void call(LinkedHashSet<InstanceInfo> instanceInfos) {
+                        // Legacy code has little tolerance if we start with empty server list
+                        if(!instanceInfos.isEmpty()) {
+                            latestServerList.set(toEureka1xInstanceInfos(instanceInfos));
+                            firstBatchLatch.countDown();
+                        }
+                    }
+                })
+                .doOnError(new Action1<Throwable>() {
+                    @Override
+                    public void call(Throwable e) {
+                        logger.error("Cannot resolve servers for vip addresses " + Arrays.toString(serviceVips), e);
+                    }
+                })
+                .subscribe();
+    }
+
+    public List<com.netflix.appinfo.InstanceInfo> getLatestServerList() {
+        return latestServerList.get();
+    }
+
+    public List<com.netflix.appinfo.InstanceInfo> getLatestServerListOrWait() {
+        try {
+            firstBatchLatch.await(FIRST_RESOLVE_TIMEOUT_SEC, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            // IGNORE
+        }
+        return latestServerList.get();
+    }
+
+    public void shutdown() {
+        subscription.unsubscribe();
+        interestClient.shutdown();
+    }
+}

--- a/eureka2-ext/eureka2-eureka1-support/src/test/java/com/netflix/eureka2/eureka1/utils/Eureka1ModelConvertersTest.java
+++ b/eureka2-ext/eureka2-eureka1-support/src/test/java/com/netflix/eureka2/eureka1/utils/Eureka1ModelConvertersTest.java
@@ -1,4 +1,4 @@
-package com.netflix.eureka2.eureka1.rest.model;
+package com.netflix.eureka2.eureka1.utils;
 
 import java.util.List;
 import java.util.Set;
@@ -20,12 +20,12 @@ import org.junit.Before;
 import org.junit.Test;
 import rx.subjects.ReplaySubject;
 
-import static com.netflix.eureka2.eureka1.rest.model.Eureka1ModelConverters.toEureka1xApplicationsFromV2Collection;
-import static com.netflix.eureka2.eureka1.rest.model.Eureka1ModelConverters.toEureka1xDataCenterInfo;
-import static com.netflix.eureka2.eureka1.rest.model.Eureka1ModelConverters.toEureka1xInstanceInfo;
-import static com.netflix.eureka2.eureka1.rest.model.Eureka1ModelConverters.toEureka1xStatus;
-import static com.netflix.eureka2.eureka1.rest.model.Eureka1ModelConverters.toEureka2xDataCenterInfo;
-import static com.netflix.eureka2.eureka1.rest.model.Eureka1ModelConverters.toEureka2xInstanceInfo;
+import static com.netflix.eureka2.eureka1.utils.Eureka1ModelConverters.toEureka1xApplicationsFromV2Collection;
+import static com.netflix.eureka2.eureka1.utils.Eureka1ModelConverters.toEureka1xDataCenterInfo;
+import static com.netflix.eureka2.eureka1.utils.Eureka1ModelConverters.toEureka1xInstanceInfo;
+import static com.netflix.eureka2.eureka1.utils.Eureka1ModelConverters.toEureka1xStatus;
+import static com.netflix.eureka2.eureka1.utils.Eureka1ModelConverters.toEureka2xDataCenterInfo;
+import static com.netflix.eureka2.eureka1.utils.Eureka1ModelConverters.toEureka2xInstanceInfo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.hamcrest.Matchers.is;

--- a/eureka2-ext/eureka2-karyon-admin/src/main/java/netflix/adminresources/resources/Eureka2RegistryItemTypeAdapter.java
+++ b/eureka2-ext/eureka2-karyon-admin/src/main/java/netflix/adminresources/resources/Eureka2RegistryItemTypeAdapter.java
@@ -13,8 +13,10 @@ public class Eureka2RegistryItemTypeAdapter implements JsonSerializer<InstanceIn
         if (AwsDataCenterInfo.class.isAssignableFrom(instanceInfo.getDataCenterInfo().getClass())) {
             final AwsDataCenterInfo dataCenterInfo = (AwsDataCenterInfo) instanceInfo.getDataCenterInfo();
             result.addProperty("instId", dataCenterInfo.getInstanceId());
-            result.addProperty("ip", dataCenterInfo.getPublicAddress().getIpAddress());
-            result.addProperty("hostname", dataCenterInfo.getPublicAddress().getHostName());
+            if(dataCenterInfo.getPublicAddress() != null) {
+                result.addProperty("ip", dataCenterInfo.getPublicAddress().getIpAddress());
+                result.addProperty("hostname", dataCenterInfo.getPublicAddress().getHostName());
+            }
             result.addProperty("zone", dataCenterInfo.getZone());
             result.addProperty("reg", dataCenterInfo.getRegion());
         }

--- a/eureka2-testkit/src/main/java/com/netflix/eureka2/testkit/cli/EurekaCLI.java
+++ b/eureka2-testkit/src/main/java/com/netflix/eureka2/testkit/cli/EurekaCLI.java
@@ -73,7 +73,9 @@ public class EurekaCLI {
             new UnregisterCommand(),
             new CloseCommand(),
             InterestCommand.forFullRegistry(),
+            InterestCommand.forApps(),
             InterestCommand.forVips(),
+            InterestCommand.forSecureVips(),
             new StatusCommand()
     };
 

--- a/eureka2-testkit/src/main/java/com/netflix/eureka2/testkit/cli/Session.java
+++ b/eureka2-testkit/src/main/java/com/netflix/eureka2/testkit/cli/Session.java
@@ -128,7 +128,7 @@ public class Session {
         interestClient = Eurekas.newInterestClientBuilder()
                 .withTransportConfig(context.getTransportConfig())
                 .withServerResolver(ServerResolvers.fromEureka(
-                                ServerResolvers.fromHostname(host).withPort(interestPort))
+                                ServerResolvers.fromDnsName(host).withPort(interestPort))
                                 .forInterest(Interests.forVips(readClusterVip))
                 )
                 .build();

--- a/eureka2-testkit/src/main/java/com/netflix/eureka2/testkit/cli/command/InterestCommand.java
+++ b/eureka2-testkit/src/main/java/com/netflix/eureka2/testkit/cli/command/InterestCommand.java
@@ -61,7 +61,7 @@ public abstract class InterestCommand extends Command {
     }
 
     public static Command forVips() {
-        return new InterestCommand("interest", -1) {
+        return new InterestCommand("interestVip", -1) {
 
             @Override
             public String getInvocationSyntax() {
@@ -70,12 +70,52 @@ public abstract class InterestCommand extends Command {
 
             @Override
             public String getDescription() {
-                return "start interest subscription for given vips";
+                return "start interest subscription for given vip(s)";
             }
 
             @Override
             protected void subscribeToInterest(Session activeSession, String[] args) {
                 activeSession.forInterest(Interests.forVips(Operator.Like, args));
+            }
+        };
+    }
+
+    public static Command forSecureVips() {
+        return new InterestCommand("interestSecureVip", -1) {
+
+            @Override
+            public String getInvocationSyntax() {
+                return getName() + " <vipName> <vipName> ...";
+            }
+
+            @Override
+            public String getDescription() {
+                return "start interest subscription for given vip(s)";
+            }
+
+            @Override
+            protected void subscribeToInterest(Session activeSession, String[] args) {
+                activeSession.forInterest(Interests.forSecureVips(Operator.Like, args));
+            }
+        };
+    }
+
+    public static Command forApps() {
+        return new InterestCommand("interestApp", -1) {
+
+            @Override
+            public String getInvocationSyntax() {
+                return getName() + " <appName> <appName> ...";
+            }
+
+            @Override
+            public String getDescription() {
+                return "start interest subscription for given application(s)";
+            }
+
+            @Override
+            protected void subscribeToInterest(Session activeSession, String[] args) {
+                activeSession.forInterest(Interests.forApplications(Operator.Like, args));
             }
         };
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,7 @@
 org.gradle.daemon=true
 
+org.gradle.jvmargs=-XX:MaxPermSize=512m
+
 slf4j_version=1.7.7
 javax_inject_version=1
 commons_cli_version=1.2

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,6 +13,7 @@ include 'eureka2-client',\
         'eureka2-ext:eureka2-kafka',\
         'eureka2-ext:eureka2-karyon-admin',\
         'eureka2-ext:eureka2-karyon-admin-status',\
+        'eureka2-ext:eureka2-eureka1-support',\
         'eureka2-ext:eureka2-eureka1-rest-api',\
         'eureka2-testkit',\
         'eureka2-examples'


### PR DESCRIPTION
Add eureka2-eureka1-support module to help bridge existing
Eureka1 clients to Eureka2 without adopting Eureka2 client API yet.