### PR TITLE
Fix for issue #702 (handle charset provided in Content-Type header)

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/provider/DiscoveryJerseyProvider.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/provider/DiscoveryJerseyProvider.java
@@ -16,7 +16,6 @@
 
 package com.netflix.discovery.provider;
 
-import javax.annotation.Nullable;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
@@ -31,7 +30,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Map;
 
 import com.netflix.discovery.converters.wrappers.CodecWrappers;
 import com.netflix.discovery.converters.wrappers.CodecWrappers.LegacyJacksonJson;
@@ -44,92 +43,71 @@ import org.slf4j.LoggerFactory;
  * A custom provider implementation for Jersey that dispatches to the
  * implementation that serializes/deserializes objects sent to and from eureka
  * server.
- * <p/>
- * <p>
- * This implementation allows users to plugin their own
- * serialization/deserialization mechanism by reading the annotation provided by
- * specifying the {@link Serializer} and dispatching it to that implementation.
- * </p>
  *
  * @author Karthik Ranganathan
  */
 @Provider
-@Produces("*/*")
+@Produces({"application/json", "application/xml"})
 @Consumes("*/*")
-public class DiscoveryJerseyProvider implements MessageBodyWriter, MessageBodyReader {
+public class DiscoveryJerseyProvider implements MessageBodyWriter<Object>, MessageBodyReader<Object> {
     private static final Logger LOGGER = LoggerFactory.getLogger(DiscoveryJerseyProvider.class);
 
-    // Cache the serializers so that they don't have to be instantiated every time
-    private static ConcurrentHashMap<Class, ISerializer> serializers = new ConcurrentHashMap<Class, ISerializer>();
+    private final EncoderWrapper jsonEncoder;
+    private final DecoderWrapper jsonDecoder;
 
-    private final EncoderWrapper encoder;
-    private final DecoderWrapper decoder;
+    // XML support is maintained for legacy/custom clients. These codecs are used only on the server side only, while
+    // Eureka client is using JSON only.
+    private final EncoderWrapper xmlEncoder;
+    private final DecoderWrapper xmlDecoder;
 
     public DiscoveryJerseyProvider() {
         this(null, null);
     }
 
-    public DiscoveryJerseyProvider(EncoderWrapper encoder, DecoderWrapper decoder) {
-        this.encoder = encoder == null ? CodecWrappers.getEncoder(LegacyJacksonJson.class) : encoder;
-        this.decoder = decoder == null ? CodecWrappers.getDecoder(LegacyJacksonJson.class) : decoder;
+    public DiscoveryJerseyProvider(EncoderWrapper jsonEncoder, DecoderWrapper jsonDecoder) {
+        this.jsonEncoder = jsonEncoder == null ? CodecWrappers.getEncoder(LegacyJacksonJson.class) : jsonEncoder;
+        this.jsonDecoder = jsonDecoder == null ? CodecWrappers.getDecoder(LegacyJacksonJson.class) : jsonDecoder;
+        LOGGER.info("Using JSON encoding codec {}", this.jsonEncoder.codecName());
+        LOGGER.info("Using JSON decoding codec {}", this.jsonDecoder.codecName());
 
-        if (encoder instanceof CodecWrappers.JacksonJsonMini) {
-            throw new UnsupportedOperationException("Encoder: " + encoder.codecName() + "is not supported for the client");
+        if (jsonEncoder instanceof CodecWrappers.JacksonJsonMini) {
+            throw new UnsupportedOperationException("Encoder: " + jsonEncoder.codecName() + "is not supported for the client");
         }
 
-        LOGGER.info("Using encoding codec {}", this.encoder.codecName());
-        LOGGER.info("Using decoding codec {}", this.decoder.codecName());
-    }
+        this.xmlEncoder = CodecWrappers.getEncoder(CodecWrappers.XStreamXml.class);
+        this.xmlDecoder = CodecWrappers.getDecoder(CodecWrappers.XStreamXml.class);
 
-    public EncoderWrapper getEncoder() {
-        return encoder;
-    }
-
-    public DecoderWrapper getDecoder() {
-        return decoder;
+        LOGGER.info("Using XML encoding codec {}", this.xmlEncoder.codecName());
+        LOGGER.info("Using XML decoding codec {}", this.xmlDecoder.codecName());
     }
 
     @Override
     public boolean isReadable(Class serializableClass, Type type, Annotation[] annotations, MediaType mediaType) {
-        if ("application".equals(mediaType.getType()) && ("xml".equals(mediaType.getSubtype()) || "json".equals(mediaType.getSubtype()))) {
-            return checkForAnnotation(serializableClass);
-        }
-        return false;
+        return isSupportedMediaType(mediaType) && isSupportedCharset(mediaType) && isSupportedEntity(serializableClass);
     }
 
     @Override
     public Object readFrom(Class serializableClass, Type type,
                            Annotation[] annotations, MediaType mediaType,
                            MultivaluedMap headers, InputStream inputStream) throws IOException {
-        if (decoder.support(mediaType)) {
-            try {
-                return decoder.decode(inputStream, serializableClass);
-            } catch (Throwable e) {
-                if (e instanceof Error) { // See issue: https://github.com/Netflix/eureka/issues/72 on why we catch Error here.
-                    closeInputOnError(inputStream);
-                    throw new WebApplicationException(createErrorReply(500, e, mediaType));
-                }
-                LOGGER.debug("Cannot parse request body", e);
-                throw new WebApplicationException(createErrorReply(400, "cannot parse request body", mediaType));
-            }
+        DecoderWrapper decoder;
+        if (MediaType.MEDIA_TYPE_WILDCARD.equals(mediaType.getSubtype())) {
+            decoder = xmlDecoder;
+        } else if ("json".equalsIgnoreCase(mediaType.getSubtype())) {
+            decoder = jsonDecoder;
+        } else {
+            decoder = xmlDecoder; // default
         }
 
-        // default to XML encoded with XStream
-        ISerializer serializer = getSerializer(serializableClass);
-        if (null != serializer) {
-            try {
-                return serializer.read(inputStream, serializableClass, mediaType);
-            } catch (Throwable e) {
-                if (e instanceof Error) { // See issue: https://github.com/Netflix/eureka/issues/72 on why we catch Error here.
-                    closeInputOnError(inputStream);
-                    throw new WebApplicationException(createErrorReply(500, e, mediaType));
-                }
-                LOGGER.debug("Cannot parse request body", e);
-                throw new WebApplicationException(createErrorReply(400, "cannot parse request body", mediaType));
+        try {
+            return decoder.decode(inputStream, serializableClass);
+        } catch (Throwable e) {
+            if (e instanceof Error) { // See issue: https://github.com/Netflix/eureka/issues/72 on why we catch Error here.
+                closeInputOnError(inputStream);
+                throw new WebApplicationException(createErrorReply(500, e, mediaType));
             }
-        } else {
-            LOGGER.error("No serializer available for serializable class: {}, de-serialization will fail.", serializableClass);
-            throw new WebApplicationException(createErrorReply(500, "No serializer available for serializable class: " + serializableClass, mediaType));
+            LOGGER.debug("Cannot parse request body", e);
+            throw new WebApplicationException(createErrorReply(400, "cannot parse request body", mediaType));
         }
     }
 
@@ -140,37 +118,59 @@ public class DiscoveryJerseyProvider implements MessageBodyWriter, MessageBodyRe
 
     @Override
     public boolean isWriteable(Class serializableClass, Type type, Annotation[] annotations, MediaType mediaType) {
-        return checkForAnnotation(serializableClass);
+        return isSupportedMediaType(mediaType) && isSupportedEntity(serializableClass);
     }
 
     @Override
     public void writeTo(Object serializableObject, Class serializableClass,
                         Type type, Annotation[] annotations, MediaType mediaType,
                         MultivaluedMap headers, OutputStream outputStream) throws IOException, WebApplicationException {
+        EncoderWrapper encoder = "json".equalsIgnoreCase(mediaType.getSubtype()) ? jsonEncoder : xmlEncoder;
 
-        if (encoder.support(mediaType)) {
-            encoder.encode(serializableObject, outputStream);
-        } else {  // default
-            ISerializer serializer = getSerializer(serializableClass);
-            if (null != serializer) {
-                serializer.write(serializableObject, outputStream, mediaType);
-            } else {
-                LOGGER.error("No serializer available for serializable class: " + serializableClass
-                        + ", serialization will fail.");
-                throw new IOException("No serializer available for serializable class: " + serializableClass);
-            }
+        // XML codec may not be available
+        if (encoder == null) {
+            throw new WebApplicationException(createErrorReply(400, "No codec available to serialize content type " + mediaType, mediaType));
         }
+
+        encoder.encode(serializableObject, outputStream);
+    }
+
+    private boolean isSupportedMediaType(MediaType mediaType) {
+        if (MediaType.APPLICATION_JSON_TYPE.isCompatible(mediaType)) {
+            return true;
+        }
+        if (MediaType.APPLICATION_XML_TYPE.isCompatible(mediaType)) {
+            return xmlDecoder != null;
+        }
+        return false;
     }
 
     /**
-     * Checks for the {@link java.io.Serializable} annotation for the given class.
+     * As content is cached, we expect both ends use UTF-8 always. If no content charset encoding is explicitly
+     * defined, UTF-8 is assumed as a default.
+     * As legacy clients may use ISO 8859-1 we accept it as well, although result may be unspecified if
+     * characters out of ASCII 0-127 range are used.
+     */
+    private static boolean isSupportedCharset(MediaType mediaType) {
+        Map<String, String> parameters = mediaType.getParameters();
+        if (parameters == null || parameters.isEmpty()) {
+            return true;
+        }
+        String charset = parameters.get("charset");
+        return charset == null
+                || "UTF-8".equalsIgnoreCase(charset)
+                || "ISO-8859-1".equalsIgnoreCase(charset);
+    }
+
+    /**
+     * Checks for the {@link Serializer} annotation for the given class.
      *
-     * @param serializableClass The class to be serialized/deserialized.
+     * @param entityType The class to be serialized/deserialized.
      * @return true if the annotation is present, false otherwise.
      */
-    private boolean checkForAnnotation(Class serializableClass) {
+    private static boolean isSupportedEntity(Class<?> entityType) {
         try {
-            Annotation annotation = serializableClass.getAnnotation(Serializer.class);
+            Annotation annotation = entityType.getAnnotation(Serializer.class);
             if (annotation != null) {
                 return true;
             }
@@ -178,48 +178,6 @@ public class DiscoveryJerseyProvider implements MessageBodyWriter, MessageBodyRe
             LOGGER.warn("Exception in checking for annotations", th);
         }
         return false;
-    }
-
-    /**
-     * Gets the {@link Serializer} implementation for serializing/ deserializing
-     * objects.
-     * <p/>
-     * <p/>
-     * The implementation is cached after the first time instantiation and then
-     * returned.
-     * <p/>
-     *
-     * @param serializableClass - The class that is to be serialized/deserialized.
-     * @return The {@link Serializer} implementation for serializing/
-     * deserializing objects.
-     */
-    @Nullable
-    private static ISerializer getSerializer(@SuppressWarnings("rawtypes") Class serializableClass) {
-        ISerializer converter = null;
-        Annotation annotation = serializableClass.getAnnotation(Serializer.class);
-        if (annotation != null) {
-            Serializer payloadConverter = (Serializer) annotation;
-            String serializer = payloadConverter.value();
-            if (serializer != null) {
-                converter = serializers.get(serializableClass);
-                if (converter == null) {
-                    try {
-                        converter = (ISerializer) Class.forName(serializer).newInstance();
-                    } catch (InstantiationException e) {
-                        LOGGER.error("Error creating a serializer.", e);
-                    } catch (IllegalAccessException e) {
-                        LOGGER.error("Error creating a serializer.", e);
-                    } catch (ClassNotFoundException e) {
-                        LOGGER.error("Error creating a serializer.", e);
-                    }
-                    if (null != converter) {
-                        serializers.put(serializableClass, converter);
-                    }
-                }
-            }
-
-        }
-        return converter;
     }
 
     private static Response createErrorReply(int status, Throwable cause, MediaType mediaType) {

--- a/eureka-client/src/test/java/com/netflix/discovery/provider/DiscoveryJerseyProviderTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/provider/DiscoveryJerseyProviderTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.discovery.provider;
+
+import javax.ws.rs.core.MediaType;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.netflix.appinfo.InstanceInfo;
+import com.netflix.discovery.converters.wrappers.CodecWrappers;
+import com.netflix.discovery.util.InstanceInfoGenerator;
+import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ */
+public class DiscoveryJerseyProviderTest {
+
+    private static final InstanceInfo INSTANCE = InstanceInfoGenerator.takeOne();
+
+    private final DiscoveryJerseyProvider jerseyProvider = new DiscoveryJerseyProvider(
+            CodecWrappers.getEncoder(CodecWrappers.JacksonJson.class),
+            CodecWrappers.getDecoder(CodecWrappers.JacksonJson.class)
+    );
+
+    @Test
+    public void testJsonEncodingDecoding() throws Exception {
+        testEncodingDecoding(MediaType.APPLICATION_JSON_TYPE);
+    }
+
+    @Test
+    public void testXmlEncodingDecoding() throws Exception {
+        testEncodingDecoding(MediaType.APPLICATION_XML_TYPE);
+    }
+
+    @Test
+    public void testDecodingWithUtf8CharsetExplicitlySet() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("charset", "UTF-8");
+        testEncodingDecoding(new MediaType("application", "json", params));
+    }
+
+    private void testEncodingDecoding(MediaType mediaType) throws IOException {
+        // Write
+        assertThat(jerseyProvider.isWriteable(InstanceInfo.class, InstanceInfo.class, null, mediaType), is(true));
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        jerseyProvider.writeTo(INSTANCE, InstanceInfo.class, InstanceInfo.class, null, mediaType, null, out);
+
+        // Read
+        assertThat(jerseyProvider.isReadable(InstanceInfo.class, InstanceInfo.class, null, mediaType), is(true));
+
+        ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+        InstanceInfo decodedInstance = (InstanceInfo) jerseyProvider.readFrom(InstanceInfo.class, InstanceInfo.class, null, mediaType, null, in);
+
+        assertThat(decodedInstance, is(equalTo(INSTANCE)));
+    }
+
+    @Test
+    public void testNonUtf8CharsetIsNotAccepted() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("charset", "ISO-8859");
+        MediaType mediaTypeWithNonSupportedCharset = new MediaType("application", "json", params);
+
+        assertThat(jerseyProvider.isReadable(InstanceInfo.class, InstanceInfo.class, null, mediaTypeWithNonSupportedCharset), is(false));
+    }
+}


### PR DESCRIPTION
This PR (compared to the previouse, undone one #739) checks for entity
types and is applied only to eureka specific data structures.