### PR TITLE
1.x Client InstanceInfo default address resolution

### DIFF
--- a/eureka-client-archaius2/src/main/java/com/netflix/discovery/EurekaArchaius2InstanceConfig.java
+++ b/eureka-client-archaius2/src/main/java/com/netflix/discovery/EurekaArchaius2InstanceConfig.java
@@ -167,6 +167,12 @@ public class EurekaArchaius2InstanceConfig extends AbstractInstanceConfig {
     }
 
     @Override
+    public String[] getDefaultAddressResolutionOrder() {
+        String result = config.getString(namespace + "defaultAddressResolutionOrder", null);
+        return result == null ? new String[0] : result.split(",");
+    }
+
+    @Override
     public String getNamespace() {
         return namespace;
     }

--- a/eureka-client/src/main/java/com/netflix/appinfo/AmazonInfo.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/AmazonInfo.java
@@ -316,4 +316,29 @@ public class AmazonInfo implements DataCenterInfo, UniqueIdentifier {
     public String getId() {
         return get(MetaDataKey.instanceId);
     }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof AmazonInfo)) return false;
+
+        AmazonInfo that = (AmazonInfo) o;
+
+        if (metadata != null ? !metadata.equals(that.metadata) : that.metadata != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return metadata != null ? metadata.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "AmazonInfo{" +
+                "metadata=" + metadata +
+                '}';
+    }
 }

--- a/eureka-client/src/main/java/com/netflix/appinfo/ApplicationInfoManager.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/ApplicationInfoManager.java
@@ -146,17 +146,29 @@ public class ApplicationInfoManager {
      * Refetches the hostname to check if it has changed. If it has, the entire
      * <code>DataCenterInfo</code> is refetched and passed on to the eureka
      * server on next heartbeat.
+     *
+     * see {@link InstanceInfo#getDefaultAddress()} for explanation on why the hostname is used as the default address
      */
     public void refreshDataCenterInfoIfRequired() {
-        String existingHostname = instanceInfo.getHostName();
-        String newHostname = config.getHostName(true);
-        if (newHostname != null && !newHostname.equals(existingHostname)) {
-            logger.warn("The public hostname changed from : "
-                    + existingHostname + " => " + newHostname);
-            InstanceInfo.Builder builder = new InstanceInfo.Builder(
-                    instanceInfo);
-            builder.setHostName(newHostname).setDataCenterInfo(
-                    config.getDataCenterInfo());
+        String existingAddress = instanceInfo.getDefaultAddress();
+        DataCenterInfo dataCenterInfo = instanceInfo.getDataCenterInfo();
+
+        String newAddress;
+        if (config instanceof CloudInstanceConfig) {
+            newAddress = ((CloudInstanceConfig) config).resolveDefaultAddress(dataCenterInfo);
+        } else {
+            newAddress = config.getHostName(true);
+        }
+        String newIp = config.getIpAddress();
+
+        if (newAddress != null && !newAddress.equals(existingAddress)) {
+            logger.warn("The address changed from : {} => {}", existingAddress, newAddress);
+
+            // :( in the legacy code here the builder is acting as a mutator.
+            // This is hard to fix as this same instanceInfo instance is referenced elsewhere.
+            // We will most likely re-write the client at sometime so not fixing for now.
+            InstanceInfo.Builder builder = new InstanceInfo.Builder(instanceInfo);
+            builder.setHostName(newAddress).setIPAddr(newIp).setDataCenterInfo(config.getDataCenterInfo());
             instanceInfo.setIsDirty();
         }
     }
@@ -169,8 +181,7 @@ public class ApplicationInfoManager {
         int currentLeaseDuration = config.getLeaseExpirationDurationInSeconds();
         int currentLeaseRenewal = config.getLeaseRenewalIntervalInSeconds();
         if (leaseInfo.getDurationInSecs() != currentLeaseDuration || leaseInfo.getRenewalIntervalInSecs() != currentLeaseRenewal) {
-            LeaseInfo newLeaseInfo = LeaseInfo.Builder
-                    .newBuilder()
+            LeaseInfo newLeaseInfo = LeaseInfo.Builder.newBuilder()
                     .setRenewalIntervalInSecs(currentLeaseRenewal)
                     .setDurationInSecs(currentLeaseDuration)
                     .build();

--- a/eureka-client/src/main/java/com/netflix/appinfo/ApplicationInfoManager.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/ApplicationInfoManager.java
@@ -147,10 +147,10 @@ public class ApplicationInfoManager {
      * <code>DataCenterInfo</code> is refetched and passed on to the eureka
      * server on next heartbeat.
      *
-     * see {@link InstanceInfo#getDefaultAddress()} for explanation on why the hostname is used as the default address
+     * see {@link InstanceInfo#getHostName()} for explanation on why the hostname is used as the default address
      */
     public void refreshDataCenterInfoIfRequired() {
-        String existingAddress = instanceInfo.getDefaultAddress();
+        String existingAddress = instanceInfo.getHostName();
         DataCenterInfo dataCenterInfo = instanceInfo.getDataCenterInfo();
 
         String newAddress;

--- a/eureka-client/src/main/java/com/netflix/appinfo/EurekaInstanceConfig.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/EurekaInstanceConfig.java
@@ -351,6 +351,21 @@ public interface EurekaInstanceConfig {
     String getSecureHealthCheckUrl();
 
     /**
+     * An instance's network addresses should be fully expressed in it's {@link DataCenterInfo}.
+     * For example for instances in AWS, this will include the publicHostname, publicIp,
+     * privateHostname and privateIp, when available. The {@link com.netflix.appinfo.InstanceInfo}
+     * will further express a "default address", which is a field that can be configured by the
+     * registering instance to advertise it's default address. This configuration allowed
+     * for the expression of an ordered list of fields that can be used to resolve the default
+     * address. The exact field values will depend on the implementation details of the corresponding
+     * implementing DataCenterInfo types.
+     *
+     * @return an ordered list of fields that should be used to preferentially
+     *         resolve this instance's default address, empty String[] for default.
+     */
+    String[] getDefaultAddressResolutionOrder();
+
+    /**
      * Get the namespace used to find properties.
      * @return the namespace used to find properties.
      */

--- a/eureka-client/src/main/java/com/netflix/appinfo/InstanceInfo.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/InstanceInfo.java
@@ -861,6 +861,22 @@ public class InstanceInfo {
         return hostName;
     }
 
+    /**
+     * Return the default network address to connect to this instance.
+     *
+     * The address can either be a hostname or an ip and there is no guarantee which will be returned.
+     * Assume the address can change dynamically over time.
+     * If a usecase need more specific hostnames or ips, please use data from {@link #getDataCenterInfo()}.
+     *
+     * For legacy reasons, the data backing this field is extracted from the hostname field
+     *
+     * @return either a hostname or an ipAddress
+     */
+    @JsonIgnore
+    public String getDefaultAddress() {
+        return hostName;
+    }
+
     @Deprecated
     public void setSID(String sid) {
         this.sid = sid;

--- a/eureka-client/src/main/java/com/netflix/appinfo/InstanceInfo.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/InstanceInfo.java
@@ -852,28 +852,21 @@ public class InstanceInfo {
         return appGroupName;
     }
 
-    /**
-     * Returns the fully qualified hostname of this running instance.
-     *
-     * @return the hostname.
-     */
-    public String getHostName() {
-        return hostName;
-    }
 
     /**
-     * Return the default network address to connect to this instance.
+     * Return the default network address to connect to this instance. Typically this would be the fully
+     * qualified public hostname.
      *
-     * The address can either be a hostname or an ip and there is no guarantee which will be returned.
-     * Assume the address can change dynamically over time.
-     * If a usecase need more specific hostnames or ips, please use data from {@link #getDataCenterInfo()}.
+     * However the user can configure the {@link EurekaInstanceConfig} to change the default value used
+     * to populate this field using the {@link EurekaInstanceConfig#getDefaultAddressResolutionOrder()} property.
      *
-     * For legacy reasons, the data backing this field is extracted from the hostname field
+     * If a use case need more specific hostnames or ips, please use data from {@link #getDataCenterInfo()}.
      *
-     * @return either a hostname or an ipAddress
+     * For legacy reasons, it is difficult to introduce a new address-type field that is agnostic to hostname/ip.
+     *
+     * @return the default address (by default the public hostname)
      */
-    @JsonIgnore
-    public String getDefaultAddress() {
+    public String getHostName() {
         return hostName;
     }
 

--- a/eureka-client/src/main/java/com/netflix/appinfo/PropertiesInstanceConfig.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/PropertiesInstanceConfig.java
@@ -305,6 +305,12 @@ public abstract class PropertiesInstanceConfig extends AbstractInstanceConfig im
     }
 
     @Override
+    public String[] getDefaultAddressResolutionOrder() {
+        String result = INSTANCE.getStringProperty(namespace + "defaultAddressResolutionOrder", null).get();
+        return result == null ? new String[0] : result.split(",");
+    }
+
+    @Override
     public String getNamespace() {
         return this.namespace;
     }

--- a/eureka-client/src/main/java/com/netflix/appinfo/providers/EurekaConfigBasedInstanceInfoProvider.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/providers/EurekaConfigBasedInstanceInfoProvider.java
@@ -5,6 +5,7 @@ import javax.inject.Singleton;
 import java.util.Map;
 
 import com.google.inject.Provider;
+import com.netflix.appinfo.CloudInstanceConfig;
 import com.netflix.appinfo.DataCenterInfo;
 import com.netflix.appinfo.EurekaInstanceConfig;
 import com.netflix.appinfo.InstanceInfo;
@@ -60,13 +61,20 @@ public class EurekaConfigBasedInstanceInfoProvider implements Provider<InstanceI
                 }
             }
 
+            String defaultAddress;
+            if (config instanceof CloudInstanceConfig) {
+                defaultAddress = ((CloudInstanceConfig) config).resolveDefaultAddress(dataCenterInfo);
+            } else {
+                defaultAddress = config.getHostName(false);
+            }
+
             builder.setNamespace(config.getNamespace())
                     .setInstanceId(instanceId)
                     .setAppName(config.getAppname())
                     .setAppGroupName(config.getAppGroupName())
                     .setDataCenterInfo(config.getDataCenterInfo())
                     .setIPAddr(config.getIpAddress())
-                    .setHostName(config.getHostName(false))
+                    .setHostName(defaultAddress)
                     .setPort(config.getNonSecurePort())
                     .enablePort(PortType.UNSECURE, config.isNonSecurePortEnabled())
                     .setSecurePort(config.getSecurePort())

--- a/eureka-client/src/main/java/com/netflix/discovery/EurekaClientConfig.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/EurekaClientConfig.java
@@ -536,6 +536,10 @@ public interface EurekaClientConfig {
      */
     String getExperimental(String name);
 
-
+    /**
+     * For compatibility, return the transport layer config class
+     *
+     * @return an instance of {@link EurekaTransportConfig}
+     */
     EurekaTransportConfig getTransportConfig();
 }

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/transport/EurekaTransportConfig.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/transport/EurekaTransportConfig.java
@@ -1,6 +1,8 @@
 package com.netflix.discovery.shared.transport;
 
 /**
+ * Config class that governs configurations relevant to the transport layer
+ *
  * @author David Liu
  */
 public interface EurekaTransportConfig {

--- a/eureka-client/src/test/java/com/netflix/appinfo/ApplicationInfoManagerTest.java
+++ b/eureka-client/src/test/java/com/netflix/appinfo/ApplicationInfoManagerTest.java
@@ -50,12 +50,12 @@ public class ApplicationInfoManagerTest {
     public void testRefreshDataCenterInfoWithAmazonInfo() {
         AmazonInfo info = (AmazonInfo) instanceInfo.getDataCenterInfo();
         String newPublicHostname = "newValue";
-        assertThat(instanceInfo.getDefaultAddress(), is(not(newPublicHostname)));
+        assertThat(instanceInfo.getHostName(), is(not(newPublicHostname)));
 
         info.getMetadata().put(publicHostname.getName(), newPublicHostname);
         applicationInfoManager.refreshDataCenterInfoIfRequired();
 
-        assertThat(instanceInfo.getDefaultAddress(), is(newPublicHostname));
+        assertThat(instanceInfo.getHostName(), is(newPublicHostname));
     }
 
     @Test
@@ -68,6 +68,6 @@ public class ApplicationInfoManagerTest {
         assertThat(info, instanceOf(MyDataCenterInfo.class));
 
         applicationInfoManager.refreshDataCenterInfoIfRequired();
-        assertThat(instanceInfo.getDefaultAddress(), is(dummyDefault));
+        assertThat(instanceInfo.getHostName(), is(dummyDefault));
     }
 }

--- a/eureka-client/src/test/java/com/netflix/appinfo/ApplicationInfoManagerTest.java
+++ b/eureka-client/src/test/java/com/netflix/appinfo/ApplicationInfoManagerTest.java
@@ -1,7 +1,9 @@
 package com.netflix.appinfo;
 
 import com.netflix.discovery.util.InstanceInfoGenerator;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static com.netflix.appinfo.AmazonInfo.MetaDataKey.*;
@@ -18,16 +20,26 @@ import static org.mockito.Mockito.when;
  */
 public class ApplicationInfoManagerTest {
 
-    private EurekaInstanceConfig config = spy(new CloudInstanceConfig());
+    private CloudInstanceConfig config = spy(new CloudInstanceConfig());
     private String dummyDefault = "dummyDefault";
     private InstanceInfo instanceInfo;
     private ApplicationInfoManager applicationInfoManager;
+
+    @BeforeClass
+    public static void setUpClass() {
+        System.setProperty("eureka.validateInstanceId", "false");
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        System.clearProperty("eureka.validateInstanceId");
+    }
 
     @Before
     public void setUp() {
         instanceInfo = InstanceInfoGenerator.takeOne();
         this.applicationInfoManager = new ApplicationInfoManager(config, instanceInfo);
-        when(config.getDefaultAddressResolutionOrder()).thenReturn(new String[] {
+        when(config.getDefaultAddressResolutionOrder()).thenReturn(new String[]{
                 publicHostname.name(),
                 localIpv4.name()
         });

--- a/eureka-client/src/test/java/com/netflix/appinfo/ApplicationInfoManagerTest.java
+++ b/eureka-client/src/test/java/com/netflix/appinfo/ApplicationInfoManagerTest.java
@@ -1,0 +1,61 @@
+package com.netflix.appinfo;
+
+import com.netflix.discovery.util.InstanceInfoGenerator;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.netflix.appinfo.AmazonInfo.MetaDataKey.*;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author David Liu
+ */
+public class ApplicationInfoManagerTest {
+
+    private EurekaInstanceConfig config = spy(new CloudInstanceConfig());
+    private String dummyDefault = "dummyDefault";
+    private InstanceInfo instanceInfo;
+    private ApplicationInfoManager applicationInfoManager;
+
+    @Before
+    public void setUp() {
+        instanceInfo = InstanceInfoGenerator.takeOne();
+        this.applicationInfoManager = new ApplicationInfoManager(config, instanceInfo);
+        when(config.getDefaultAddressResolutionOrder()).thenReturn(new String[] {
+                publicHostname.name(),
+                localIpv4.name()
+        });
+        when(config.getHostName(anyBoolean())).thenReturn(dummyDefault);
+    }
+
+    @Test
+    public void testRefreshDataCenterInfoWithAmazonInfo() {
+        AmazonInfo info = (AmazonInfo) instanceInfo.getDataCenterInfo();
+        String newPublicHostname = "newValue";
+        assertThat(instanceInfo.getDefaultAddress(), is(not(newPublicHostname)));
+
+        info.getMetadata().put(publicHostname.getName(), newPublicHostname);
+        applicationInfoManager.refreshDataCenterInfoIfRequired();
+
+        assertThat(instanceInfo.getDefaultAddress(), is(newPublicHostname));
+    }
+
+    @Test
+    public void testRefreshDataCenterInfoWithMyDataCenterInfo() {
+        // override datacenterinfo to the non-aws version
+        MyDataCenterInfo myDataCenterInfo = new MyDataCenterInfo(DataCenterInfo.Name.MyOwn);
+        instanceInfo = new InstanceInfo.Builder(instanceInfo).setDataCenterInfo(myDataCenterInfo).build();
+
+        DataCenterInfo info = instanceInfo.getDataCenterInfo();
+        assertThat(info, instanceOf(MyDataCenterInfo.class));
+
+        applicationInfoManager.refreshDataCenterInfoIfRequired();
+        assertThat(instanceInfo.getDefaultAddress(), is(dummyDefault));
+    }
+}

--- a/eureka-client/src/test/java/com/netflix/appinfo/CloudInstanceConfigTest.java
+++ b/eureka-client/src/test/java/com/netflix/appinfo/CloudInstanceConfigTest.java
@@ -1,7 +1,9 @@
 package com.netflix.appinfo;
 
 import com.netflix.discovery.util.InstanceInfoGenerator;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static com.netflix.appinfo.AmazonInfo.MetaDataKey.localIpv4;
@@ -20,6 +22,16 @@ public class CloudInstanceConfigTest {
     private CloudInstanceConfig config;
     private String dummyDefault = "dummyDefault";
     private InstanceInfo instanceInfo;
+
+    @BeforeClass
+    public static void setUpClass() {
+        System.setProperty("eureka.validateInstanceId", "false");
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        System.clearProperty("eureka.validateInstanceId");
+    }
 
     @Before
     public void setUp() {

--- a/eureka-client/src/test/java/com/netflix/appinfo/CloudInstanceConfigTest.java
+++ b/eureka-client/src/test/java/com/netflix/appinfo/CloudInstanceConfigTest.java
@@ -1,0 +1,47 @@
+package com.netflix.appinfo;
+
+import com.netflix.discovery.util.InstanceInfoGenerator;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.netflix.appinfo.AmazonInfo.MetaDataKey.localIpv4;
+import static com.netflix.appinfo.AmazonInfo.MetaDataKey.publicHostname;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author David Liu
+ */
+public class CloudInstanceConfigTest {
+
+    private CloudInstanceConfig config;
+    private String dummyDefault = "dummyDefault";
+    private InstanceInfo instanceInfo;
+
+    @Before
+    public void setUp() {
+        config = spy(new CloudInstanceConfig());
+
+        instanceInfo = InstanceInfoGenerator.takeOne();
+        when(config.getDefaultAddressResolutionOrder()).thenReturn(new String[] {
+                publicHostname.name(),
+                localIpv4.name()
+        });
+        when(config.getHostName(anyBoolean())).thenReturn(dummyDefault);
+    }
+
+    @Test
+    public void testResolveDefaultAddress() {
+        AmazonInfo info = (AmazonInfo) instanceInfo.getDataCenterInfo();
+        assertThat(config.resolveDefaultAddress(info), is(info.get(publicHostname)));
+
+        info.getMetadata().remove(publicHostname.getName());
+        assertThat(config.resolveDefaultAddress(info), is(info.get(localIpv4)));
+
+        info.getMetadata().remove(localIpv4.getName());
+        assertThat(config.resolveDefaultAddress(info), is(dummyDefault));
+    }
+}


### PR DESCRIPTION
Adding ability to define resolution order of the local InstanceInfo's "default" network address based on data available in AmazonInfo.