### PR TITLE
2.x various fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ buildscript {
 }
 
 plugins {
-    id 'nebula.netflixoss' version '2.2.9'
+    id 'nebula.netflixoss' version '2.2.10'
 }
 
 ext {
@@ -70,8 +70,21 @@ subprojects {
     configurations.all {
         exclude group: 'com.netflix.rxjava' // Use io.reactivex:rxjava
         exclude group: 'com.netflix.rxnetty' // Use io.reactivex:rxnetty
-        exclude module: 'log4j' // From ocelli
         exclude module: 'slf4j-log4j12' // From ocelli
+        exclude group: 'log4j', module: 'log4j'  // exclude log4j 1
+
+        resolutionStrategy {
+            eachDependency { DependencyResolveDetails details ->
+                //specifying a fixed version for all jersey libs
+                if (details.requested.group == 'com.sun.jersey') {
+                    details.useVersion "${jersey_version}"
+                }
+
+                if (details.requested.group == 'com.netflix.governator') {
+                    details.useVersion "${governator_version}"
+                }
+            }
+        }
     }
 
     dependencies {

--- a/eureka2-bridge/build.gradle
+++ b/eureka2-bridge/build.gradle
@@ -36,7 +36,7 @@ jar {
     }
 }
 
-mainClassName = "com.netflix.eureka2.server.EurekaBridgeServer"
+mainClassName = "com.netflix.eureka2.server.EurekaBridgeServerRunner"
 applicationDefaultJvmArgs = ["-Xms2g",
                              "-Xmx4g",
 //                             "-Dcom.sun.management.jmxremote",

--- a/eureka2-bridge/src/main/java/com/netflix/eureka2/server/EurekaBridgeServerConfigurationModule.java
+++ b/eureka2-bridge/src/main/java/com/netflix/eureka2/server/EurekaBridgeServerConfigurationModule.java
@@ -19,6 +19,10 @@ public class EurekaBridgeServerConfigurationModule extends EurekaWriteServerConf
         return rootConfig;
     }
 
+    public static Module fromArchaius() {
+        return fromArchaius(DEFAULT_CONFIG_PREFIX);
+    }
+
     public static Module fromArchaius(final String prefix) {
         return new EurekaBridgeServerConfigurationModule() {
             @Provides

--- a/eureka2-bridge/src/main/java/com/netflix/eureka2/server/EurekaBridgeServerRunner.java
+++ b/eureka2-bridge/src/main/java/com/netflix/eureka2/server/EurekaBridgeServerRunner.java
@@ -1,25 +1,21 @@
 package com.netflix.eureka2.server;
 
-import com.google.inject.AbstractModule;
 import com.google.inject.Module;
-import com.google.inject.util.Modules;
-import com.netflix.archaius.inject.ApplicationLayer;
 import com.netflix.discovery.guice.EurekaModule;
 import com.netflix.eureka2.server.config.BridgeServerConfig;
 import com.netflix.eureka2.server.module.CommonEurekaServerModule;
 import com.netflix.eureka2.server.spi.ExtAbstractModule;
 import com.netflix.eureka2.server.spi.ExtAbstractModule.ServerType;
-import com.netflix.governator.DefaultGovernatorConfiguration;
-import com.netflix.governator.Governator;
 import com.netflix.governator.LifecycleInjector;
 import com.netflix.governator.auto.ModuleListProviders;
+import com.netflix.karyon.DefaultKaryonConfiguration;
+import com.netflix.karyon.Karyon;
+import com.netflix.karyon.archaius.ArchaiusKaryonConfiguration;
 import netflix.adminresources.resources.KaryonWebAdminModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
-
-import static com.netflix.eureka2.server.config.ServerConfigurationNames.DEFAULT_CONFIG_PREFIX;
 
 /**
  * A Bridge (Write) server that captures snapshots of Eureka 1.0 Data and replicates changes of the 1.0 data
@@ -46,22 +42,9 @@ public class EurekaBridgeServerRunner extends EurekaServerRunner<EurekaBridgeSer
 
     @Override
     protected List<Module> getModules() {
-        Module configModule;
-
-        if (config == null && name == null) {
-            configModule = EurekaBridgeServerConfigurationModule.fromArchaius(DEFAULT_CONFIG_PREFIX);
-        } else if (config == null) {  // have name
-            configModule = Modules
-                    .override(EurekaBridgeServerConfigurationModule.fromArchaius(DEFAULT_CONFIG_PREFIX))
-                    .with(new AbstractModule() {
-                        @Override
-                        protected void configure() {
-                            bind(String.class).annotatedWith(ApplicationLayer.class).toInstance(name);
-                        }
-                    });
-        } else {  // have config
-            configModule = EurekaBridgeServerConfigurationModule.fromConfig(config);
-        }
+        Module configModule = (config == null)
+                ? EurekaBridgeServerConfigurationModule.fromArchaius()
+                : EurekaBridgeServerConfigurationModule.fromConfig(config);
 
         return asList(
                 configModule,
@@ -74,11 +57,16 @@ public class EurekaBridgeServerRunner extends EurekaServerRunner<EurekaBridgeSer
 
     @Override
     protected LifecycleInjector createInjector() {
-        return Governator.createInjector(
-                DefaultGovernatorConfiguration.builder()
-                        .addProfile(ServerType.Bridge.name())
-                        .addModuleListProvider(ModuleListProviders.forServiceLoader(ExtAbstractModule.class))
-                        .build(),
+        DefaultKaryonConfiguration.Builder configurationBuilder = (name == null)
+                ? ArchaiusKaryonConfiguration.builder()
+                : ArchaiusKaryonConfiguration.builder().withConfigName(name);
+
+        configurationBuilder
+                .addProfile(ServerType.Bridge.name())
+                .addModuleListProvider(ModuleListProviders.forServiceLoader(ExtAbstractModule.class));
+
+        return Karyon.createInjector(
+                configurationBuilder.build(),
                 getModules()
         );
     }

--- a/eureka2-dashboard/build.gradle
+++ b/eureka2-dashboard/build.gradle
@@ -33,7 +33,7 @@ jar {
     }
 }
 
-mainClassName = "com.netflix.eureka2.EurekaDashboardServer"
+mainClassName = "com.netflix.eureka2.EurekaDashboardRunner"
 applicationDefaultJvmArgs = ["-Xms2g",
                              "-Xmx4g",
 //                             "-Dcom.sun.management.jmxremote",

--- a/eureka2-dashboard/src/main/java/com/netflix/eureka2/EurekaDashboardConfigurationModule.java
+++ b/eureka2-dashboard/src/main/java/com/netflix/eureka2/EurekaDashboardConfigurationModule.java
@@ -20,6 +20,10 @@ public abstract class EurekaDashboardConfigurationModule extends ServerConfigura
         return rootConfig;
     }
 
+    public static Module fromArchaius() {
+        return fromArchaius(DEFAULT_CONFIG_PREFIX);
+    }
+
     public static Module fromArchaius(final String prefix) {
         return new EurekaDashboardConfigurationModule() {
             @Provides

--- a/eureka2-ext/eureka2-kafka/build.gradle
+++ b/eureka2-ext/eureka2-kafka/build.gradle
@@ -19,12 +19,7 @@ apply plugin: 'osgi'
 dependencies {
     compile project(':eureka2-server')
     compile project(':eureka2-client')
-    compile("org.apache.kafka:kafka_2.9.2:${kafka_version}") {
-        exclude module: 'jms'
-        exclude module: 'jmxtools'
-        exclude module: 'jmxri'
-        exclude module: 'zookeeper'
-    }
+    compile "org.apache.kafka:kafka-clients:${kafka_version}"
 
     testCompile project(':eureka2-test-utils')
 }

--- a/eureka2-ext/eureka2-kafka/src/main/java/com/netflix/eureka2/server/audit/kafka/KafkaAuditServiceModule.java
+++ b/eureka2-ext/eureka2-kafka/src/main/java/com/netflix/eureka2/server/audit/kafka/KafkaAuditServiceModule.java
@@ -31,7 +31,7 @@ import com.netflix.governator.auto.annotations.ConditionalOnProfile;
  *
  * @author Tomasz Bak
  */
-@ConditionalOnProfile({ExtAbstractModule.WRITE_PROFILE, ExtAbstractModule.BRIDGE_PROFILE})
+@ConditionalOnProfile(value = {ExtAbstractModule.WRITE_PROFILE, ExtAbstractModule.BRIDGE_PROFILE}, matchAll = false)
 public class KafkaAuditServiceModule extends ExtAbstractModule {
 
     private static final TypeLiteral<StreamedDataCollector<InetSocketAddress>> STREAMED_DATA_COLLECTOR_TYPE_LITERAL =

--- a/eureka2-ext/eureka2-kafka/src/main/java/com/netflix/eureka2/server/audit/kafka/KafkaAuditServiceModule.java
+++ b/eureka2-ext/eureka2-kafka/src/main/java/com/netflix/eureka2/server/audit/kafka/KafkaAuditServiceModule.java
@@ -18,13 +18,19 @@ package com.netflix.eureka2.server.audit.kafka;
 
 import java.net.InetSocketAddress;
 
+import com.google.inject.Module;
+import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
+import com.netflix.archaius.ConfigProxyFactory;
 import com.netflix.eureka2.server.audit.AuditService;
 import com.netflix.eureka2.server.audit.AuditServiceController;
+import com.netflix.eureka2.server.audit.kafka.config.KafkaAuditServiceConfig;
 import com.netflix.eureka2.server.spi.ExtAbstractModule;
 import com.netflix.eureka2.utils.StreamedDataCollector;
 import com.netflix.governator.auto.annotations.ConditionalOnProfile;
+
+import javax.inject.Singleton;
 
 /**
  * Guice module for injecting {@link AuditService} with Kafka persistence.
@@ -33,6 +39,8 @@ import com.netflix.governator.auto.annotations.ConditionalOnProfile;
  */
 @ConditionalOnProfile(value = {ExtAbstractModule.WRITE_PROFILE, ExtAbstractModule.BRIDGE_PROFILE}, matchAll = false)
 public class KafkaAuditServiceModule extends ExtAbstractModule {
+
+    public static final String DEFAULT_CONFIG_PREFIX = "eureka.ext.audit.kafka";
 
     private static final TypeLiteral<StreamedDataCollector<InetSocketAddress>> STREAMED_DATA_COLLECTOR_TYPE_LITERAL =
             new TypeLiteral<StreamedDataCollector<InetSocketAddress>>() {
@@ -43,5 +51,22 @@ public class KafkaAuditServiceModule extends ExtAbstractModule {
         bind(STREAMED_DATA_COLLECTOR_TYPE_LITERAL).toProvider(KafkaServersProvider.class);
         bind(AuditServiceController.class).in(Scopes.SINGLETON);
         bind(AuditService.class).to(KafkaAuditService.class);
+    }
+
+    @Provides
+    @Singleton
+    public KafkaAuditServiceConfig getConfiguration(ConfigProxyFactory factory) {
+        return factory.newProxy(KafkaAuditServiceConfig.class, DEFAULT_CONFIG_PREFIX);
+    }
+
+    public static Module fromConfig(final KafkaAuditServiceConfig config) {
+        return new KafkaAuditServiceModule() {
+            @Override
+            @Provides
+            @Singleton
+            public KafkaAuditServiceConfig getConfiguration(ConfigProxyFactory factory) {
+                return config;
+            }
+        };
     }
 }

--- a/eureka2-ext/eureka2-kafka/src/main/java/com/netflix/eureka2/server/audit/kafka/KafkaServersProvider.java
+++ b/eureka2-ext/eureka2-kafka/src/main/java/com/netflix/eureka2/server/audit/kafka/KafkaServersProvider.java
@@ -26,6 +26,7 @@ import java.util.regex.Pattern;
 import com.netflix.eureka2.interests.Interests;
 import com.netflix.eureka2.registry.instance.InstanceInfo;
 import com.netflix.eureka2.registry.selector.ServiceSelector;
+import com.netflix.eureka2.server.audit.kafka.config.KafkaAuditServiceConfig;
 import com.netflix.eureka2.server.spi.ExtensionContext;
 import com.netflix.eureka2.utils.StreamedDataCollector;
 import rx.functions.Func1;
@@ -44,10 +45,10 @@ public class KafkaServersProvider implements Provider<StreamedDataCollector<Inet
     private static final ServiceSelector SELECTOR = ServiceSelector.selectBy().publicIp(true).or().any();
 
     private final ExtensionContext context;
-    private final KafkaAuditConfig config;
+    private final KafkaAuditServiceConfig config;
 
     @Inject
-    public KafkaServersProvider(ExtensionContext context, KafkaAuditConfig config) {
+    public KafkaServersProvider(ExtensionContext context, KafkaAuditServiceConfig config) {
         this.context = context;
         this.config = config;
     }
@@ -55,7 +56,7 @@ public class KafkaServersProvider implements Provider<StreamedDataCollector<Inet
     @Override
     public StreamedDataCollector<InetSocketAddress> get() {
         StreamedDataCollector<InetSocketAddress> delegate;
-        if (config.getKafkaServerList() == null) {
+        if (config.getServerList() == null) {
             delegate = StreamedDataCollector.from(
                     context.getLocalRegistryView().forInterest(Interests.forVips(config.getKafkaVip())),
                     new Func1<InstanceInfo, InetSocketAddress>() {
@@ -73,7 +74,7 @@ public class KafkaServersProvider implements Provider<StreamedDataCollector<Inet
 
     private List<InetSocketAddress> parseServerList() {
         List<InetSocketAddress> servers = new ArrayList<>();
-        for (String part : SEMICOLON_RE.split(config.getKafkaServerList())) {
+        for (String part : SEMICOLON_RE.split(config.getServerList())) {
             int idx = part.indexOf(':');
             String host;
             int port;

--- a/eureka2-ext/eureka2-kafka/src/main/java/com/netflix/eureka2/server/audit/kafka/config/KafkaAuditServiceConfig.java
+++ b/eureka2-ext/eureka2-kafka/src/main/java/com/netflix/eureka2/server/audit/kafka/config/KafkaAuditServiceConfig.java
@@ -1,0 +1,50 @@
+package com.netflix.eureka2.server.audit.kafka.config;
+
+import com.netflix.archaius.annotations.DefaultValue;
+
+/**
+ * @author David Liu
+ */
+public interface KafkaAuditServiceConfig {
+
+    int DEFAULT_KAFKA_PORT = 7101;
+    long DEFAULT_RETRY_INTERVAL_MS = 30000;
+    int DEFAULT_MAX_QUEUE_SIZE = 10000;
+
+    /**
+     * Kafka server list can be injected directly via configuration, in the following format:
+     * host[:port][;host[:port...]]
+     *
+     * This property is an alternative to {@link #getKafkaVip()}, with higher priority if both defined.
+     */
+    String getServerList();
+
+    /**
+     * VIP address resolved in local Eureka registry. This property must be set, unless a list of
+     * Kafka servers is defined directly with {@link #getServerList()}.
+     */
+    String getKafkaVip();
+
+    /**
+     * Kafka topic for audit messages. If not set, Eureka cluster name is used.
+     */
+    String getKafkaTopic();
+
+    /**
+     * Kafka server port. Optional parameter with defaults.
+     */
+    @DefaultValue("" + DEFAULT_KAFKA_PORT)
+    int getKafkaPort();
+
+    /**
+     * Kafka reconnect retry interval. Optional parameter with defaults.
+     */
+    @DefaultValue("" + DEFAULT_RETRY_INTERVAL_MS)
+    long getRetryIntervalMs();
+
+    /**
+     * Audit record queue size. Optional parameter with defaults.
+     */
+    @DefaultValue("" + DEFAULT_MAX_QUEUE_SIZE)
+    int getMaxQueueSize();
+}

--- a/eureka2-ext/eureka2-kafka/src/main/java/com/netflix/eureka2/server/audit/kafka/config/bean/KafkaAuditServiceConfigBean.java
+++ b/eureka2-ext/eureka2-kafka/src/main/java/com/netflix/eureka2/server/audit/kafka/config/bean/KafkaAuditServiceConfigBean.java
@@ -1,0 +1,106 @@
+package com.netflix.eureka2.server.audit.kafka.config.bean;
+
+import com.netflix.eureka2.server.audit.kafka.config.KafkaAuditServiceConfig;
+
+/**
+ * @author David Liu
+ */
+public class KafkaAuditServiceConfigBean implements KafkaAuditServiceConfig {
+
+    private final String kafkaServerList;
+    private final String kafkaVip;
+    private final String kafkaTopic;
+    private final int kafkaPort;
+    private final long retryIntervalMs;
+    private final int maxQueueSize;
+
+    public KafkaAuditServiceConfigBean(String kafkaServerList,
+                                       String kafkaVip,
+                                       String kafkaTopic,
+                                       int kafkaPort,
+                                       long retryIntervalMs,
+                                       int maxQueueSize) {
+        this.kafkaServerList = kafkaServerList;
+        this.kafkaVip = kafkaVip;
+        this.kafkaTopic = kafkaTopic;
+        this.kafkaPort = kafkaPort;
+        this.retryIntervalMs = retryIntervalMs;
+        this.maxQueueSize = maxQueueSize;
+    }
+
+    @Override
+    public String getServerList() {
+        return kafkaServerList;
+    }
+
+    @Override
+    public String getKafkaVip() {
+        return kafkaVip;
+    }
+
+    @Override
+    public String getKafkaTopic() {
+        return kafkaTopic;
+    }
+
+    @Override
+    public int getKafkaPort() {
+        return kafkaPort;
+    }
+
+    @Override
+    public long getRetryIntervalMs() {
+        return retryIntervalMs;
+    }
+
+    @Override
+    public int getMaxQueueSize() {
+        return maxQueueSize;
+    }
+
+    public static Builder anKafkaAuditServiceConfig() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String kafkaServerList;
+        private String kafkaVip;
+        private String kafkaTopic;
+        private int kafkaPort = KafkaAuditServiceConfig.DEFAULT_KAFKA_PORT;
+        private long retryIntervalMs = KafkaAuditServiceConfig.DEFAULT_RETRY_INTERVAL_MS;
+        private int maxQueueSize = KafkaAuditServiceConfig.DEFAULT_MAX_QUEUE_SIZE;
+
+        private Builder() {}
+
+        public Builder withKafkaServerList(String kafkaServerList) {
+            this.kafkaServerList = kafkaServerList;
+            return this;
+        }
+        public Builder withKafkaVip(String kafkaVip) {
+            this.kafkaVip = kafkaVip;
+            return this;
+        }
+        public Builder withKafkaTopic(String kafkaTopic) {
+            this.kafkaTopic = kafkaTopic;
+            return this;
+        }
+        public Builder withKafkaPort(int kafkaPort) {
+            this.kafkaPort = kafkaPort;
+            return this;
+        }
+        public Builder withRetryIntervalMs(long retryIntervalMs) {
+            this.retryIntervalMs = retryIntervalMs;
+            return this;
+        }
+        public Builder withMaxQueueSize(int maxQueueSize) {
+            this.maxQueueSize = maxQueueSize;
+            return this;
+        }
+
+        public KafkaAuditServiceConfig build() {
+            KafkaAuditServiceConfig configBean = new KafkaAuditServiceConfigBean(
+                    kafkaServerList, kafkaVip, kafkaTopic, kafkaPort, retryIntervalMs, maxQueueSize);
+            return configBean;
+        }
+    }
+}

--- a/eureka2-ext/eureka2-kafka/src/test/java/com/netflix/eureka2/server/audit/kafka/KafkaAuditServiceTest.java
+++ b/eureka2-ext/eureka2-kafka/src/test/java/com/netflix/eureka2/server/audit/kafka/KafkaAuditServiceTest.java
@@ -20,15 +20,15 @@ import java.util.ServiceLoader;
 
 import com.google.inject.Module;
 import com.netflix.eureka2.server.audit.AuditRecord;
+import com.netflix.eureka2.server.audit.kafka.config.KafkaAuditServiceConfig;
 import com.netflix.eureka2.server.spi.ExtAbstractModule;
 import com.netflix.eureka2.testkit.data.builder.SampleAuditRecord;
 import org.junit.After;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import static java.lang.String.format;
+import static com.netflix.eureka2.server.audit.kafka.config.bean.KafkaAuditServiceConfigBean.*;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * @author Tomasz Bak
@@ -38,16 +38,10 @@ public class KafkaAuditServiceTest {
     private KafkaAuditService auditService;
 
     public void setUpAuditService() throws Exception {
-        String kafkaPropertyValue = System.getProperty(KafkaAuditConfig.KAFKA_SERVERS_KEY);
-        if (kafkaPropertyValue == null) {
-            fail(format("This is integration test and requires that system property %s is set", KafkaAuditConfig.KAFKA_SERVERS_KEY));
-        }
-        String kafkaTopic = System.getProperty(KafkaAuditConfig.KAFKA_TOPIC_KEY);
-        if (kafkaTopic == null) {
-            fail(format("This is integration test and requires that system property %s is set", KafkaAuditConfig.KAFKA_TOPIC_KEY));
-        }
-        KafkaAuditConfig config = new KafkaAuditConfig(kafkaPropertyValue, null, -1, kafkaTopic,
-                KafkaAuditConfig.DEFAULT_RETRY_INTERVAL_MS, KafkaAuditConfig.DEFAULT_MAX_QUEUE_SIZE);
+        KafkaAuditServiceConfig config = anKafkaAuditServiceConfig()
+                .withKafkaServerList("localhost:7101")
+                .withKafkaTopic("myTopic")
+                .build();
         KafkaServersProvider kafkaServersProvider = new KafkaServersProvider(null, config);
         auditService = new KafkaAuditService(null, config, kafkaServersProvider);
         auditService.start();
@@ -60,6 +54,8 @@ public class KafkaAuditServiceTest {
         }
     }
 
+    // TODO obsolete as we now use governator profiles for loading
+    @Ignore
     @Test(timeout = 60000)
     public void testServiceLoadBootstrapping() throws Exception {
         ServiceLoader<ExtAbstractModule> loader = ServiceLoader.load(ExtAbstractModule.class);

--- a/eureka2-ext/eureka2-karyon-admin/build.gradle
+++ b/eureka2-ext/eureka2-karyon-admin/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     compile project(':eureka2-client')
     compile project(':eureka2-server')
     compile "org.codehaus.jettison:jettison:${jettison_version}"
-    compile "com.netflix.karyon:karyon2-admin-web:${karyon_version}"
+    compile "com.netflix.karyon:karyon2-admin-web:${karyon2_version}"
     testCompile project(':eureka2-test-utils')
 }
 

--- a/eureka2-ext/eureka2-karyon-admin/src/main/java/netflix/adminresources/resources/eureka/registry/InstanceRegistryCache.java
+++ b/eureka2-ext/eureka2-karyon-admin/src/main/java/netflix/adminresources/resources/eureka/registry/InstanceRegistryCache.java
@@ -1,23 +1,25 @@
 package netflix.adminresources.resources.eureka.registry;
 
 import javax.annotation.PostConstruct;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import com.netflix.eureka2.client.EurekaInterestClient;
-import com.netflix.eureka2.client.Eurekas;
-import com.netflix.eureka2.client.resolver.ServerResolver;
-import com.netflix.eureka2.client.resolver.ServerResolvers;
 import com.netflix.eureka2.interests.ChangeNotification;
 import com.netflix.eureka2.interests.Interests;
 import com.netflix.eureka2.registry.instance.InstanceInfo;
 import com.netflix.eureka2.server.AbstractEurekaServer;
+import com.netflix.eureka2.utils.rx.RetryStrategyFunc;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import rx.functions.Action1;
 
 @Singleton
 public class InstanceRegistryCache {
+    private static final Logger logger = LoggerFactory.getLogger(InstanceRegistryCache.class);
 
     private final Map<String, InstanceInfoSummary> registryCache;
     private final AbstractEurekaServer eurekaServer;
@@ -25,29 +27,36 @@ public class InstanceRegistryCache {
     @Inject
     public InstanceRegistryCache(AbstractEurekaServer eurekaServer) {
         this.eurekaServer = eurekaServer;
-        registryCache = new ConcurrentHashMap<>();
+        this.registryCache = new ConcurrentHashMap<>();
     }
 
     public Map<String, InstanceInfoSummary> get() {
-        return registryCache;
+        return new HashMap<>(registryCache);
     }
 
     @PostConstruct
     public void start() {
-        ServerResolver resolver = ServerResolvers.fromHostname("localhost").withPort(eurekaServer.getInterestPort());
-        EurekaInterestClient interestClient = Eurekas.newInterestClientBuilder().withServerResolver(resolver).build();
-        interestClient.forInterest(Interests.forFullRegistry()).retry().subscribe(new Action1<ChangeNotification<InstanceInfo>>() {
-            @Override
-            public void call(ChangeNotification<InstanceInfo> changeNotification) {
-                final ChangeNotification.Kind notificationKind = changeNotification.getKind();
-                final InstanceInfo instInfo = changeNotification.getData();
-                if (notificationKind == ChangeNotification.Kind.Add ||
-                        notificationKind == ChangeNotification.Kind.Modify) {
-                    registryCache.put(instInfo.getId(), new InstanceInfoSummary(instInfo));
-                } else if (notificationKind == ChangeNotification.Kind.Delete) {
-                    registryCache.remove(instInfo.getId());
-                }
-            }
-        });
+        eurekaServer.getEurekaServerRegistry().forInterest(Interests.forFullRegistry())
+                .doOnError(new Action1<Throwable>() {
+                    @Override
+                    public void call(Throwable throwable) {
+                        logger.warn("forInterest to the registry failed", throwable);
+                        registryCache.clear();  // clear the cache of any stale entries, the retry should repopulate
+                    }
+                })
+                .retryWhen(new RetryStrategyFunc(30, TimeUnit.SECONDS))
+                .subscribe(new Action1<ChangeNotification<InstanceInfo>>() {
+                    @Override
+                    public void call(ChangeNotification<InstanceInfo> changeNotification) {
+                        final ChangeNotification.Kind notificationKind = changeNotification.getKind();
+                        final InstanceInfo instInfo = changeNotification.getData();
+                        if (notificationKind == ChangeNotification.Kind.Add ||
+                                notificationKind == ChangeNotification.Kind.Modify) {
+                            registryCache.put(instInfo.getId(), new InstanceInfoSummary(instInfo));
+                        } else if (notificationKind == ChangeNotification.Kind.Delete) {
+                            registryCache.remove(instInfo.getId());
+                        }
+                    }
+                });
     }
 }

--- a/eureka2-read-server/build.gradle
+++ b/eureka2-read-server/build.gradle
@@ -31,7 +31,7 @@ jar {
     }
 }
 
-mainClassName = "com.netflix.eureka2.server.EurekaReadServer"
+mainClassName = "com.netflix.eureka2.server.EurekaReadServerRunner"
 applicationDefaultJvmArgs = ["-Xms2g",
                              "-Xmx4g",
 //                             "-Dcom.sun.management.jmxremote",

--- a/eureka2-read-server/src/main/java/com/netflix/eureka2/server/EurekaReadServerConfigurationModule.java
+++ b/eureka2-read-server/src/main/java/com/netflix/eureka2/server/EurekaReadServerConfigurationModule.java
@@ -13,6 +13,10 @@ import com.netflix.eureka2.server.module.ServerConfigurationModule;
  */
 public abstract class EurekaReadServerConfigurationModule extends ServerConfigurationModule<EurekaServerConfig> {
 
+    public static Module fromArchaius() {
+        return fromArchaius(DEFAULT_CONFIG_PREFIX);
+    }
+
     public static Module fromArchaius(final String prefix) {
         return new EurekaReadServerConfigurationModule() {
             @Provides

--- a/eureka2-read-server/src/main/java/com/netflix/eureka2/server/EurekaReadServerRunner.java
+++ b/eureka2-read-server/src/main/java/com/netflix/eureka2/server/EurekaReadServerRunner.java
@@ -16,25 +16,21 @@
 
 package com.netflix.eureka2.server;
 
-import com.google.inject.AbstractModule;
 import com.google.inject.Module;
-import com.google.inject.util.Modules;
-import com.netflix.archaius.inject.ApplicationLayer;
 import com.netflix.eureka2.server.config.EurekaServerConfig;
 import com.netflix.eureka2.server.module.CommonEurekaServerModule;
 import com.netflix.eureka2.server.spi.ExtAbstractModule;
 import com.netflix.eureka2.server.spi.ExtAbstractModule.ServerType;
-import com.netflix.governator.DefaultGovernatorConfiguration;
-import com.netflix.governator.Governator;
 import com.netflix.governator.LifecycleInjector;
 import com.netflix.governator.auto.ModuleListProviders;
+import com.netflix.karyon.DefaultKaryonConfiguration;
+import com.netflix.karyon.Karyon;
+import com.netflix.karyon.archaius.ArchaiusKaryonConfiguration;
 import netflix.adminresources.resources.KaryonWebAdminModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
-
-import static com.netflix.eureka2.server.config.ServerConfigurationNames.DEFAULT_CONFIG_PREFIX;
 
 /**
  * @author Tomasz Bak
@@ -56,22 +52,9 @@ public class EurekaReadServerRunner extends EurekaServerRunner<EurekaReadServer>
 
     @Override
     protected List<Module> getModules() {
-        Module configModule;
-
-        if (config == null && name == null) {
-            configModule = EurekaReadServerConfigurationModule.fromArchaius(DEFAULT_CONFIG_PREFIX);
-        } else if (config == null) {  // have name
-            configModule = Modules
-                    .override(EurekaReadServerConfigurationModule.fromArchaius(DEFAULT_CONFIG_PREFIX))
-                    .with(new AbstractModule() {
-                        @Override
-                        protected void configure() {
-                            bind(String.class).annotatedWith(ApplicationLayer.class).toInstance(name);
-                        }
-                    });
-        } else {  // have config
-            configModule = EurekaReadServerConfigurationModule.fromConfig(config);
-        }
+        Module configModule = (config == null)
+                ? EurekaReadServerConfigurationModule.fromArchaius()
+                : EurekaReadServerConfigurationModule.fromConfig(config);
 
         return asList(
                 configModule,
@@ -83,11 +66,16 @@ public class EurekaReadServerRunner extends EurekaServerRunner<EurekaReadServer>
 
     @Override
     protected LifecycleInjector createInjector() {
-        return Governator.createInjector(
-                DefaultGovernatorConfiguration.builder()
-                        .addProfile(ServerType.Read.name())
-                        .addModuleListProvider(ModuleListProviders.forServiceLoader(ExtAbstractModule.class))
-                        .build(),
+        DefaultKaryonConfiguration.Builder configurationBuilder = (name == null)
+                ? ArchaiusKaryonConfiguration.builder()
+                : ArchaiusKaryonConfiguration.builder().withConfigName(name);
+
+        configurationBuilder
+                .addProfile(ServerType.Read.name())
+                .addModuleListProvider(ModuleListProviders.forServiceLoader(ExtAbstractModule.class));
+
+        return Karyon.createInjector(
+                configurationBuilder.build(),
                 getModules()
         );
     }

--- a/eureka2-server/build.gradle
+++ b/eureka2-server/build.gradle
@@ -20,22 +20,21 @@ dependencies {
     compile project(':eureka2-core')
     compile project(':eureka2-metrics-spectator')
 
-    compile "org.slf4j:slf4j-simple:${slf4j_version}"
-
     compile "org.codehaus.jettison:jettison:${jettison_version}"
-    compile "com.netflix.archaius:archaius2-guice:${archaius2_version}"
-    compile "com.netflix.archaius:archaius2-archaius1-bridge:${archaius2_version}"
-    compile "com.netflix.governator:governator:${governator_version}" // Required by Karyon admin
-    compile "com.netflix.governator:governator-core:${governator_version}"
+
+    compile "com.netflix.karyon:karyon3-core:${karyon3_version}"
+    compile "com.netflix.karyon:karyon3-archaius2:${karyon3_version}"
     compile "io.reactivex:rxnetty-spectator:${rxnetty_version}"
 
-    compile "com.netflix.karyon:karyon2-core:${karyon_version}"
-    compile("com.netflix.karyon:karyon2-admin-web:${karyon_version}") {
+    // FIXME Depend on karyon2 for the healthcheck framework and the admin console. Switch over to karyon3
+    // once the equivalent is ready.
+    compile "com.netflix.karyon:karyon2-core:${karyon2_version}"
+    compile("com.netflix.karyon:karyon2-admin-web:${karyon2_version}") {
         exclude module: 'eureka-client'
     }
     compile "commons-codec:commons-codec:${commons_codec_version}"
 
-    compile "com.netflix.servo:servo-core:${servo_version}"
+    runtime "org.slf4j:slf4j-simple:${slf4j_version}"
 
     testCompile project(':eureka2-test-utils')
 }

--- a/eureka2-server/src/main/java/com/netflix/eureka2/server/AbstractEurekaServer.java
+++ b/eureka2-server/src/main/java/com/netflix/eureka2/server/AbstractEurekaServer.java
@@ -14,7 +14,7 @@ import netflix.adminresources.AdminResourcesContainer;
 /**
  * @author Tomasz Bak
  */
-public class AbstractEurekaServer {
+public abstract class AbstractEurekaServer {
 
     protected final Injector injector;
 

--- a/eureka2-server/src/main/java/com/netflix/eureka2/server/module/ServerConfigurationModule.java
+++ b/eureka2-server/src/main/java/com/netflix/eureka2/server/module/ServerConfigurationModule.java
@@ -17,6 +17,8 @@ import javax.inject.Singleton;
  */
 public abstract class ServerConfigurationModule<T extends EurekaServerConfig> extends AbstractModule {
 
+    protected static final String DEFAULT_CONFIG_PREFIX = "eureka2.";
+
     @Override
     protected void configure() {
         install(new ArchaiusModule());

--- a/eureka2-testkit/build.gradle
+++ b/eureka2-testkit/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     compile project(':eureka2-read-server')
     compile project(':eureka2-write-server')
     compile project(':eureka2-dashboard')
-    compile "com.netflix.karyon:karyon2-admin-healthcheck-plugin:${karyon_version}"
+    compile "com.netflix.karyon:karyon2-admin-healthcheck-plugin:${karyon2_version}"
     compile project(':eureka2-ext:eureka2-karyon-admin')
     compile project(':eureka2-ext:eureka2-eureka1-rest-api')
     compile "jline:jline:${jline_version}"

--- a/eureka2-write-server/build.gradle
+++ b/eureka2-write-server/build.gradle
@@ -23,6 +23,7 @@ configurations {
 
 dependencies {
     compile project(':eureka2-server')
+    compile project(':eureka2-ext:eureka2-karyon-admin')
     testCompile project(':eureka2-test-utils')
 }
 

--- a/eureka2-write-server/build.gradle
+++ b/eureka2-write-server/build.gradle
@@ -23,7 +23,6 @@ configurations {
 
 dependencies {
     compile project(':eureka2-server')
-    compile project(':eureka2-ext:eureka2-karyon-admin')
     testCompile project(':eureka2-test-utils')
 }
 

--- a/eureka2-write-server/build.gradle
+++ b/eureka2-write-server/build.gradle
@@ -35,7 +35,7 @@ jar {
     }
 }
 
-mainClassName = "com.netflix.eureka2.server.EurekaWriteServer"
+mainClassName = "com.netflix.eureka2.server.EurekaWriteServerRunner"
 applicationDefaultJvmArgs = ["-Xms2g",
                              "-Xmx4g",
                              "-XX:+UseConcMarkSweepGC",

--- a/eureka2-write-server/src/main/java/com/netflix/eureka2/server/EurekaWriteServerConfigurationModule.java
+++ b/eureka2-write-server/src/main/java/com/netflix/eureka2/server/EurekaWriteServerConfigurationModule.java
@@ -27,6 +27,10 @@ public abstract class EurekaWriteServerConfigurationModule extends ServerConfigu
         return rootConfig.getBootstrap();
     }
 
+    public static Module fromArchaius() {
+        return fromArchaius(DEFAULT_CONFIG_PREFIX);
+    }
+
     public static Module fromArchaius(final String prefix) {
         return new EurekaWriteServerConfigurationModule() {
             @Provides

--- a/eureka2-write-server/src/main/java/com/netflix/eureka2/server/EurekaWriteServerRunner.java
+++ b/eureka2-write-server/src/main/java/com/netflix/eureka2/server/EurekaWriteServerRunner.java
@@ -16,25 +16,21 @@
 
 package com.netflix.eureka2.server;
 
-import com.google.inject.AbstractModule;
 import com.google.inject.Module;
-import com.google.inject.util.Modules;
-import com.netflix.archaius.inject.ApplicationLayer;
 import com.netflix.eureka2.server.config.WriteServerConfig;
 import com.netflix.eureka2.server.module.CommonEurekaServerModule;
 import com.netflix.eureka2.server.spi.ExtAbstractModule;
 import com.netflix.eureka2.server.spi.ExtAbstractModule.ServerType;
-import com.netflix.governator.DefaultGovernatorConfiguration;
-import com.netflix.governator.Governator;
 import com.netflix.governator.LifecycleInjector;
 import com.netflix.governator.auto.ModuleListProviders;
+import com.netflix.karyon.DefaultKaryonConfiguration;
+import com.netflix.karyon.Karyon;
+import com.netflix.karyon.archaius.ArchaiusKaryonConfiguration;
 import netflix.adminresources.resources.KaryonWebAdminModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
-
-import static com.netflix.eureka2.server.config.ServerConfigurationNames.DEFAULT_CONFIG_PREFIX;
 
 /**
  * @author Tomasz Bak
@@ -57,22 +53,9 @@ public class EurekaWriteServerRunner extends EurekaServerRunner<EurekaWriteServe
 
     @Override
     protected List<Module> getModules() {
-        Module configModule;
-
-        if (config == null && name == null) {
-            configModule = EurekaWriteServerConfigurationModule.fromArchaius(DEFAULT_CONFIG_PREFIX);
-        } else if (config == null) {  // have name
-            configModule = Modules
-                    .override(EurekaWriteServerConfigurationModule.fromArchaius(DEFAULT_CONFIG_PREFIX))
-                    .with(new AbstractModule() {
-                        @Override
-                        protected void configure() {
-                            bind(String.class).annotatedWith(ApplicationLayer.class).toInstance(name);
-                        }
-                    });
-        } else {  // have config
-            configModule = EurekaWriteServerConfigurationModule.fromConfig(config);
-        }
+        Module configModule = (config == null)
+                ? EurekaWriteServerConfigurationModule.fromArchaius()
+                : EurekaWriteServerConfigurationModule.fromConfig(config);
 
         return asList(
                 configModule,
@@ -84,12 +67,16 @@ public class EurekaWriteServerRunner extends EurekaServerRunner<EurekaWriteServe
 
     @Override
     protected LifecycleInjector createInjector() {
+        DefaultKaryonConfiguration.Builder configurationBuilder = (name == null)
+                ? ArchaiusKaryonConfiguration.builder()
+                : ArchaiusKaryonConfiguration.builder().withConfigName(name);
 
-        return Governator.createInjector(
-                DefaultGovernatorConfiguration.builder()
-                        .addProfile(ServerType.Write.name())
-                        .addModuleListProvider(ModuleListProviders.forServiceLoader(ExtAbstractModule.class))
-                        .build(),
+        configurationBuilder
+                .addProfile(ServerType.Write.name())
+                .addModuleListProvider(ModuleListProviders.forServiceLoader(ExtAbstractModule.class));
+
+        return Karyon.createInjector(
+                configurationBuilder.build(),
                 getModules()
         );
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,21 +1,24 @@
 org.gradle.jvmargs=-XX:MaxPermSize=512m
 
 slf4j_version=1.7.7
+log4j2_version=2.3
 javax_inject_version=1
 commons_cli_version=1.2
 rxjava_version=1.0.12
 rxnetty_version=0.4.10
-karyon_version=2.7.1
+karyon2_version=2.7.1
+karyon3_version=3.0.1-rc.2
 servo_version=0.8.0
 spectator_version=0.20.0
 archaius2_version=2.0.0-rc.21
 governator_version=1.7.6-rc.4
 avro_version=1.7.7
-kafka_version=0.8.1.1
+kafka_version=0.8.2.1
 commons_codec_version=1.7
 commons_compress_version=1.7
 eureka_v1_version=1.1.157
 jettison_version=1.2
+jersey_version=1.19
 aws_version=1.9.16
 
 #shading dependencies


### PR DESCRIPTION
 - use karyon3 for consolidated config loading across modules and extModules
 - switch kafka dep to kafka-clients and other dependency clean ups
 - update eureka2-kafka to use latest archaius for config loading
 - update gradle runners
 - change admin eureka2 view to read directly from registry