### PR TITLE
Properly unregister Servo monitors on shutdown

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/util/EurekaMonitors.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/util/EurekaMonitors.java
@@ -181,7 +181,7 @@ public enum EurekaMonitors {
     public static void shutdown() {
         for (EurekaMonitors c : EurekaMonitors.values()) {
             DefaultMonitorRegistry.getInstance().unregister(
-                    Monitors.newObjectMonitor(c.name(), c));
+                    Monitors.newObjectMonitor(c.getName(), c));
         }
     }
 }


### PR DESCRIPTION
Fix for https://github.com/Netflix/eureka/issues/638