### PR TITLE
Capture "CacheRefreshed" event

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/CacheRefreshedEvent.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/CacheRefreshedEvent.java
@@ -1,0 +1,11 @@
+package com.netflix.discovery;
+
+/**
+ * This event is sent by {@link EurekaClient) whenever it has refreshed its local 
+ * local cache with information received from the Eureka server.
+ * 
+ * @author brenuart
+ */
+public class CacheRefreshedEvent extends DiscoveryEvent {
+
+}

--- a/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
@@ -2010,11 +2010,7 @@ public class DiscoveryClient implements EurekaClient {
      * @param newStatus the new remote {@link InstanceStatus} 
      */
     protected void onRemoteStatusChanged(InstanceInfo.InstanceStatus oldStatus, InstanceInfo.InstanceStatus newStatus) {
-    	// Publish event if an EventBus is available
-        if (eventBus != null) {
-            StatusChangeEvent event = new StatusChangeEvent(oldStatus, newStatus);
-            eventBus.publish(event);
-        }
+    	fireEvent(new StatusChangeEvent(oldStatus, newStatus));
     }
     
     /**
@@ -2024,7 +2020,19 @@ public class DiscoveryClient implements EurekaClient {
      * Subclasses may override this method to implement custom behavior if needed.
      */
     protected void onCacheRefreshed() {
-    	// NOOP
+    	fireEvent(new CacheRefreshedEvent());
     }
 
+
+    /**
+     * Send the given event on the EventBus if one is available
+     * 
+     * @param event the event to send on the eventBus
+     */
+    protected void fireEvent(DiscoveryEvent event) {
+    	// Publish event if an EventBus is available
+        if (eventBus != null) {
+            eventBus.publish(event);
+        }
+    }
 }

--- a/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
@@ -844,13 +844,6 @@ public class DiscoveryClient implements EurekaClient {
 
             logger.debug(PREFIX + appPathIdentifier + " -  refresh status: "
                     + response.getStatus());
-
-            // Notify about cache refreshed before updating the instance remote status
-            onCacheRefreshed();
-            
-            // Update remote status based on refreshed data held in the cache
-            updateInstanceRemoteStatus();
-
         } catch (Throwable e) {
             logger.error(
                     PREFIX + appPathIdentifier
@@ -863,6 +856,14 @@ public class DiscoveryClient implements EurekaClient {
             }
             closeResponse(response);
         }
+
+        // Notify about cache refresh before updating the instance remote status
+        onCacheRefreshed();
+        
+        // Update remote status based on refreshed data held in the cache
+        updateInstanceRemoteStatus();
+
+        // registry was fetched successfully, so return true
         return true;
     }
 

--- a/eureka-client/src/main/java/com/netflix/discovery/DiscoveryEvent.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DiscoveryEvent.java
@@ -1,0 +1,33 @@
+/**
+ * 
+ */
+package com.netflix.discovery;
+
+
+/**
+ * Class to be extended by all discovery events. Abstract as it
+ * doesn't make sense for generic events to be published directly.
+ * 
+ * @author brenuart
+ */
+public abstract class DiscoveryEvent {
+
+	/** System time when the event happened */
+	private final long timestamp;
+	
+	
+	/**
+	 * Create a new DiscoveryEvent
+	 */
+	public DiscoveryEvent() {
+		super();
+		this.timestamp = System.currentTimeMillis();
+	}
+	
+	/**
+	 * Return the system time in milliseconds when the event happened.
+	 */
+	public final long getTimestamp() {
+		return this.timestamp;
+	}
+}

--- a/eureka-client/src/main/java/com/netflix/discovery/StatusChangeEvent.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/StatusChangeEvent.java
@@ -10,7 +10,7 @@ import com.netflix.appinfo.InstanceInfo;
  * @author elandau
  *
  */
-public class StatusChangeEvent {
+public class StatusChangeEvent extends DiscoveryEvent {
     private final InstanceInfo.InstanceStatus current;
     private final InstanceInfo.InstanceStatus previous;
 


### PR DESCRIPTION
The objective is to capture "cache refreshed" events. A few comments (following discussion in https://github.com/Netflix/eureka/issues/545):

1/ Added protected methods invoked when remote status is changed and cache is refreshed. They  are currently responsible to fire the appropriate event to the EventBus if one is available.
They are intentionally made protected so subclasses of the `DiscoveryClient` can override them if they need more advanced behaviour like:
- implement the Observer pattern and invoke registered listeners/observers
- compute actual changes when cache is refreshed
- etc

2/ I could create a `CacheRefreshedEvent` similar to the existing `StatusChangedEvent` and fire it every time the cache is refreshed. However, I'm not sure about the implications this additional event may have on components currently listening to the only StatusChangedEvent... What is your opinion?

3/ The `FETCH_REGISTRY_TIMER` includes the time taken by the following bloc of code:

     private boolean fetchRegistry(boolean forceFullRegistryFetch) {
         try {
            ....
            // Notify about cache refreshed before updating the instance remote status
            onCacheRefreshed();
            
            // Update remote status based on refreshed data held in the cache
            updateInstanceRemoteStatus();
       } catch(Throwable t) {
       ....
       } finally {
           tracer.stop();

The tracer includes the time it takes to notify listening parties. Should't we stop the timer before?

4/ I could have introduced the `Observer` pattern directly. But then I think it should have been done for both the `StatusChangedEvent` AND the newly introduced `CacheRefreshedEvent`...
They new protected methods are good starting point to build the Observer pattern if needed.
