### PR TITLE
2.x Fix dashboard/bridge health check. Add integration test to verify that.

### DIFF
--- a/eureka2-integration/src/test/resources/bridge-server-startupAndShutdown.properties
+++ b/eureka2-integration/src/test/resources/bridge-server-startupAndShutdown.properties
@@ -12,5 +12,6 @@ eureka.dataCenterInfo.type=Basic
 eureka.services.discovery.port=0
 eureka.services.replication.port=0
 eureka.services.shutdown.port=0
+eureka.services.http.port=0
 
 eureka.services.bridge.refreshRateSec=30

--- a/eureka2-integration/src/test/resources/dashboard-server-startupAndShutdown.properties
+++ b/eureka2-integration/src/test/resources/dashboard-server-startupAndShutdown.properties
@@ -28,3 +28,4 @@ eureka.dataCenterInfo.type=Basic
 
 # User ephemeral port
 eureka.services.shutdown.port=0
+eureka.services.http.port=0

--- a/eureka2-integration/src/test/resources/read-server-startupAndShutdown.properties
+++ b/eureka2-integration/src/test/resources/read-server-startupAndShutdown.properties
@@ -29,3 +29,4 @@ eureka.dataCenterInfo.type=Basic
 # use ephemeral ports
 eureka.services.discovery.port=0
 eureka.services.shutdown.port=0
+eureka.services.http.port=0

--- a/eureka2-integration/src/test/resources/write-server-startupAndShutdown.properties
+++ b/eureka2-integration/src/test/resources/write-server-startupAndShutdown.properties
@@ -30,6 +30,7 @@ eureka.dataCenterInfo.type=Basic
 eureka.services.registration.port=0
 eureka.services.discovery.port=0
 eureka.services.replication.port=0
+eureka.services.http.port=0
 
 eureka.services.shutdown.port=0
 

--- a/eureka2-server/src/main/java/com/netflix/eureka2/server/AbstractEurekaServer.java
+++ b/eureka2-server/src/main/java/com/netflix/eureka2/server/AbstractEurekaServer.java
@@ -30,6 +30,7 @@ import com.netflix.config.ConfigurationManager;
 import com.netflix.eureka2.server.config.EurekaCommonConfig;
 import com.netflix.eureka2.server.health.EurekaHealthStatusModule;
 import com.netflix.eureka2.server.health.KaryonHealthCheckHandler;
+import com.netflix.eureka2.server.http.EurekaHttpServer;
 import com.netflix.eureka2.server.utils.guice.PostInjectorModule;
 import com.netflix.governator.configuration.ArchaiusConfigurationProvider;
 import com.netflix.governator.configuration.ArchaiusConfigurationProvider.Builder;
@@ -79,6 +80,14 @@ public abstract class AbstractEurekaServer<C extends EurekaCommonConfig> {
     protected AbstractEurekaServer(C config) {
         this.config = config;
         this.name = null;
+    }
+
+    public int getHttpServerPort() {
+        EurekaHttpServer httpServer = injector.getInstance(EurekaHttpServer.class);
+        if (httpServer != null) {
+            return httpServer.serverPort();
+        }
+        return -1;
     }
 
     public int getShutdownPort() {

--- a/eureka2-server/src/main/java/com/netflix/eureka2/server/health/HealthStatusProviderRegistry.java
+++ b/eureka2-server/src/main/java/com/netflix/eureka2/server/health/HealthStatusProviderRegistry.java
@@ -1,14 +1,22 @@
 package com.netflix.eureka2.server.health;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import com.netflix.eureka2.health.HealthStatusProvider;
+import com.netflix.eureka2.health.HealthStatusUpdate;
+import com.netflix.eureka2.health.SubsystemDescriptor;
+import com.netflix.eureka2.registry.instance.InstanceInfo.Status;
 import com.netflix.eureka2.server.utils.guice.PostInjector;
 import rx.Observable;
 import rx.subjects.ReplaySubject;
 
 /**
+ * Collects health status providers, and makes them available via {@link HealthStatusProviderRegistry#activate()}
+ * method. If no provider is registered, a default {@link AlwaysHealthyStatusProvider} is returned, to
+ * report always status UP.
+ *
  * @author Tomasz Bak
  */
 public class HealthStatusProviderRegistry {
@@ -26,6 +34,26 @@ public class HealthStatusProviderRegistry {
 
     @PostInjector
     public void activate() {
+        if (providers.isEmpty()) {
+            List<HealthStatusProvider<?>> providers = Collections.<HealthStatusProvider<?>>singletonList(
+                    new AlwaysHealthyStatusProvider()
+            );
+            providerSubject.onNext(providers);
+        }
         providerSubject.onNext(providers);
+    }
+
+    static class AlwaysHealthyStatusProvider implements HealthStatusProvider<AlwaysHealthyStatusProvider> {
+
+        private static final SubsystemDescriptor<AlwaysHealthyStatusProvider> DESCRIPTOR = new SubsystemDescriptor<>(
+                AlwaysHealthyStatusProvider.class,
+                "Always healthy status provider",
+                "Healthcheck that always returns status UP"
+        );
+
+        @Override
+        public Observable<HealthStatusUpdate<AlwaysHealthyStatusProvider>> healthStatus() {
+            return Observable.just(new HealthStatusUpdate<AlwaysHealthyStatusProvider>(Status.UP, DESCRIPTOR));
+        }
     }
 }

--- a/eureka2-server/src/test/java/com/netflix/eureka2/server/health/HealthStatusProviderRegistryTest.java
+++ b/eureka2-server/src/test/java/com/netflix/eureka2/server/health/HealthStatusProviderRegistryTest.java
@@ -1,0 +1,37 @@
+package com.netflix.eureka2.server.health;
+
+import java.util.List;
+
+import com.netflix.eureka2.health.HealthStatusProvider;
+import com.netflix.eureka2.health.HealthStatusUpdate;
+import com.netflix.eureka2.registry.instance.InstanceInfo.Status;
+import com.netflix.eureka2.rx.ExtTestSubscriber;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Tomasz Bak
+ */
+public class HealthStatusProviderRegistryTest {
+
+    @Test
+    public void testReturnsDefaultHealthStatusProviderIfNonInjected() throws Exception {
+        HealthStatusProviderRegistry registry = new HealthStatusProviderRegistry();
+
+        ExtTestSubscriber<List<HealthStatusProvider<?>>> testSubscriber = new ExtTestSubscriber<>();
+        registry.healthStatusProviders().subscribe(testSubscriber);
+
+        registry.activate();
+
+        List<HealthStatusProvider<?>> statusProviders = testSubscriber.takeNextOrFail();
+        assertThat(statusProviders.size(), is(1));
+
+        ExtTestSubscriber<HealthStatusUpdate<?>> healthSubscriber = new ExtTestSubscriber<>();
+        statusProviders.get(0).healthStatus().subscribe(healthSubscriber);
+
+        assertThat(healthSubscriber.takeNext().getStatus(), is(equalTo(Status.UP)));
+    }
+}


### PR DESCRIPTION
 Dashboard/bridge do not provide yet any health check provider, so observable
 stream of server status never emitted any value. In this change, if there are no
 providers bound, a default one is registered returning always Status.UP.