### PR TITLE
singleton scoping EurekaConfigBasedInstanceInfoProvider

### DIFF
--- a/eureka-client/src/main/java/com/netflix/appinfo/providers/EurekaConfigBasedInstanceInfoProvider.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/providers/EurekaConfigBasedInstanceInfoProvider.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import com.netflix.governator.guice.lazy.LazySingleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,6 +22,7 @@ import com.netflix.appinfo.InstanceInfo.PortType;
  * @author elandau
  *
  */
+@LazySingleton
 public class EurekaConfigBasedInstanceInfoProvider implements Provider<InstanceInfo> {
     private static final Logger LOG = LoggerFactory.getLogger(EurekaConfigBasedInstanceInfoProvider.class);
 

--- a/eureka-client/src/main/java/com/netflix/appinfo/providers/EurekaConfigBasedInstanceInfoProvider.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/providers/EurekaConfigBasedInstanceInfoProvider.java
@@ -19,6 +19,9 @@ import com.netflix.appinfo.InstanceInfo.PortType;
  * InstanceInfo provider that constructs the InstanceInfo this this instance using
  * EurekaInstanceConfig.
  *
+ * This provider is @Singleton scope as it provides the InstanceInfo for both DiscoveryClient
+ * and ApplicationInfoManager, and need to provide the same InstanceInfo to both.
+ *
  * @author elandau
  *
  */

--- a/eureka-client/src/test/java/com/netflix/discovery/converters/InstanceInfoGenerator.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/converters/InstanceInfoGenerator.java
@@ -64,7 +64,7 @@ public class InstanceInfoGenerator {
     }
 
     public Applications toApplications() {
-        Map<String, Application> appsByName = new HashMap<>();
+        Map<String, Application> appsByName = new HashMap<String, Application>();
         Iterator<InstanceInfo> it = serviceIterator();
         while (it.hasNext()) {
             InstanceInfo instanceInfo = it.next();


### PR DESCRIPTION
bug fix: Re-adding @LazySingleton to EurekaInstanceInfoProvider to ensure InstanceInfo singleton for injection into DiscoveryClient and ApplicationInfoManager.