### PR TITLE
blitz4j is no longer included in eureka server as part of 1.3.5...

### DIFF
--- a/eureka-server/src/main/resources/log4j.properties
+++ b/eureka-server/src/main/resources/log4j.properties
@@ -1,6 +1,6 @@
 log4j.rootCategory=INFO,stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-#log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout=com.netflix.logging.log4jAdapter.NFPatternLayout
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+#log4j.appender.stdout.layout=com.netflix.logging.log4jAdapter.NFPatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d %-5p %C:%L [%t] [%M] %m%n
 log4j.logger.asyncAppenders=INFO,stdout


### PR DESCRIPTION
 ... #714 . Default log4j properties still points to a class that is part of blitz4j, generating an exception at boot time.