### PR TITLE
Disable the read only cache if 'responseCacheUpdateIntervalMs' is set to 0

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/EurekaServerConfig.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/EurekaServerConfig.java
@@ -259,7 +259,7 @@ public interface EurekaServerConfig {
 
     /**
      * Gets the time interval with which the payload cache of the client should
-     * be updated.
+     * be updated. Set to 0 to update the cache immediately.
      *
      * @return time in milliseconds.
      */


### PR DESCRIPTION
'responseCacheUpdateIntervalMs' controls how often the read only cache is updated with changes collected in the read-write cache. The lesser the value, the faster the cache is updated. So a value of 0 can be interpreted as an immediate update. 
This seems a good and easy way to disable the read only cache.

See https://github.com/Netflix/eureka/issues/536