### PR TITLE
Upgrade netflix-eventbus to purge the transitive dependency on findbugs

### DIFF
--- a/eureka-client/build.gradle
+++ b/eureka-client/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'nebula-test-jar'
 apply plugin: 'provided-base'
 
 dependencies {
-    compile "com.netflix.netflix-commons:netflix-eventbus:0.1.2"
+    compile "com.netflix.netflix-commons:netflix-eventbus:0.3.0"
     compile 'com.thoughtworks.xstream:xstream:1.4.2'
     compile "com.netflix.archaius:archaius-core:${archaiusVersion}"
     compile 'javax.ws.rs:jsr311-api:1.1.1'


### PR DESCRIPTION
This effectively removes eureka-client's only transitive dependency on LGPL code.