### PR TITLE
Enable custom metadata-aware DataCenterInfo implementations

### DIFF
--- a/eureka-client/src/main/java/com/netflix/appinfo/AbstractInstanceConfig.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/AbstractInstanceConfig.java
@@ -46,12 +46,7 @@ public abstract class AbstractInstanceConfig implements EurekaInstanceConfig {
     private static final int SECURE_PORT = 443;
     private static final boolean INSTANCE_ENABLED_ON_INIT = false;
     private static final Pair<String, String> hostInfo = getHostInfo();
-    private DataCenterInfo info = new DataCenterInfo() {
-        @Override
-        public Name getName() {
-            return Name.MyOwn;
-        }
-    };
+    private DataCenterInfo info = new MyDataCenterInfo();
 
     protected AbstractInstanceConfig() {
 

--- a/eureka-client/src/main/java/com/netflix/appinfo/AmazonInfo.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/AmazonInfo.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
  *
  */
 @JsonDeserialize(builder = StringInterningAmazonInfoBuilder.class)
-public class AmazonInfo implements DataCenterInfo, UniqueIdentifier {
+public class AmazonInfo implements DataCenterInfo, UniqueIdentifier, MetadataAware {
 
     private Map<String, String> metadata = new HashMap<String, String>();
     private static DynamicBooleanProperty shouldLogAWSMetadataError;
@@ -284,6 +284,7 @@ public class AmazonInfo implements DataCenterInfo, UniqueIdentifier {
      *
      * @return the map of AWS metadata as specified by {@link MetaDataKey}.
      */
+    @Override
     @JsonProperty("metadata")
     public Map<String, String> getMetadata() {
         return metadata;
@@ -295,6 +296,7 @@ public class AmazonInfo implements DataCenterInfo, UniqueIdentifier {
      * @param metadataMap
      *            the map containing AWS metadata.
      */
+    @Override
     public void setMetadata(Map<String, String> metadataMap) {
         this.metadata = metadataMap;
     }

--- a/eureka-client/src/main/java/com/netflix/appinfo/InstanceInfo.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/InstanceInfo.java
@@ -858,7 +858,8 @@ public class InstanceInfo {
     @JsonIgnore
     public String getId() {
         if (dataCenterInfo instanceof UniqueIdentifier) {
-            return ((UniqueIdentifier) dataCenterInfo).getId();
+            String id = ((UniqueIdentifier) dataCenterInfo).getId();
+            return id != null ? id : hostName;
         } else {
             return hostName;
         }

--- a/eureka-client/src/main/java/com/netflix/appinfo/MetadataAware.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/MetadataAware.java
@@ -1,0 +1,8 @@
+package com.netflix.appinfo;
+
+import java.util.Map;
+
+public interface MetadataAware {
+    Map<String, String> getMetadata();
+    void setMetadata(Map<String, String> metadata);
+}

--- a/eureka-client/src/main/java/com/netflix/appinfo/MyDataCenterInfo.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/MyDataCenterInfo.java
@@ -1,13 +1,16 @@
 package com.netflix.appinfo;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Map;
 
 /**
  * @author Tomasz Bak
  */
-public class MyDataCenterInfo implements DataCenterInfo, MetadataAware {
+public class MyDataCenterInfo implements DataCenterInfo, MetadataAware, UniqueIdentifier {
     private Name name = Name.MyOwn;
+    private String id;
     private Map<String, String> metadata = Collections.emptyMap();
 
     public MyDataCenterInfo() {}
@@ -31,7 +34,17 @@ public class MyDataCenterInfo implements DataCenterInfo, MetadataAware {
     }
 
     @Override
-    public void setMetadata(Map<String, String> metadata) {
+    public void setMetadata(@Nonnull Map<String, String> metadata) {
         this.metadata = metadata;
+    }
+
+    @Nullable
+    @Override
+    public String getId() {
+        return this.id != null ? this.id : this.metadata.get("instance-id");
+    }
+
+    public void setId(String id) {
+        this.id = id;
     }
 }

--- a/eureka-client/src/main/java/com/netflix/appinfo/MyDataCenterInfo.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/MyDataCenterInfo.java
@@ -1,22 +1,37 @@
 package com.netflix.appinfo;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * @author Tomasz Bak
  */
-public class MyDataCenterInfo implements DataCenterInfo {
+public class MyDataCenterInfo implements DataCenterInfo, MetadataAware {
+    private Name name = Name.MyOwn;
+    private Map<String, String> metadata = Collections.emptyMap();
 
-    private final Name name;
+    public MyDataCenterInfo() {}
 
-    @JsonCreator
-    public MyDataCenterInfo(@JsonProperty("name") Name name) {
+    public MyDataCenterInfo(Name name) {
         this.name = name;
     }
 
     @Override
     public Name getName() {
         return name;
+    }
+
+    public void setName(Name name) {
+        this.name = name;
+    }
+
+    @Override
+    public Map<String, String> getMetadata() {
+        return metadata;
+    }
+
+    @Override
+    public void setMetadata(Map<String, String> metadata) {
+        this.metadata = metadata;
     }
 }

--- a/eureka-client/src/main/java/com/netflix/appinfo/UniqueIdentifier.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/UniqueIdentifier.java
@@ -1,10 +1,12 @@
 package com.netflix.appinfo;
 
+import javax.annotation.Nullable;
+
 /**
  * Generally indicates the unique identifier of a {@link com.netflix.appinfo.DataCenterInfo}, if applicable.
  *
  * @author rthomas@atlassian.com
  */
 public interface UniqueIdentifier {
-    String getId();
+    @Nullable String getId();
 }

--- a/eureka-client/src/test/java/com/netflix/appinfo/InstanceInfoTest.java
+++ b/eureka-client/src/test/java/com/netflix/appinfo/InstanceInfoTest.java
@@ -28,22 +28,13 @@ public class InstanceInfoTest {
 
     @Test
     public void testCopyConstructor() {
-
-        DataCenterInfo myDCI = new DataCenterInfo() {
-
-            public DataCenterInfo.Name getName() {
-                return DataCenterInfo.Name.MyOwn;
-            }
-
-        };
-
+        DataCenterInfo myDCI = new MyDataCenterInfo();
 
         InstanceInfo smallII1 = newBuilder().setAppName("test").setDataCenterInfo(myDCI).build();
         InstanceInfo smallII2 = new InstanceInfo(smallII1);
 
         assertNotSame(smallII1, smallII2);
         Assert.assertEquals(smallII1, smallII2);
-
 
         InstanceInfo fullII1 = newBuilder().setMetadata(null)
                 .setOverriddenStatus(InstanceInfo.InstanceStatus.UNKNOWN)

--- a/eureka-client/src/test/java/com/netflix/discovery/converters/EurekaJsonAndXmlJacksonCodecTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/converters/EurekaJsonAndXmlJacksonCodecTest.java
@@ -3,12 +3,9 @@ package com.netflix.discovery.converters;
 import java.util.Iterator;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.netflix.appinfo.AmazonInfo;
+import com.netflix.appinfo.*;
 import com.netflix.appinfo.AmazonInfo.MetaDataKey;
-import com.netflix.appinfo.DataCenterInfo;
 import com.netflix.appinfo.DataCenterInfo.Name;
-import com.netflix.appinfo.InstanceInfo;
-import com.netflix.appinfo.LeaseInfo;
 import com.netflix.discovery.converters.jackson.EurekaJsonJacksonCodec;
 import com.netflix.discovery.converters.jackson.EurekaXmlJacksonCodec;
 import com.netflix.discovery.shared.Application;
@@ -77,12 +74,7 @@ public class EurekaJsonAndXmlJacksonCodecTest {
     }
 
     private void doMyDataCenterInfoEncodeDecodeTest(ObjectMapper mapper) throws Exception {
-        DataCenterInfo myDataCenterInfo = new DataCenterInfo() {
-            @Override
-            public Name getName() {
-                return Name.MyOwn;
-            }
-        };
+        DataCenterInfo myDataCenterInfo = new MyDataCenterInfo();
 
         String encodedString = mapper.writeValueAsString(myDataCenterInfo);
         DataCenterInfo decodedValue = mapper.readValue(encodedString, DataCenterInfo.class);


### PR DESCRIPTION
Currently, `DataCenterInfo` metadata is only serialized/deserialized if it is an instance of `AmazonInfo`.  It is sometimes useful to be able to hang metadata on non-AmazonInfo `DataCenterInfo` instances (e.g. MyDataCenterInfo) as well.

This PR introduces a new `MetadataAware` interface, and both `AmazonInfo` and `MyDataCenterInfo` are made to extend it.  Any `DataCenterInfo` implementation that is also `MetadataAware` will have its metadata serialized/deserialized.

Since `MyDataCenterInfo` did not previously support metadata, its metadata map is initialized to an empty map (effectively preserving its state prior to the PR).

This PR blocks progress in Spring Cloud Netflix on adoption of eureka-client 1.2.2 and later.  After merge, we can effectively get rid of the [custom codec](https://github.com/spring-cloud/spring-cloud-netflix/blob/master/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/eureka/DataCenterAwareJacksonCodec.java) in Spring Cloud Netflix.