### PR TITLE
1.x Fix AWS meta data refresh

### DIFF
--- a/eureka-client/src/main/java/com/netflix/appinfo/ApplicationInfoManager.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/ApplicationInfoManager.java
@@ -151,11 +151,11 @@ public class ApplicationInfoManager {
      */
     public void refreshDataCenterInfoIfRequired() {
         String existingAddress = instanceInfo.getHostName();
-        DataCenterInfo dataCenterInfo = instanceInfo.getDataCenterInfo();
 
         String newAddress;
         if (config instanceof CloudInstanceConfig) {
-            newAddress = ((CloudInstanceConfig) config).resolveDefaultAddress(dataCenterInfo);
+            // Refresh data center info, and return up to date address
+            newAddress = ((CloudInstanceConfig) config).resolveDefaultAddress();
         } else {
             newAddress = config.getHostName(true);
         }

--- a/eureka-client/src/main/java/com/netflix/appinfo/providers/EurekaConfigBasedInstanceInfoProvider.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/providers/EurekaConfigBasedInstanceInfoProvider.java
@@ -63,7 +63,8 @@ public class EurekaConfigBasedInstanceInfoProvider implements Provider<InstanceI
 
             String defaultAddress;
             if (config instanceof CloudInstanceConfig) {
-                defaultAddress = ((CloudInstanceConfig) config).resolveDefaultAddress(dataCenterInfo);
+                // Refresh AWS data center info, and return up to date address
+                defaultAddress = ((CloudInstanceConfig) config).resolveDefaultAddress();
             } else {
                 defaultAddress = config.getHostName(false);
             }

--- a/eureka-client/src/test/java/com/netflix/appinfo/ApplicationInfoManagerTest.java
+++ b/eureka-client/src/test/java/com/netflix/appinfo/ApplicationInfoManagerTest.java
@@ -6,8 +6,8 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import static com.netflix.appinfo.AmazonInfo.MetaDataKey.*;
-import static org.hamcrest.CoreMatchers.instanceOf;
+import static com.netflix.appinfo.AmazonInfo.MetaDataKey.localIpv4;
+import static com.netflix.appinfo.AmazonInfo.MetaDataKey.publicHostname;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
@@ -48,26 +48,12 @@ public class ApplicationInfoManagerTest {
 
     @Test
     public void testRefreshDataCenterInfoWithAmazonInfo() {
-        AmazonInfo info = (AmazonInfo) instanceInfo.getDataCenterInfo();
         String newPublicHostname = "newValue";
         assertThat(instanceInfo.getHostName(), is(not(newPublicHostname)));
 
-        info.getMetadata().put(publicHostname.getName(), newPublicHostname);
+        config.info.getMetadata().put(publicHostname.getName(), newPublicHostname);
         applicationInfoManager.refreshDataCenterInfoIfRequired();
 
         assertThat(instanceInfo.getHostName(), is(newPublicHostname));
-    }
-
-    @Test
-    public void testRefreshDataCenterInfoWithMyDataCenterInfo() {
-        // override datacenterinfo to the non-aws version
-        MyDataCenterInfo myDataCenterInfo = new MyDataCenterInfo(DataCenterInfo.Name.MyOwn);
-        instanceInfo = new InstanceInfo.Builder(instanceInfo).setDataCenterInfo(myDataCenterInfo).build();
-
-        DataCenterInfo info = instanceInfo.getDataCenterInfo();
-        assertThat(info, instanceOf(MyDataCenterInfo.class));
-
-        applicationInfoManager.refreshDataCenterInfoIfRequired();
-        assertThat(instanceInfo.getHostName(), is(dummyDefault));
     }
 }


### PR DESCRIPTION
AWS meta data updates were ignored, which for Discovery servers themselves resulted in an infinite loop of EIP binding, and registry clear/upload sequences. This in turn caused massive expiries, and large network traffic.