### PR TITLE
Add event control for initial instance info heartbeat and instanceinfo update (UP status typically)

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/DefaultEurekaClientConfig.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DefaultEurekaClientConfig.java
@@ -487,4 +487,9 @@ public class DefaultEurekaClientConfig implements EurekaClientConfig {
         return configInstance.getStringProperty(
                 namespace + "escapeCharReplacement", "__").get();
     }
+
+    @Override
+    public boolean getUsesExplicitEventsForInitialDiscoveryCalls() {
+        return configInstance.getBooleanProperty(namespace + "client.useExplicitEventsForInitialDiscoveryCalls", false).get();
+    }
 }

--- a/eureka-client/src/main/java/com/netflix/discovery/DefaultEurekaClientConfig.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DefaultEurekaClientConfig.java
@@ -489,7 +489,7 @@ public class DefaultEurekaClientConfig implements EurekaClientConfig {
     }
 
     @Override
-    public boolean getUsesExplicitEventsForInitialDiscoveryCalls() {
-        return configInstance.getBooleanProperty(namespace + "client.useExplicitEventsForInitialDiscoveryCalls", false).get();
+    public boolean getUseExplicitEventsForInitialDiscoveryCalls() {
+        return configInstance.getBooleanProperty(namespace + "appinfo.useExplicitEventsForInitialDiscoveryCalls", false).get();
     }
 }

--- a/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
@@ -324,7 +324,14 @@ public class DiscoveryClient implements EurekaClient {
         if (clientConfig.shouldFetchRegistry() && !fetchRegistry(false)) {
             fetchRegistryFromBackup();
         }
-        initScheduledTasks();
+
+        initRegistryFetchPoller();
+        boolean eventsForInstanceInfoUpdaters = clientConfig.getUsesExplicitEventsForInitialDiscoveryCalls();
+        if (!eventsForInstanceInfoUpdaters) {
+            initInstanceHeartBeatUpdater(eventsForInstanceInfoUpdaters);
+            initInstanceInfoRefreshUpdater(eventsForInstanceInfoUpdaters);
+        }
+
         try {
             Monitors.registerObject(this);
         } catch (Throwable e) {
@@ -594,17 +601,11 @@ public class DiscoveryClient implements EurekaClient {
     /**
      * Checks to see if the eureka client registration is enabled.
      *
-     * @param myInfo
-     *            - The instance info object
      * @return - true, if the instance should be registered with eureka, false
      *         otherwise
      */
-    private boolean shouldRegister(InstanceInfo myInfo) {
-        if (!clientConfig.shouldRegisterWithEureka()) {
-            return false;
-        }
-
-        return true;
+    private boolean shouldRegister() {
+        return clientConfig.shouldRegisterWithEureka();
     }
 
     /**
@@ -730,7 +731,7 @@ public class DiscoveryClient implements EurekaClient {
         cancelScheduledTasks();
 
         // If APPINFO was registered
-        if (instanceInfo != null && shouldRegister(instanceInfo)) {
+        if (instanceInfo != null && shouldRegister()) {
             instanceInfo.setStatus(InstanceStatus.DOWN);
             unregister();
         }
@@ -1337,10 +1338,64 @@ public class DiscoveryClient implements EurekaClient {
         }
     }
 
+    private void initRegistryFetchPoller() {
+        if (clientConfig.shouldFetchRegistry()) {
+            // registry cache refresh timer
+            int registryFetchIntervalSeconds = clientConfig.getRegistryFetchIntervalSeconds();
+            int expBackOffBound = clientConfig.getCacheRefreshExecutorExponentialBackOffBound();
+            scheduler.schedule(
+                    new TimedSupervisorTask(
+                            "cacheRefresh",
+                            scheduler,
+                            cacheRefreshExecutor,
+                            registryFetchIntervalSeconds,
+                            TimeUnit.SECONDS,
+                            expBackOffBound,
+                            new CacheRefreshThread()
+                    ),
+                    registryFetchIntervalSeconds, TimeUnit.SECONDS);
+        }
+    }
+
+    private void initInstanceHeartBeatUpdater(boolean startNow) {
+        int renewalIntervalInSecs = instanceInfo.getLeaseInfo().getRenewalIntervalInSecs();
+        long startDelay = startNow ? 0 : renewalIntervalInSecs;
+        int expBackOffBound = clientConfig.getHeartbeatExecutorExponentialBackOffBound();
+        logger.info("Starting heartbeat executor: " + "renew interval is: " + renewalIntervalInSecs);
+
+        // Heartbeat timer
+        scheduler.schedule(
+                new TimedSupervisorTask(
+                        "heartbeat",
+                        scheduler,
+                        heartbeatExecutor,
+                        renewalIntervalInSecs,
+                        TimeUnit.SECONDS,
+                        expBackOffBound,
+                        new HeartbeatThread()
+                ),
+                startDelay, TimeUnit.SECONDS);
+    }
+
+    private void initInstanceInfoRefreshUpdater(boolean startNow) {
+        long startDelay = startNow ? 0 :  clientConfig.getInitialInstanceInfoReplicationIntervalSeconds();
+
+        // InstanceInfo replication timer
+        instanceInfoReplicator = new InstanceInfoReplicator();
+        scheduler.scheduleWithFixedDelay(instanceInfoReplicator,
+                startDelay,
+                clientConfig.getInstanceInfoReplicationIntervalSeconds(), TimeUnit.SECONDS);
+
+    }
+
     /**
      * Initializes all scheduled tasks.
      */
-    private void initScheduledTasks() {
+    private void initScheduledTasks(boolean usesEventForStartingInstanceInfoUpdates, boolean eventForStartingInstanceFired) {
+        if (!usesEventForStartingInstanceInfoUpdates && eventForStartingInstanceFired) {
+            throw new UnsupportedOperationException("invalid argument combination");
+        }
+
         if (clientConfig.shouldFetchRegistry()) {
             // registry cache refresh timer
             int registryFetchIntervalSeconds = clientConfig.getRegistryFetchIntervalSeconds();
@@ -1358,7 +1413,12 @@ public class DiscoveryClient implements EurekaClient {
                     registryFetchIntervalSeconds, TimeUnit.SECONDS);
         }
 
-        if (shouldRegister(instanceInfo)) {
+        if (!shouldRegister()) {
+            logger.info("Not registering with Eureka server per configuration");
+            return;
+        }
+
+        if (!usesEventForStartingInstanceInfoUpdates) {
             int renewalIntervalInSecs = instanceInfo.getLeaseInfo().getRenewalIntervalInSecs();
             int expBackOffBound = clientConfig.getHeartbeatExecutorExponentialBackOffBound();
             logger.info("Starting heartbeat executor: " + "renew interval is: " + renewalIntervalInSecs);
@@ -1382,8 +1442,30 @@ public class DiscoveryClient implements EurekaClient {
                     clientConfig.getInitialInstanceInfoReplicationIntervalSeconds(),
                     clientConfig.getInstanceInfoReplicationIntervalSeconds(), TimeUnit.SECONDS);
 
-        } else {
-            logger.info("Not registering with Eureka server per configuration");
+        }
+        else {
+            int renewalIntervalInSecs = instanceInfo.getLeaseInfo().getRenewalIntervalInSecs();
+            int expBackOffBound = clientConfig.getHeartbeatExecutorExponentialBackOffBound();
+            logger.info("Starting heartbeat executor: " + "renew interval is: " + renewalIntervalInSecs);
+
+            // Heartbeat timer
+            scheduler.schedule(
+                    new TimedSupervisorTask(
+                            "heartbeat",
+                            scheduler,
+                            heartbeatExecutor,
+                            renewalIntervalInSecs,
+                            TimeUnit.SECONDS,
+                            expBackOffBound,
+                            new HeartbeatThread()
+                    ),
+                    eventForStartingInstanceFired ? 0 : renewalIntervalInSecs, TimeUnit.SECONDS);
+
+            // InstanceInfo replication timer
+            instanceInfoReplicator = new InstanceInfoReplicator();
+            scheduler.scheduleWithFixedDelay(instanceInfoReplicator,
+                    eventForStartingInstanceFired ? 0 : clientConfig.getInitialInstanceInfoReplicationIntervalSeconds(),
+                    clientConfig.getInstanceInfoReplicationIntervalSeconds(), TimeUnit.SECONDS);
         }
     }
 
@@ -1790,6 +1872,24 @@ public class DiscoveryClient implements EurekaClient {
         }
 
         return healthCheckHandler;
+    }
+
+    @Override
+    public void registerInDiscovery() {
+        boolean eventsForInstanceInfoUpdaters = clientConfig.getUsesExplicitEventsForInitialDiscoveryCalls();
+        if (eventsForInstanceInfoUpdaters) {
+            initInstanceHeartBeatUpdater(true);
+        }
+        // else expected that DiscoveryClient initialization already initialized heartbeat
+    }
+
+    @Override
+    public void markAsUpInDiscovery() {
+        boolean eventsForInstanceInfoUpdaters = clientConfig.getUsesExplicitEventsForInitialDiscoveryCalls();
+        if (eventsForInstanceInfoUpdaters) {
+            initInstanceInfoRefreshUpdater(true);
+        }
+        // else expected that DiscoveryClient initialization already initialized instanceinforefresher
     }
 
     /**

--- a/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
@@ -326,10 +326,14 @@ public class DiscoveryClient implements EurekaClient {
         }
 
         initRegistryFetchPoller();
-        boolean eventsForInstanceInfoUpdaters = clientConfig.getUsesExplicitEventsForInitialDiscoveryCalls();
+        boolean eventsForInstanceInfoUpdaters = clientConfig.getUseExplicitEventsForInitialDiscoveryCalls();
         if (!eventsForInstanceInfoUpdaters) {
-            initInstanceHeartBeatUpdater(eventsForInstanceInfoUpdaters);
-            initInstanceInfoRefreshUpdater(eventsForInstanceInfoUpdaters);
+            if (shouldRegister()) {
+                initInstanceHeartBeatUpdater(eventsForInstanceInfoUpdaters);
+                initInstanceInfoRefreshUpdater(eventsForInstanceInfoUpdaters);
+            } else {
+                logger.info("Not registering with Eureka server per configuration");
+            }
         }
 
         try {
@@ -1875,18 +1879,18 @@ public class DiscoveryClient implements EurekaClient {
     }
 
     @Override
-    public void registerInDiscovery() {
-        boolean eventsForInstanceInfoUpdaters = clientConfig.getUsesExplicitEventsForInitialDiscoveryCalls();
-        if (eventsForInstanceInfoUpdaters) {
+    public void startInstanceInfoHeartBeatNow() {
+        boolean eventsForInstanceInfoUpdaters = clientConfig.getUseExplicitEventsForInitialDiscoveryCalls();
+        if (shouldRegister() && eventsForInstanceInfoUpdaters) {
             initInstanceHeartBeatUpdater(true);
         }
         // else expected that DiscoveryClient initialization already initialized heartbeat
     }
 
     @Override
-    public void markAsUpInDiscovery() {
-        boolean eventsForInstanceInfoUpdaters = clientConfig.getUsesExplicitEventsForInitialDiscoveryCalls();
-        if (eventsForInstanceInfoUpdaters) {
+    public void startInstanceInfoRefreshNow() {
+        boolean eventsForInstanceInfoUpdaters = clientConfig.getUseExplicitEventsForInitialDiscoveryCalls();
+        if (shouldRegister() && eventsForInstanceInfoUpdaters) {
             initInstanceInfoRefreshUpdater(true);
         }
         // else expected that DiscoveryClient initialization already initialized instanceinforefresher

--- a/eureka-client/src/main/java/com/netflix/discovery/EurekaClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/EurekaClient.java
@@ -158,14 +158,14 @@ public interface EurekaClient extends LookupService {
     public HealthCheckHandler getHealthCheckHandler();
 
     /**
-     * Event to indicate current instance should register in discovery immediately
+     * Start the instance info heart beat executions
      */
-    public void registerInDiscovery();
+    public void startInstanceInfoHeartBeatNow();
 
     /**
-     * Event to indicate current instance should be marked as up in discovery immediately
+     * Start the instance info refresh executions, likely with instanceInfo went to UP status
      */
-    public void markAsUpInDiscovery();
+    public void startInstanceInfoRefreshNow();
 
     // =============
     // other methods

--- a/eureka-client/src/main/java/com/netflix/discovery/EurekaClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/EurekaClient.java
@@ -157,6 +157,16 @@ public interface EurekaClient extends LookupService {
      */
     public HealthCheckHandler getHealthCheckHandler();
 
+    /**
+     * Event to indicate current instance should register in discovery immediately
+     */
+    public void registerInDiscovery();
+
+    /**
+     * Event to indicate current instance should be marked as up in discovery immediately
+     */
+    public void markAsUpInDiscovery();
+
     // =============
     // other methods
     // =============

--- a/eureka-client/src/main/java/com/netflix/discovery/EurekaClientConfig.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/EurekaClientConfig.java
@@ -498,4 +498,9 @@ public interface EurekaClientConfig {
      * @return Replacement string for underscore sign <code>_</code>.
      */
     String getEscapeCharReplacement();
+
+    /**
+     *
+     */
+    boolean getUsesExplicitEventsForInitialDiscoveryCalls();
 }

--- a/eureka-client/src/main/java/com/netflix/discovery/EurekaClientConfig.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/EurekaClientConfig.java
@@ -502,5 +502,5 @@ public interface EurekaClientConfig {
     /**
      *
      */
-    boolean getUsesExplicitEventsForInitialDiscoveryCalls();
+    boolean getUseExplicitEventsForInitialDiscoveryCalls();
 }


### PR DESCRIPTION
This is the patch that allows an event oriented approach to starting InstanceInfo scheduled tasks (general HeartBeat and InstanceInfo (HealthCheck/Status/etc)).  It should be backwardsly compatible with no change in behavior (by default the tasks are started the same delays as before from DiscoveryClient initialization).  If however, the app sets the useExplicitEventsForInitialDiscoveryCalls, then the client is expected to call the methods startInstanceInfoHeartBeatNow and startInstanceInfoRefreshNow, likely calling them far sooner than the default initial delay.