### PR TITLE
Add the ability to use additional Jersey ClientFilters in the DiscoveryClient

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/DiscoveryManager.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DiscoveryManager.java
@@ -19,6 +19,7 @@ package com.netflix.discovery;
 import com.netflix.appinfo.ApplicationInfoManager;
 import com.netflix.appinfo.EurekaInstanceConfig;
 import com.netflix.appinfo.InstanceInfo;
+import com.netflix.discovery.DiscoveryClient.DiscoveryClientOptionalArgs;
 import com.netflix.discovery.shared.LookupService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,7 +76,7 @@ public class DiscoveryManager {
      * @param eurekaConfig the eureka client configuration of the instance.
      */
     public void initComponent(EurekaInstanceConfig config,
-                              EurekaClientConfig eurekaConfig) {
+                              EurekaClientConfig eurekaConfig, DiscoveryClientOptionalArgs args) {
         this.eurekaInstanceConfig = config;
         this.eurekaClientConfig = eurekaConfig;
         if (ApplicationInfoManager.getInstance().getInfo() == null) {
@@ -83,7 +84,12 @@ public class DiscoveryManager {
             ApplicationInfoManager.getInstance().initComponent(config);
         }
         InstanceInfo info = ApplicationInfoManager.getInstance().getInfo();
-        discoveryClient = new DiscoveryClient(info, eurekaConfig);
+        discoveryClient = new DiscoveryClient(info, eurekaConfig, args);
+    }
+    
+    public void initComponent(EurekaInstanceConfig config,
+            EurekaClientConfig eurekaConfig) {
+        initComponent(config, eurekaConfig, null);
     }
 
     /**


### PR DESCRIPTION
So we can do things like add Authorization headers and authenticate those on the Eureka Server