### PR TITLE
EurekaNameSpace not used in eureka.region

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/DefaultEurekaClientConfig.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DefaultEurekaClientConfig.java
@@ -359,7 +359,7 @@ public class DefaultEurekaClientConfig implements EurekaClientConfig {
      */
     @Override
     public String getRegion() {
-        return configInstance.getStringProperty("eureka.region", "us-east-1")
+        return configInstance.getStringProperty(namespace + "region", "us-east-1")
                 .get();
     }
 

--- a/eureka-client/src/main/java/com/netflix/discovery/DefaultEurekaClientConfig.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DefaultEurekaClientConfig.java
@@ -359,8 +359,8 @@ public class DefaultEurekaClientConfig implements EurekaClientConfig {
      */
     @Override
     public String getRegion() {
-        return configInstance.getStringProperty(namespace + "region", "us-east-1")
-                .get();
+        DynamicStringProperty defaultEurekaRegion = configInstance.getStringProperty("eureka.region", "us-east-1");
+        return configInstance.getStringProperty(namespace + "region", defaultEurekaRegion.get()).get();
     }
 
     /*


### PR DESCRIPTION
Hello,

I've seen that the eureka.region property in DefaultEurekaClientConfig.class it's not tied to the namespace, and when using a different namespace there is the need to hardcode this property.

Regards,
Jaume