### PR TITLE
Destroying jersey cleaner thread on DiscoveryClient shutdown

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
@@ -729,6 +729,9 @@ public class DiscoveryClient implements EurekaClient {
     public void shutdown() {
         cancelScheduledTasks();
 
+        if (discoveryJerseyClient != null) {
+            discoveryJerseyClient.destroyResources();
+        }
         // If APPINFO was registered
         if (instanceInfo != null && shouldRegister(instanceInfo)) {
             instanceInfo.setStatus(InstanceStatus.DOWN);

--- a/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientCloseJerseyThreadTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientCloseJerseyThreadTest.java
@@ -1,0 +1,32 @@
+package com.netflix.discovery;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.util.Set;
+
+import org.junit.Test;
+
+public class DiscoveryClientCloseJerseyThreadTest extends AbstractDiscoveryClientTester {
+
+    private static final String THREAD_NAME = "Eureka-JerseyClient-Conn-Cleaner";
+
+    @Test
+    public void testThreadCount() throws InterruptedException {
+        assertThat(containsJerseyThread(), equalTo(true));
+        client.shutdown();
+        // Give up control for cleaner thread to die
+        Thread.sleep(1);
+        assertThat(containsJerseyThread(), equalTo(false));
+    }
+
+    private boolean containsJerseyThread() {
+        Set<Thread> threads = Thread.getAllStackTraces().keySet();
+        for (Thread t : threads) {
+            if (t.getName().contains(THREAD_NAME)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
When reloading or shutting down the context in Tomcat 8 we get a warning that there was a thread created but not cleaned up:
```
WARNING: The web application [example] appears to have started a thread named [Eureka-JerseyClient-Conn-Cleaner2] but has failed to stop it. This is very likely to create a memory leak. Stack trace of thread:
 sun.misc.Unsafe.park(Native Method)
 java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:215)
 java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(AbstractQueuedSynchronizer.java:2078)
 java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ScheduledThreadPoolExecutor.java:1093)
 java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ScheduledThreadPoolExecutor.java:809)
 java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1067)
 java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1127)
 java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
 java.lang.Thread.run(Thread.java:745)
```

Evidence for this being a problem can be found in the Spring Cloud project:
[EurekaDiscoveryClientConfiguration.java](https://github.com/spring-cloud/spring-cloud-netflix/blob/master/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/eureka/EurekaDiscoveryClientConfiguration.java)

My suggested solution is to check for a discoveryJerseyClient object, and clean it up during the DiscoveryClient shutdown method.

I have provided a test that demonstrates the thread living beyond the shutdown command in it's current state.