### PR TITLE
2.x Refactorings/reactive registry

### DIFF
--- a/eureka2-core/src/main/java/com/netflix/eureka2/interests/IndexRegistry.java
+++ b/eureka2-core/src/main/java/com/netflix/eureka2/interests/IndexRegistry.java
@@ -1,13 +1,19 @@
 package com.netflix.eureka2.interests;
 
 import com.netflix.eureka2.registry.SourcedEurekaRegistry;
+import com.netflix.eureka2.registry.instance.InstanceInfo;
 import rx.Observable;
+
+import java.util.Iterator;
 
 /**
  * @author Nitesh Kant
  */
 public interface IndexRegistry<T> {
 
+    /**
+     * The interest for this call is required to be an atomic interest and not a {@link MultipleInterests}
+     */
     Observable<ChangeNotification<T>> forInterest(Interest<T> interest,
                                                   Observable<ChangeNotification<T>> dataSource,
                                                   Index.InitStateHolder<T> initStateHolder);

--- a/eureka2-core/src/main/java/com/netflix/eureka2/interests/MultipleInterests.java
+++ b/eureka2-core/src/main/java/com/netflix/eureka2/interests/MultipleInterests.java
@@ -23,6 +23,9 @@ import java.util.Set;
  * Eureka client can subscribe to multiple interests at the same time. This class
  * describes such multiple interests subscription.
  *
+ * Note after a multipleInterests is created, the internal set of interests are always
+ * flattened to the base-level interests
+ *
  * @author Tomasz Bak
  */
 public class MultipleInterests<T> extends Interest<T> {

--- a/eureka2-integration/src/test/java/com/netflix/eureka2/integration/EurekaClientIntegrationTest.java
+++ b/eureka2-integration/src/test/java/com/netflix/eureka2/integration/EurekaClientIntegrationTest.java
@@ -34,7 +34,7 @@ import static org.junit.Assert.assertThat;
  * @author Tomasz Bak
  */
 @Category(IntegrationTest.class)
-public class EurekaClientIntegrationTest {
+public class EurekaClientIntegrationTest extends IntegrationTestClassSetup {
 
     @Rule
     public final EurekaDeploymentResource eurekaDeploymentResource = new EurekaDeploymentResource(1, 1);

--- a/eureka2-integration/src/test/java/com/netflix/eureka2/integration/IntegrationTestClassSetup.java
+++ b/eureka2-integration/src/test/java/com/netflix/eureka2/integration/IntegrationTestClassSetup.java
@@ -1,0 +1,22 @@
+package com.netflix.eureka2.integration;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+/**
+ * @author David Liu
+ */
+public abstract class IntegrationTestClassSetup {
+
+    @BeforeClass
+    public static void setUpClass() {
+        System.setProperty("eureka.hacks.interestChannel.bufferHintDelayMs", "10");
+        System.setProperty("eureka.hacks.interestChannel.maxBufferHintDelayMs", "100");
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        System.clearProperty("eureka.hacks.interestChannel.bufferHintDelayMs");
+        System.clearProperty("eureka.hacks.interestChannel.maxBufferHintDelayMs");
+    }
+}

--- a/eureka2-integration/src/test/java/com/netflix/eureka2/integration/ReadServerIntegrationTest.java
+++ b/eureka2-integration/src/test/java/com/netflix/eureka2/integration/ReadServerIntegrationTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertThat;
 /**
  * @author David Liu
  */
-public class ReadServerIntegrationTest {
+public class ReadServerIntegrationTest extends IntegrationTestClassSetup {
 
     private static final int REGISTRY_INITIAL_SIZE = 100;
 

--- a/eureka2-integration/src/test/java/com/netflix/eureka2/integration/ReadWriteClusterIntegrationTest.java
+++ b/eureka2-integration/src/test/java/com/netflix/eureka2/integration/ReadWriteClusterIntegrationTest.java
@@ -27,7 +27,7 @@ import static org.hamcrest.Matchers.is;
  * @author David Liu
  */
 @Category(IntegrationTest.class)
-public class ReadWriteClusterIntegrationTest {
+public class ReadWriteClusterIntegrationTest extends IntegrationTestClassSetup {
 
     @Rule
     public final EurekaDeploymentResource eurekaDeploymentResource = new EurekaDeploymentResource(3, 6);

--- a/eureka2-integration/src/test/java/com/netflix/eureka2/integration/WriteClusterIntegrationTest.java
+++ b/eureka2-integration/src/test/java/com/netflix/eureka2/integration/WriteClusterIntegrationTest.java
@@ -37,7 +37,7 @@ import static org.hamcrest.Matchers.is;
  * @author David Liu
  */
 @Category(IntegrationTest.class)
-public class WriteClusterIntegrationTest {
+public class WriteClusterIntegrationTest extends IntegrationTestClassSetup {
 
     @Rule
     public final EurekaDeploymentResource eurekaDeploymentResource = new EurekaDeploymentResource(2, 0);

--- a/eureka2-integration/src/test/java/com/netflix/eureka2/integration/WriteServerIntegrationTest.java
+++ b/eureka2-integration/src/test/java/com/netflix/eureka2/integration/WriteServerIntegrationTest.java
@@ -28,7 +28,7 @@ import static org.hamcrest.Matchers.is;
  * @author David Liu
  */
 @Category(IntegrationTest.class)
-public class WriteServerIntegrationTest {
+public class WriteServerIntegrationTest extends IntegrationTestClassSetup {
 
     @Rule
     public final EurekaDeploymentResource eurekaDeploymentResource = new EurekaDeploymentResource(1, 0);

--- a/eureka2-integration/src/test/java/com/netflix/eureka2/integration/batching/IndexBatchMergeIntegrationTest.java
+++ b/eureka2-integration/src/test/java/com/netflix/eureka2/integration/batching/IndexBatchMergeIntegrationTest.java
@@ -1,0 +1,167 @@
+package com.netflix.eureka2.integration.batching;
+
+import com.netflix.eureka2.channel.InterestChannel;
+import com.netflix.eureka2.client.EurekaInterestClient;
+import com.netflix.eureka2.client.channel.ClientChannelFactory;
+import com.netflix.eureka2.client.channel.InterestChannelFactory;
+import com.netflix.eureka2.client.interest.BatchAwareIndexRegistry;
+import com.netflix.eureka2.client.interest.BatchingRegistry;
+import com.netflix.eureka2.client.interest.BatchingRegistryImpl;
+import com.netflix.eureka2.client.interest.EurekaInterestClientImpl;
+import com.netflix.eureka2.interests.ChangeNotification;
+import com.netflix.eureka2.interests.IndexRegistry;
+import com.netflix.eureka2.interests.IndexRegistryImpl;
+import com.netflix.eureka2.interests.Interest;
+import com.netflix.eureka2.interests.Interests;
+import com.netflix.eureka2.interests.StreamStateNotification;
+import com.netflix.eureka2.metric.EurekaRegistryMetricFactory;
+import com.netflix.eureka2.metric.client.EurekaClientMetricFactory;
+import com.netflix.eureka2.protocol.discovery.AddInstance;
+import com.netflix.eureka2.protocol.discovery.InterestSetNotification;
+import com.netflix.eureka2.protocol.discovery.SampleAddInstance;
+import com.netflix.eureka2.protocol.discovery.StreamStateUpdate;
+import com.netflix.eureka2.registry.SourcedEurekaRegistry;
+import com.netflix.eureka2.registry.SourcedEurekaRegistryImpl;
+import com.netflix.eureka2.registry.instance.InstanceInfo;
+import com.netflix.eureka2.rx.ExtTestSubscriber;
+import com.netflix.eureka2.transport.MessageConnection;
+import com.netflix.eureka2.transport.TransportClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import rx.Observable;
+import rx.functions.Func1;
+import rx.subjects.ReplaySubject;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author David Liu
+ */
+public class IndexBatchMergeIntegrationTest {
+
+    private final ExtTestSubscriber<ChangeNotification<InstanceInfo>> testSubscriber = new ExtTestSubscriber<>();
+
+    private final ReplaySubject<Object> incomingSubject = ReplaySubject.create();
+    private final ReplaySubject<Void> serverConnectionLifecycle = ReplaySubject.create();
+
+    private SourcedEurekaRegistry<InstanceInfo> registry;
+    private MessageConnection serverConnection;
+    private BatchingRegistry<InstanceInfo> remoteBatchingRegistry;
+    private IndexRegistry<InstanceInfo> localIndexRegistry;
+    private IndexRegistry<InstanceInfo> compositeIndexRegistry;
+    private EurekaInterestClient interestClient;
+
+    @Before
+    public void setUp() {
+        remoteBatchingRegistry = new BatchingRegistryImpl<>();
+        localIndexRegistry = new IndexRegistryImpl<>();
+        compositeIndexRegistry = new BatchAwareIndexRegistry<>(localIndexRegistry, remoteBatchingRegistry);
+
+        registry = new SourcedEurekaRegistryImpl(compositeIndexRegistry, EurekaRegistryMetricFactory.registryMetrics());
+
+        serverConnection = mock(MessageConnection.class);
+        when(serverConnection.incoming()).thenReturn(incomingSubject);
+        when(serverConnection.acknowledge()).thenReturn(Observable.<Void>empty());
+        when(serverConnection.lifecycleObservable()).thenReturn(serverConnectionLifecycle);
+
+        TransportClient transport = mock(TransportClient.class);
+        when(transport.connect()).thenReturn(Observable.just(serverConnection));
+
+        ClientChannelFactory<InterestChannel> channelFactory = new InterestChannelFactory(
+                transport,
+                registry,
+                remoteBatchingRegistry,
+                EurekaClientMetricFactory.clientMetrics()
+        );
+
+        interestClient = new EurekaInterestClientImpl(registry, channelFactory);
+    }
+
+    @Test
+    public void testNewInterestServerHasData() throws Exception {
+        final Interest<InstanceInfo> interest = Interests.forFullRegistry();
+
+        final List<InterestSetNotification> data1 = Arrays.asList(
+                newBufferStart(interest),
+                SampleAddInstance.ZuulAdd.newMessage(),
+                SampleAddInstance.ZuulAdd.newMessage(),
+                SampleAddInstance.ZuulAdd.newMessage(),
+                SampleAddInstance.ZuulAdd.newMessage(),
+                SampleAddInstance.ZuulAdd.newMessage(),
+                SampleAddInstance.ZuulAdd.newMessage(),
+                SampleAddInstance.ZuulAdd.newMessage(),
+                newBufferEnd(interest)
+        );
+
+        final Observable<InterestSetNotification> remoteData = Observable.timer(100, TimeUnit.MILLISECONDS).
+                flatMap(new Func1<Long, Observable<InterestSetNotification>>() {
+                    @Override
+                    public Observable<InterestSetNotification> call(Long aLong) {
+                        return Observable.from(data1);
+                    }
+                });
+
+        when(serverConnection.submitWithAck(Mockito.anyObject())).then(new Answer<Observable<Void>>() {
+            @Override
+            public Observable<Void> answer(InvocationOnMock invocation) throws Throwable {
+                remoteData.subscribe(incomingSubject);
+                return Observable.empty();
+            }
+        });
+
+        Observable<ChangeNotification<InstanceInfo>> notifications = interestClient.forInterest(interest);
+
+        notifications.subscribe(testSubscriber);
+
+        testSubscriber.assertProducesInAnyOrder(toChangeNotifications(data1), new Func1<ChangeNotification<InstanceInfo>, ChangeNotification<InstanceInfo>>() {
+            @Override
+            public ChangeNotification<InstanceInfo> call(ChangeNotification<InstanceInfo> notification) {
+                return notification;
+            }
+        }, 5000, TimeUnit.MILLISECONDS);
+
+        List<ChangeNotification<InstanceInfo>> received = testSubscriber.getOnNextItems();
+        for (int i = 0; i < received.size() - 1; i++) {
+            assertThat(received.get(i).getKind(), is(not(ChangeNotification.Kind.BufferSentinel)));
+        }
+        assertThat(received.get(received.size() - 1).getKind(), is(ChangeNotification.Kind.BufferSentinel));
+    }
+
+    private List<ChangeNotification<InstanceInfo>> toChangeNotifications(List<InterestSetNotification> interestSetNotifications) {
+        List<ChangeNotification<InstanceInfo>> toReturn = new ArrayList<>(interestSetNotifications.size());
+        for (InterestSetNotification n : interestSetNotifications) {
+            if (n instanceof StreamStateUpdate) {
+                if (((StreamStateUpdate) n).getState() == StreamStateNotification.BufferState.BufferEnd) {
+                    toReturn.add(ChangeNotification.<InstanceInfo>bufferSentinel());
+                } else {
+                    // ignore buffer start
+                }
+            } else if (n instanceof AddInstance) {
+                toReturn.add(new ChangeNotification<>(ChangeNotification.Kind.Add, ((AddInstance) n).getInstanceInfo()));
+            }
+        }
+
+        return toReturn;
+    }
+
+    private StreamStateUpdate newBufferStart(Interest<InstanceInfo> interest) {
+        return new StreamStateUpdate(StreamStateNotification.bufferStartNotification(interest));
+    }
+
+    private StreamStateUpdate newBufferEnd(Interest<InstanceInfo> interest) {
+        return new StreamStateUpdate(StreamStateNotification.bufferEndNotification(interest));
+    }
+}

--- a/eureka2-integration/src/test/java/com/netflix/eureka2/integration/examples/SimpleAppIntegrationTest.java
+++ b/eureka2-integration/src/test/java/com/netflix/eureka2/integration/examples/SimpleAppIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.netflix.eureka2.integration.examples;
 
 import com.netflix.eureka2.example.client.SimpleApp;
+import com.netflix.eureka2.integration.IntegrationTestClassSetup;
 import com.netflix.eureka2.junit.categories.IntegrationTest;
 import com.netflix.eureka2.junit.categories.LongRunningTest;
 import com.netflix.eureka2.testkit.embedded.cluster.EmbeddedReadCluster;
@@ -15,7 +16,7 @@ import org.junit.experimental.categories.Category;
  * @author Tomasz Bak
  */
 @Category({IntegrationTest.class, LongRunningTest.class})
-public class SimpleAppIntegrationTest {
+public class SimpleAppIntegrationTest extends IntegrationTestClassSetup {
 
     @Rule
     public final EurekaDeploymentResource eurekaDeploymentResource = new EurekaDeploymentResource(1, 1);

--- a/eureka2-integration/src/test/java/com/netflix/eureka2/integration/mixedcodec/AbstractMixedCodecTest.java
+++ b/eureka2-integration/src/test/java/com/netflix/eureka2/integration/mixedcodec/AbstractMixedCodecTest.java
@@ -2,6 +2,7 @@ package com.netflix.eureka2.integration.mixedcodec;
 
 import com.netflix.eureka2.client.EurekaInterestClient;
 import com.netflix.eureka2.client.EurekaRegistrationClient;
+import com.netflix.eureka2.integration.IntegrationTestClassSetup;
 import com.netflix.eureka2.interests.ChangeNotification;
 import com.netflix.eureka2.interests.Interests;
 import com.netflix.eureka2.registry.instance.InstanceInfo;
@@ -21,7 +22,7 @@ import static org.hamcrest.Matchers.is;
  *
  * @author David Liu
  */
-public abstract class AbstractMixedCodecTest {
+public abstract class AbstractMixedCodecTest extends IntegrationTestClassSetup {
 
     private final InstanceInfo registeringInfo = SampleInstanceInfo.CliServer.build();
 

--- a/eureka2-integration/src/test/java/com/netflix/eureka2/integration/random/AbstractRandomLifecycleTest.java
+++ b/eureka2-integration/src/test/java/com/netflix/eureka2/integration/random/AbstractRandomLifecycleTest.java
@@ -1,7 +1,10 @@
 package com.netflix.eureka2.integration.random;
 
+import com.netflix.eureka2.integration.IntegrationTestClassSetup;
 import com.netflix.eureka2.interests.ChangeNotification;
 import com.netflix.eureka2.registry.instance.InstanceInfo;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,7 +17,7 @@ import static org.hamcrest.number.OrderingComparison.lessThanOrEqualTo;
 /**
  * @author David Liu
  */
-public abstract class AbstractRandomLifecycleTest {
+public abstract class AbstractRandomLifecycleTest extends IntegrationTestClassSetup {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractRandomLifecycleTest.class);
 

--- a/eureka2-test-utils/src/main/java/com/netflix/eureka2/rx/ExtTestSubscriber.java
+++ b/eureka2-test-utils/src/main/java/com/netflix/eureka2/rx/ExtTestSubscriber.java
@@ -108,6 +108,10 @@ public class ExtTestSubscriber<T> extends Subscriber<T> {
         return available.poll(24, TimeUnit.HOURS);
     }
 
+    public List<T> getOnNextItems() {
+        return new ArrayList<>(items);
+    }
+
     public List<T> takeNextOrWait(int n) throws InterruptedException {
         List<T> result = new ArrayList<>(n);
         for (int i = 0; i < n; i++) {


### PR DESCRIPTION
- Clean up extra use of a subject in the initStateHolder
- Adding temporary fix for client side batching issue (too eagerly emit BufferMarker when local cache is empty but data is transmitted from server side).