### PR TITLE
Cross account describe ASGs

### DIFF
--- a/eureka-core/build.gradle
+++ b/eureka-core/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     compile "com.amazonaws:aws-java-sdk-core:$awsVersion"
     compile "com.amazonaws:aws-java-sdk-ec2:$awsVersion"
     compile "com.amazonaws:aws-java-sdk-autoscaling:$awsVersion"
+    compile "com.amazonaws:aws-java-sdk-sts:$awsVersion"
     compile "javax.servlet:servlet-api:$servletVersion"
     compile 'com.thoughtworks.xstream:xstream:1.4.2'
     compile 'javax.ws.rs:jsr311-api:1.1.1'

--- a/eureka-core/src/main/java/com/netflix/eureka/DefaultEurekaServerConfig.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/DefaultEurekaServerConfig.java
@@ -82,6 +82,9 @@ public class DefaultEurekaServerConfig implements EurekaServerConfig {
     private final DynamicIntProperty rateLimiterRegistryFetchAverageRate = configInstance.getIntProperty(namespace + "rateLimiter.registryFetchAverageRate", 500);
     private final DynamicIntProperty rateLimiterFullFetchAverageRate = configInstance.getIntProperty(namespace + "rateLimiter.fullFetchAverageRate", 100);
 
+    private final DynamicStringProperty listAutoScalingGroupsRoleName =
+            configInstance.getStringProperty(namespace + "listAutoScalingGroupsRoleName", "ListAutoScalingGroups");
+
     public DefaultEurekaServerConfig() {
         init();
     }
@@ -579,5 +582,10 @@ public class DefaultEurekaServerConfig implements EurekaServerConfig {
     @Override
     public int getRateLimiterFullFetchAverageRate() {
         return rateLimiterFullFetchAverageRate.get();
+    }
+
+    @Override
+    public String getListAutoScalingGroupsRoleName() {
+        return listAutoScalingGroupsRoleName.get();
     }
 }

--- a/eureka-core/src/main/java/com/netflix/eureka/EurekaServerConfig.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/EurekaServerConfig.java
@@ -551,4 +551,9 @@ public interface EurekaServerConfig {
      * See also {@link #getRateLimiterBurstSize()}.
      */
     int getRateLimiterFullFetchAverageRate();
+
+    /**
+     * Name of the Role used to describe auto scaling groups from third AWS accounts.
+     */
+    String getListAutoScalingGroupsRoleName();
 }

--- a/eureka-core/src/main/java/com/netflix/eureka/util/AwsAsgUtil.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/util/AwsAsgUtil.java
@@ -25,8 +25,20 @@ import java.util.TimerTask;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient;
+import com.amazonaws.services.securitytoken.model.AssumeRoleResult;
+import com.google.common.base.Strings;
+import com.netflix.appinfo.AmazonInfo;
+import com.netflix.appinfo.AmazonInfo.MetaDataKey;
+import com.netflix.appinfo.ApplicationInfoManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.BasicSessionCredentials;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.amazonaws.services.autoscaling.AmazonAutoScaling;
 import com.amazonaws.services.autoscaling.AmazonAutoScalingClient;
@@ -34,7 +46,7 @@ import com.amazonaws.services.autoscaling.model.AutoScalingGroup;
 import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsRequest;
 import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsResult;
 import com.amazonaws.services.autoscaling.model.SuspendedProcess;
-import com.google.common.base.Strings;
+import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -48,8 +60,6 @@ import com.netflix.eureka.PeerAwareInstanceRegistry;
 import com.netflix.servo.annotations.DataSourceType;
 import com.netflix.servo.monitor.Monitors;
 import com.netflix.servo.monitor.Stopwatch;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A utility class for querying and updating information about amazon
@@ -65,6 +75,7 @@ public class AwsAsgUtil {
     private static final EurekaServerConfig eurekaConfig = EurekaServerConfigurationManager
             .getInstance().getConfiguration();
     private static final AmazonAutoScaling client = getAmazonAutoScalingClient();
+    private static final String accountId = getAccountId();
     // Cache for the AWS ASG information
     private final LoadingCache<String, Boolean> asgCache = CacheBuilder
             .newBuilder().initialCapacity(500)
@@ -142,7 +153,13 @@ public class AwsAsgUtil {
      * @return - true if the ASG is disabled, false otherwise
      */
     private boolean isAddToLoadBalancerSuspended(String asgName) {
-        AutoScalingGroup asg = retrieveAutoScalingGroup(asgName);
+        String asgAccount = getASGAccount(asgName);
+        AutoScalingGroup asg;
+        if(asgAccount.equals(accountId)) {
+            asg = retrieveAutoScalingGroup(asgName);
+        } else {
+            asg = retrieveAutoScalingGroupCrossAccount(asgAccount, asgName);
+        }
         if (asg == null) {
             logger.warn(
                     "The ASG information for {} could not be found. So returning false.",
@@ -186,6 +203,47 @@ public class AwsAsgUtil {
         DescribeAutoScalingGroupsRequest request = new DescribeAutoScalingGroupsRequest()
                 .withAutoScalingGroupNames(asgName);
         DescribeAutoScalingGroupsResult result = client
+                .describeAutoScalingGroups(request);
+        List<AutoScalingGroup> asgs = result.getAutoScalingGroups();
+        if (asgs.isEmpty()) {
+            return null;
+        } else {
+            return asgs.get(0);
+        }
+    }
+
+    private AutoScalingGroup retrieveAutoScalingGroupCrossAccount(String asgAccount, String asgName) {
+        logger.debug("Getting cross account ASG for asgName: " + asgName + ", asgAccount: " + asgAccount);
+
+        final AWSSecurityTokenService sts = new AWSSecurityTokenServiceClient(new InstanceProfileCredentialsProvider());
+        String region = DiscoveryManager.getInstance().getEurekaClientConfig()
+                .getRegion();
+        if (!region.equals("us-east-1")) {
+            sts.setEndpoint("sts." + region + ".amazonaws.com");
+        }
+
+        String roleArn = "arn:aws:iam::" + asgAccount + ":role/ListAutoScalingGroups";
+
+        final AssumeRoleResult assumeRoleResult = sts.assumeRole(new AssumeRoleRequest()
+                        .withRoleArn(roleArn)
+                        .withRoleSessionName("session-name-here")
+        );
+
+        ClientConfiguration clientConfiguration = new ClientConfiguration()
+                .withConnectionTimeout(eurekaConfig.getASGQueryTimeoutMs());
+
+        AmazonAutoScaling autoScalingClient = new AmazonAutoScalingClient(
+                new BasicSessionCredentials(
+                        assumeRoleResult.getCredentials().getAccessKeyId(),
+                        assumeRoleResult.getCredentials().getSecretAccessKey(),
+                        assumeRoleResult.getCredentials().getSessionToken()
+                ),
+                clientConfiguration
+        );
+
+        DescribeAutoScalingGroupsRequest request = new DescribeAutoScalingGroupsRequest()
+                .withAutoScalingGroupNames(asgName);
+        DescribeAutoScalingGroupsResult result = autoScalingClient
                 .describeAutoScalingGroups(request);
         List<AutoScalingGroup> asgs = result.getAutoScalingGroups();
         if (asgs.isEmpty()) {
@@ -300,7 +358,7 @@ public class AwsAsgUtil {
     private Set<String> getASGNames() {
         Set<String> asgNames = new HashSet<String>();
         Applications apps = PeerAwareInstanceRegistry.getInstance()
-                .getApplications(false);
+        .getApplications(false);
         for (Application app : apps.getRegisteredApplications()) {
             for (InstanceInfo instanceInfo : app.getInstances()) {
                 String asgName = instanceInfo.getASGName();
@@ -311,6 +369,29 @@ public class AwsAsgUtil {
         }
 
         return asgNames;
+    }
+
+    /**
+     * Get the AWS account id where an ASG is created.
+     *
+     * @param asgName
+     *            - The name of the ASG
+     * @return the account id
+     */
+    private String getASGAccount(String asgName) {
+        Applications apps = PeerAwareInstanceRegistry.getInstance().getApplications(false);
+
+        for (Application app : apps.getRegisteredApplications()) {
+            for (InstanceInfo instanceInfo : app.getInstances()) {
+                String thisAsgName = instanceInfo.getASGName();
+                if (thisAsgName != null && thisAsgName.equals(asgName)) {
+                    return ((AmazonInfo) instanceInfo.getDataCenterInfo()).get(MetaDataKey.accountId);
+                }
+            }
+        }
+
+        logger.error("Couldn't get the ASG account for " + asgName);
+        return accountId;
     }
 
     private static AmazonAutoScaling getAmazonAutoScalingClient() {
@@ -329,6 +410,11 @@ public class AwsAsgUtil {
                     new InstanceProfileCredentialsProvider(),
                     clientConfiguration);
         }
+    }
+
+    private static String getAccountId() {
+        InstanceInfo myInfo = ApplicationInfoManager.getInstance().getInfo();
+        return ((AmazonInfo) myInfo.getDataCenterInfo()).get(MetaDataKey.accountId);
     }
 
 }

--- a/eureka-core/src/main/java/com/netflix/eureka/util/AwsAsgUtil.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/util/AwsAsgUtil.java
@@ -219,7 +219,10 @@ public class AwsAsgUtil {
             sts.setEndpoint("sts." + region + ".amazonaws.com");
         }
 
-        String roleArn = "arn:aws:iam::" + asgAccount + ":role/ListAutoScalingGroups";
+        String roleName = EurekaServerConfigurationManager.getInstance().getConfiguration().
+                getListAutoScalingGroupsRoleName();
+
+        String roleArn = "arn:aws:iam::" + asgAccount + ":role/" + roleName;
 
         AssumeRoleResult assumeRoleResult = sts.assumeRole(new AssumeRoleRequest()
                         .withRoleArn(roleArn)

--- a/eureka-core/src/main/java/com/netflix/eureka/util/AwsAsgUtil.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/util/AwsAsgUtil.java
@@ -399,7 +399,10 @@ public class AwsAsgUtil {
             for (InstanceInfo instanceInfo : app.getInstances()) {
                 String thisAsgName = instanceInfo.getASGName();
                 if (thisAsgName != null && thisAsgName.equals(asgName)) {
-                    return ((AmazonInfo) instanceInfo.getDataCenterInfo()).get(MetaDataKey.accountId);
+                    String accountId = ((AmazonInfo) instanceInfo.getDataCenterInfo()).get(MetaDataKey.accountId);
+                    if (accountId != null) {
+                        return accountId;
+                    }
                 }
             }
         }


### PR DESCRIPTION
The motivation of this patch is to make Eureka capable of knowing the state of auto scaling groups even if they are from microservices running in accounts other than the one where Eureka is running.

In that case, it will do a a cross-account assume role to get permission to describe the ASGs.

[Here](http://docs.aws.amazon.com/IAM/latest/UserGuide/roles-walkthrough-crossacct.html ) is a walkthrough from Amazon that explains how to setup the cross-account IAM role delegation: 

The role must be called `ListAutoScalingGroups` and the policy must be like this:
```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Action": [
                "autoscaling:DescribeAutoScalingGroups"
            ],
            "Effect": "Allow",
            "Resource": "*"
        }
    ]
} 
```