### PR TITLE
1.x Add composite strategy bootstrap resolver 

### DIFF
--- a/eureka-client-archaius2/src/main/java/com/netflix/discovery/shared/transport/EurekaArchaius2TransportConfig.java
+++ b/eureka-client-archaius2/src/main/java/com/netflix/discovery/shared/transport/EurekaArchaius2TransportConfig.java
@@ -35,11 +35,6 @@ public class EurekaArchaius2TransportConfig implements EurekaTransportConfig {
     }
 
     @Override
-    public int getBootstrapResolverRefreshIntervalSeconds() {
-        return config.getInteger("bootstrapResolverRefreshIntervalSeconds", 5 * 60);
-    }
-
-    @Override
     public int getApplicationsResolverDataStalenessThresholdSeconds() {
         return config.getInteger("applicationsResolverDataStalenessThresholdSeconds", 5*60);
     }
@@ -60,8 +55,18 @@ public class EurekaArchaius2TransportConfig implements EurekaTransportConfig {
     }
 
     @Override
+    public String getWriteClusterVip() {
+        return config.getString("writeClusterVip", null);
+    }
+
+    @Override
     public String getReadClusterVip() {
         return config.getString("readClusterVip", null);
+    }
+
+    @Override
+    public String getBootstrapResolverStrategy() {
+        return config.getString("bootstrapResolverStrategy", null);
     }
 
     @Override

--- a/eureka-client-archaius2/src/main/java/com/netflix/discovery/shared/transport/EurekaArchaius2TransportConfig.java
+++ b/eureka-client-archaius2/src/main/java/com/netflix/discovery/shared/transport/EurekaArchaius2TransportConfig.java
@@ -40,6 +40,11 @@ public class EurekaArchaius2TransportConfig implements EurekaTransportConfig {
     }
 
     @Override
+    public boolean applicationsResolverUseIp() {
+        return config.getBoolean("applicationsResolverUseIp", false);
+    }
+
+    @Override
     public int getAsyncResolverRefreshIntervalMs() {
         return config.getInteger("asyncResolverRefreshIntervalMs", 5 * 60 * 1000);
     }

--- a/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
@@ -1143,37 +1143,28 @@ public class DiscoveryClient implements EurekaClient {
 
                 ++deltaCount;
                 if (ActionType.ADDED.equals(instance.getActionType())) {
-                    Application existingApp = applications
-                            .getRegisteredApplications(instance.getAppName());
+                    Application existingApp = applications.getRegisteredApplications(instance.getAppName());
                     if (existingApp == null) {
                         applications.addApplication(app);
                     }
-                    logger.debug("Added instance {} to the existing apps in region {}",
-                            instance.getId(), instanceRegion);
-                    applications.getRegisteredApplications(
-                            instance.getAppName()).addInstance(instance);
+                    logger.debug("Added instance {} to the existing apps in region {}", instance.getId(), instanceRegion);
+                    applications.getRegisteredApplications(instance.getAppName()).addInstance(instance);
                 } else if (ActionType.MODIFIED.equals(instance.getActionType())) {
-                    Application existingApp = applications
-                            .getRegisteredApplications(instance.getAppName());
+                    Application existingApp = applications.getRegisteredApplications(instance.getAppName());
                     if (existingApp == null) {
                         applications.addApplication(app);
                     }
-                    logger.debug("Modified instance {} to the existing apps ",
-                            instance.getId());
+                    logger.debug("Modified instance {} to the existing apps ", instance.getId());
 
-                    applications.getRegisteredApplications(
-                            instance.getAppName()).addInstance(instance);
+                    applications.getRegisteredApplications(instance.getAppName()).addInstance(instance);
 
                 } else if (ActionType.DELETED.equals(instance.getActionType())) {
-                    Application existingApp = applications
-                            .getRegisteredApplications(instance.getAppName());
+                    Application existingApp = applications.getRegisteredApplications(instance.getAppName());
                     if (existingApp == null) {
                         applications.addApplication(app);
                     }
-                    logger.debug("Deleted instance {} to the existing apps ",
-                            instance.getId());
-                    applications.getRegisteredApplications(
-                            instance.getAppName()).removeInstance(instance);
+                    logger.debug("Deleted instance {} to the existing apps ", instance.getId());
+                    applications.getRegisteredApplications(instance.getAppName()).removeInstance(instance);
                 }
             }
         }

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/Applications.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/Applications.java
@@ -299,7 +299,7 @@ public class Applications {
         for (Application otherApp : apps.getRegisteredApplications()) {
             Application thisApp = this.getRegisteredApplications(otherApp.getName());
             if (thisApp == null) {
-                logger.warn("The application %s is not found in local cache :", otherApp.getName());
+                logger.warn("Application not found in local cache : {}", otherApp.getName());
                 continue;
             }
             for (InstanceInfo instanceInfo : thisApp.getInstancesAsIsFromEureka()) {

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/resolver/AsyncResolver.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/resolver/AsyncResolver.java
@@ -109,7 +109,7 @@ public class AsyncResolver<T extends EurekaEndpoint> implements ClosableResolver
 
         this.executorService = Executors.newScheduledThreadPool(1,
                 new ThreadFactoryBuilder()
-                        .setNameFormat("AsyncResolver-%d")
+                        .setNameFormat("AsyncResolver-" + name + "-%d")
                         .setDaemon(true)
                         .build());
 
@@ -117,7 +117,7 @@ public class AsyncResolver<T extends EurekaEndpoint> implements ClosableResolver
                 1, executorThreadPoolSize, 0, TimeUnit.SECONDS,
                 new SynchronousQueue<Runnable>(),  // use direct handoff
                 new ThreadFactoryBuilder()
-                        .setNameFormat("AsyncResolver-executor-%d")
+                        .setNameFormat("AsyncResolver-" + name + "-executor-%d")
                         .setDaemon(true)
                         .build()
         );

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/resolver/DefaultEndpoint.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/resolver/DefaultEndpoint.java
@@ -26,7 +26,7 @@ import java.util.List;
  */
 public class DefaultEndpoint implements EurekaEndpoint {
 
-    protected final String hostName;
+    protected final String networkAddress;
     protected final int port;
     protected final boolean isSecure;
     protected final String relativeUri;
@@ -37,7 +37,7 @@ public class DefaultEndpoint implements EurekaEndpoint {
 
         try {
             URL url = new URL(serviceUrl);
-            this.hostName = url.getHost();
+            this.networkAddress = url.getHost();
             this.port = url.getPort();
             this.isSecure = "https".equals(url.getProtocol());
             this.relativeUri = url.getPath();
@@ -46,8 +46,8 @@ public class DefaultEndpoint implements EurekaEndpoint {
         }
     }
 
-    public DefaultEndpoint(String hostName, int port, boolean isSecure, String relativeUri) {
-        this.hostName = hostName;
+    public DefaultEndpoint(String networkAddress, int port, boolean isSecure, String relativeUri) {
+        this.networkAddress = networkAddress;
         this.port = port;
         this.isSecure = isSecure;
         this.relativeUri = relativeUri;
@@ -55,7 +55,7 @@ public class DefaultEndpoint implements EurekaEndpoint {
         StringBuilder sb = new StringBuilder()
                 .append(isSecure ? "https" : "http")
                 .append("://")
-                .append(hostName)
+                .append(networkAddress)
                 .append(':')
                 .append(port);
         if (relativeUri != null) {
@@ -72,9 +72,15 @@ public class DefaultEndpoint implements EurekaEndpoint {
         return serviceUrl;
     }
 
+    @Deprecated
     @Override
     public String getHostName() {
-        return hostName;
+        return networkAddress;
+    }
+
+    @Override
+    public String getNetworkAddress() {
+        return networkAddress;
     }
 
     @Override
@@ -113,7 +119,7 @@ public class DefaultEndpoint implements EurekaEndpoint {
 
         if (isSecure != that.isSecure) return false;
         if (port != that.port) return false;
-        if (hostName != null ? !hostName.equals(that.hostName) : that.hostName != null) return false;
+        if (networkAddress != null ? !networkAddress.equals(that.networkAddress) : that.networkAddress != null) return false;
         if (relativeUri != null ? !relativeUri.equals(that.relativeUri) : that.relativeUri != null) return false;
         if (serviceUrl != null ? !serviceUrl.equals(that.serviceUrl) : that.serviceUrl != null) return false;
 
@@ -122,7 +128,7 @@ public class DefaultEndpoint implements EurekaEndpoint {
 
     @Override
     public int hashCode() {
-        int result = hostName != null ? hostName.hashCode() : 0;
+        int result = networkAddress != null ? networkAddress.hashCode() : 0;
         result = 31 * result + port;
         result = 31 * result + (isSecure ? 1 : 0);
         result = 31 * result + (relativeUri != null ? relativeUri.hashCode() : 0);

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/resolver/EurekaEndpoint.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/resolver/EurekaEndpoint.java
@@ -16,14 +16,17 @@
 
 package com.netflix.discovery.shared.resolver;
 
-/**
- * @author David Liu
- */
 public interface EurekaEndpoint extends Comparable<Object> {
 
     String getServiceUrl();
 
+    /**
+     * @deprecated use {@link #getNetworkAddress()}
+     */
+    @Deprecated
     String getHostName();
+
+    String getNetworkAddress();
 
     int getPort();
 

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/resolver/LegacyClusterResolver.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/resolver/LegacyClusterResolver.java
@@ -30,7 +30,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * @deprecated as of 2016-02-11. Will be deleted in an upcoming release
+ * @deprecated as of 2016-02-11. Will be deleted in an upcoming release.
+ * See {@link com.netflix.discovery.shared.resolver.aws.ConfigClusterResolver} for replacement.
  *
  * Server resolver that mimics the behavior of the original implementation. Either DNS or server
  * list resolvers are instantiated, and they can be swapped in runtime because of the dynamic configuration

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/resolver/LegacyClusterResolver.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/resolver/LegacyClusterResolver.java
@@ -30,6 +30,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
+ * @deprecated as of 2016-02-11. Will be deleted in an upcoming release
+ *
  * Server resolver that mimics the behavior of the original implementation. Either DNS or server
  * list resolvers are instantiated, and they can be swapped in runtime because of the dynamic configuration
  * change.
@@ -39,6 +41,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Tomasz Bak
  */
+@Deprecated
 public class LegacyClusterResolver implements ClusterResolver<AwsEndpoint> {
 
     private static final Logger logger = LoggerFactory.getLogger(LegacyClusterResolver.class);

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/resolver/aws/ApplicationsResolver.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/resolver/aws/ApplicationsResolver.java
@@ -57,7 +57,10 @@ public class ApplicationsResolver implements ClusterResolver<AwsEndpoint> {
             List<InstanceInfo> validInstanceInfos = applications.getInstancesByVirtualHostName(vipAddress);
             for (InstanceInfo instanceInfo : validInstanceInfos) {
                 if (instanceInfo.getStatus() == InstanceInfo.InstanceStatus.UP) {
-                    result.add(ResolverUtils.instanceInfoToEndpoint(clientConfig, instanceInfo));
+                    AwsEndpoint endpoint = ResolverUtils.instanceInfoToEndpoint(clientConfig, transportConfig, instanceInfo);
+                    if (endpoint != null) {
+                        result.add(endpoint);
+                    }
                 }
             }
         }

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/resolver/aws/ApplicationsResolver.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/resolver/aws/ApplicationsResolver.java
@@ -22,13 +22,23 @@ public class ApplicationsResolver implements ClusterResolver<AwsEndpoint> {
     private final EurekaClientConfig clientConfig;
     private final EurekaTransportConfig transportConfig;
     private final ApplicationsSource applicationsSource;
+    private final String vipAddress;
 
+    @Deprecated
     public ApplicationsResolver(EurekaClientConfig clientConfig,
                                 EurekaTransportConfig transportConfig,
                                 ApplicationsSource applicationsSource) {
+        this(clientConfig, transportConfig, applicationsSource, transportConfig.getReadClusterVip());
+    }
+
+    public ApplicationsResolver(EurekaClientConfig clientConfig,
+                                EurekaTransportConfig transportConfig,
+                                ApplicationsSource applicationsSource,
+                                String vipAddress) {
         this.clientConfig = clientConfig;
         this.transportConfig = transportConfig;
         this.applicationsSource = applicationsSource;
+        this.vipAddress = vipAddress;
     }
 
     @Override
@@ -43,7 +53,6 @@ public class ApplicationsResolver implements ClusterResolver<AwsEndpoint> {
         Applications applications = applicationsSource.getApplications(
                 transportConfig.getApplicationsResolverDataStalenessThresholdSeconds(), TimeUnit.SECONDS);
 
-        String vipAddress = transportConfig.getReadClusterVip();
         if (applications != null && vipAddress != null) {
             List<InstanceInfo> validInstanceInfos = applications.getInstancesByVirtualHostName(vipAddress);
             for (InstanceInfo instanceInfo : validInstanceInfos) {

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/transport/DefaultEurekaTransportConfig.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/transport/DefaultEurekaTransportConfig.java
@@ -34,6 +34,11 @@ public class DefaultEurekaTransportConfig implements EurekaTransportConfig {
     }
 
     @Override
+    public boolean applicationsResolverUseIp() {
+        return configInstance.getBooleanProperty(namespace + "applicationsResolverUseIp", false).get();
+    }
+
+    @Override
     public int getAsyncResolverRefreshIntervalMs() {
         return configInstance.getIntProperty(namespace + "asyncResolverRefreshIntervalMs", 5*60*1000).get();
     }

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/transport/DefaultEurekaTransportConfig.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/transport/DefaultEurekaTransportConfig.java
@@ -29,11 +29,6 @@ public class DefaultEurekaTransportConfig implements EurekaTransportConfig {
     }
 
     @Override
-    public int getBootstrapResolverRefreshIntervalSeconds() {
-        return configInstance.getIntProperty(namespace + "bootstrapResolverRefreshIntervalSeconds", 5*60).get();
-    }
-
-    @Override
     public int getApplicationsResolverDataStalenessThresholdSeconds() {
         return configInstance.getIntProperty(namespace + "applicationsResolverDataStalenessThresholdSeconds", 5*60).get();
     }
@@ -54,8 +49,18 @@ public class DefaultEurekaTransportConfig implements EurekaTransportConfig {
     }
 
     @Override
+    public String getWriteClusterVip() {
+        return configInstance.getStringProperty(namespace + "writeClusterVip", null).get();
+    }
+
+    @Override
     public String getReadClusterVip() {
         return configInstance.getStringProperty(namespace + "readClusterVip", null).get();
+    }
+
+    @Override
+    public String getBootstrapResolverStrategy() {
+        return configInstance.getStringProperty(namespace + "bootstrapResolverStrategy", null).get();
     }
 
     @Override

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/transport/EurekaHttpClients.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/transport/EurekaHttpClients.java
@@ -153,8 +153,8 @@ public final class EurekaHttpClients {
     }
 
     /**
-     * @return a bootstrap resolver that resolves eureka server endpoints based on either DNS or static config,
-     *         depending on configuration for one or the other. This resolver will warm up at the start.
+     * @return a bootstrap resolver that resolves eureka server endpoints via a remote call to a "vip source"
+     *         the local registry, where the source is found from a rootResolver (dns or config)
      */
     static ClosableResolver<AwsEndpoint> compositeBootstrapResolver(
             final EurekaClientConfig clientConfig,

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/transport/EurekaTransportConfig.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/transport/EurekaTransportConfig.java
@@ -23,6 +23,14 @@ public interface EurekaTransportConfig {
     int getApplicationsResolverDataStalenessThresholdSeconds();
 
     /**
+     * By default, the applications resolver extracts the public hostname from internal InstanceInfos for resolutions.
+     * Set this to true to change this behaviour to use ip addresses instead (private ip if ip type can be determined).
+     *
+     * @return false by default
+     */
+    boolean applicationsResolverUseIp();
+
+    /**
      * @return the interval to poll for the async resolver.
      */
     int getAsyncResolverRefreshIntervalMs();

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/transport/EurekaTransportConfig.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/transport/EurekaTransportConfig.java
@@ -18,13 +18,6 @@ public interface EurekaTransportConfig {
     double getRetryableClientQuarantineRefreshPercentage();
 
     /**
-     * Indicates how often(in seconds) to poll for changes to the bootstrap eureka server urls
-     *
-     * @return the interval to poll for bootstrap eureka server url changes (e.g. if stored in dns)
-     */
-    int getBootstrapResolverRefreshIntervalSeconds();
-
-    /**
      * @return the max staleness threshold tolerated by the applications resolver
      */
     int getApplicationsResolverDataStalenessThresholdSeconds();
@@ -45,12 +38,30 @@ public interface EurekaTransportConfig {
     int getAsyncExecutorThreadPoolSize();
 
     /**
+     * The remote vipAddress of the primary eureka cluster to register with.
+     *
+     * @return the vipAddress for the write cluster to register with
+     */
+    String getWriteClusterVip();
+
+    /**
      * The remote vipAddress of the eureka cluster (either the primaries or a readonly replica) to fetch registry
      * data from.
      *
      * @return the vipAddress for the readonly cluster to redirect to, if applicable (can be the same as the bootstrap)
      */
     String getReadClusterVip();
+
+    /**
+     * Can be used to specify different bootstrap resolve strategies. Current supported strategies are:
+     *  - default (if no match): bootstrap from dns txt records or static config hostnames
+     *  - composite: bootstrap from local registry if data is available
+     *    and warm (see {@link #getApplicationsResolverDataStalenessThresholdSeconds()}, otherwise
+     *    fall back to a backing default
+     *
+     * @return null for the default strategy, by default
+     */
+    String getBootstrapResolverStrategy();
 
     /**
      * By default, the transport uses the same (bootstrap) resolver for queries.

--- a/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientRedirectTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientRedirectTest.java
@@ -15,6 +15,7 @@ import com.netflix.discovery.shared.Application;
 import com.netflix.discovery.shared.Applications;
 import com.netflix.discovery.util.EurekaEntityFunctions;
 import com.netflix.discovery.util.InstanceInfoGenerator;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -80,6 +81,19 @@ public class DiscoveryClientRedirectTest {
     @Before
     public void setUp() throws Exception {
         targetServerBaseUri = "http://localhost:" + targetServerMockRule.getHttpPort();
+    }
+
+    @After
+    public void tearDown() {
+        if (redirectServerMockClient != null) {
+            redirectServerMockClient.reset();
+            redirectServerMockClient.stop();
+        }
+
+        if (targetServerMockClient.client != null) {
+            targetServerMockClient.client.reset();
+            targetServerMockClient.client.stop();
+        }
     }
 
     @Test

--- a/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientRedirectTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientRedirectTest.java
@@ -87,12 +87,10 @@ public class DiscoveryClientRedirectTest {
     public void tearDown() {
         if (redirectServerMockClient != null) {
             redirectServerMockClient.reset();
-            redirectServerMockClient.stop();
         }
 
         if (targetServerMockClient.client != null) {
             targetServerMockClient.client.reset();
-            targetServerMockClient.client.stop();
         }
     }
 

--- a/eureka-client/src/test/java/com/netflix/discovery/shared/resolver/aws/ApplicationsResolverTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/shared/resolver/aws/ApplicationsResolverTest.java
@@ -45,7 +45,8 @@ public class ApplicationsResolverTest {
         resolver = new ApplicationsResolver(
                 clientConfig,
                 transportConfig,
-                applicationsSource
+                applicationsSource,
+                transportConfig.getReadClusterVip()
         );
     }
 
@@ -61,6 +62,14 @@ public class ApplicationsResolverTest {
     public void testVipDoesNotExist() {
         vipAddress = "doNotExist";
         when(transportConfig.getReadClusterVip()).thenReturn(vipAddress);
+
+        resolver = new ApplicationsResolver(  // recreate the resolver as desired config behaviour has changed
+                clientConfig,
+                transportConfig,
+                applicationsSource,
+                transportConfig.getReadClusterVip()
+        );
+
         when(applicationsSource.getApplications(anyInt(), eq(TimeUnit.SECONDS))).thenReturn(applications);
 
         List<AwsEndpoint> endpoints = resolver.getClusterEndpoints();

--- a/eureka-client/src/test/java/com/netflix/discovery/shared/resolver/aws/EurekaHttpResolverTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/shared/resolver/aws/EurekaHttpResolverTest.java
@@ -6,6 +6,7 @@ import com.netflix.discovery.shared.Applications;
 import com.netflix.discovery.shared.transport.EurekaHttpClient;
 import com.netflix.discovery.shared.transport.EurekaHttpClientFactory;
 import com.netflix.discovery.shared.transport.EurekaHttpResponse;
+import com.netflix.discovery.shared.transport.EurekaTransportConfig;
 import com.netflix.discovery.util.InstanceInfoGenerator;
 import org.junit.After;
 import org.junit.Before;
@@ -27,6 +28,7 @@ import static org.mockito.Mockito.when;
 public class EurekaHttpResolverTest {
 
     private final EurekaClientConfig clientConfig = mock(EurekaClientConfig.class);
+    private final EurekaTransportConfig transportConfig = mock(EurekaTransportConfig.class);
     private final EurekaHttpClientFactory clientFactory = mock(EurekaHttpClientFactory.class);
     private final EurekaHttpClient httpClient = mock(EurekaHttpClient.class);
 
@@ -45,7 +47,7 @@ public class EurekaHttpResolverTest {
         when(clientFactory.newClient()).thenReturn(httpClient);
         when(httpClient.getVip(vipAddress)).thenReturn(EurekaHttpResponse.anEurekaHttpResponse(200, applications).build());
 
-        resolver = new EurekaHttpResolver(clientConfig, clientFactory, vipAddress);
+        resolver = new EurekaHttpResolver(clientConfig, transportConfig, clientFactory, vipAddress);
     }
 
     @After

--- a/eureka-client/src/test/java/com/netflix/discovery/shared/resolver/aws/TestEurekaHttpResolver.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/shared/resolver/aws/TestEurekaHttpResolver.java
@@ -2,14 +2,15 @@ package com.netflix.discovery.shared.resolver.aws;
 
 import com.netflix.discovery.EurekaClientConfig;
 import com.netflix.discovery.shared.transport.EurekaHttpClientFactory;
+import com.netflix.discovery.shared.transport.EurekaTransportConfig;
 
 /**
- * Used to expose test onstructor to other packages
+ * Used to expose test constructor to other packages
  *
  * @author David Liu
  */
 public class TestEurekaHttpResolver extends EurekaHttpResolver {
-    public TestEurekaHttpResolver(EurekaClientConfig clientConfig, EurekaHttpClientFactory clientFactory, String vipAddress) {
-        super(clientConfig, clientFactory, vipAddress);
+    public TestEurekaHttpResolver(EurekaClientConfig clientConfig, EurekaTransportConfig transportConfig, EurekaHttpClientFactory clientFactory, String vipAddress) {
+        super(clientConfig, transportConfig, clientFactory, vipAddress);
     }
 }

--- a/eureka-client/src/test/java/com/netflix/discovery/shared/transport/EurekaHttpClientsTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/shared/transport/EurekaHttpClientsTest.java
@@ -165,9 +165,10 @@ public class EurekaHttpClientsTest {
         EurekaHttpResolver remoteResolver = spy(new TestEurekaHttpResolver(clientConfig, remoteResolverClientFactory, vipAddress));
         when(transportConfig.getReadClusterVip()).thenReturn(vipAddress);
 
-        ApplicationsResolver localResolver = spy(new ApplicationsResolver(clientConfig, transportConfig, applicationsSource));
+        ApplicationsResolver localResolver = spy(new ApplicationsResolver(
+                clientConfig, transportConfig, applicationsSource, transportConfig.getReadClusterVip()));
 
-        ClosableResolver resolver = EurekaHttpClients.queryClientResolver(
+        ClosableResolver resolver = EurekaHttpClients.compositeQueryResolver(
                 remoteResolver,
                 localResolver,
                 clientConfig,

--- a/eureka-client/src/test/java/com/netflix/discovery/shared/transport/EurekaHttpClientsTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/shared/transport/EurekaHttpClientsTest.java
@@ -159,7 +159,7 @@ public class EurekaHttpClientsTest {
         when(clientConfig.getRegion()).thenReturn("us-east-1");
 
         when(transportConfig.getWriteClusterVip()).thenReturn(vipAddress);
-        when(transportConfig.getAsyncExecutorThreadPoolSize()).thenReturn(3);
+        when(transportConfig.getAsyncExecutorThreadPoolSize()).thenReturn(4);
         when(transportConfig.getAsyncResolverRefreshIntervalMs()).thenReturn(300);
         when(transportConfig.getAsyncResolverWarmUpTimeoutMs()).thenReturn(200);
 
@@ -195,10 +195,10 @@ public class EurekaHttpClientsTest {
             endpoints = resolver.getClusterEndpoints();
             assertThat(endpoints.size(), equalTo(applications.getInstancesByVirtualHostName(vipAddress).size()));
 
-            // wait for the third cycle that hits the app source
+            // wait for the third cycle that triggers the mock http client (which is the third resolver cycle)
             // for the third cycle we have mocked the application resolver to return null data so should fall back
             // to calling the remote resolver again (which should return applications2)
-            verify(applicationsSource, timeout(1000).times(3)).getApplications(anyInt(), eq(TimeUnit.SECONDS));
+            verify(mockHttpClient, timeout(1000).times(3)).getVip(anyString());
             endpoints = resolver.getClusterEndpoints();
             assertThat(endpoints.size(), equalTo(applications2.getInstancesByVirtualHostName(vipAddress).size()));
         } finally {

--- a/eureka-client/src/test/java/com/netflix/discovery/shared/transport/EurekaHttpClientsTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/shared/transport/EurekaHttpClientsTest.java
@@ -162,7 +162,7 @@ public class EurekaHttpClientsTest {
         when(remoteResolverClientFactory.newClient()).thenReturn(httpClient);
         when(httpClient.getVip(vipAddress)).thenReturn(EurekaHttpResponse.anEurekaHttpResponse(200, applications).build());
 
-        EurekaHttpResolver remoteResolver = spy(new TestEurekaHttpResolver(clientConfig, remoteResolverClientFactory, vipAddress));
+        EurekaHttpResolver remoteResolver = spy(new TestEurekaHttpResolver(clientConfig, transportConfig, remoteResolverClientFactory, vipAddress));
         when(transportConfig.getReadClusterVip()).thenReturn(vipAddress);
 
         ApplicationsResolver localResolver = spy(new ApplicationsResolver(

--- a/eureka-client/src/test/java/com/netflix/discovery/shared/transport/EurekaHttpClientsTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/shared/transport/EurekaHttpClientsTest.java
@@ -160,8 +160,8 @@ public class EurekaHttpClientsTest {
 
         when(transportConfig.getWriteClusterVip()).thenReturn(vipAddress);
         when(transportConfig.getAsyncExecutorThreadPoolSize()).thenReturn(4);
-        when(transportConfig.getAsyncResolverRefreshIntervalMs()).thenReturn(300);
-        when(transportConfig.getAsyncResolverWarmUpTimeoutMs()).thenReturn(200);
+        when(transportConfig.getAsyncResolverRefreshIntervalMs()).thenReturn(400);
+        when(transportConfig.getAsyncResolverWarmUpTimeoutMs()).thenReturn(400);
 
         ApplicationsResolver.ApplicationsSource applicationsSource = mock(ApplicationsResolver.ApplicationsSource.class);
         when(applicationsSource.getApplications(anyInt(), eq(TimeUnit.SECONDS)))
@@ -191,14 +191,14 @@ public class EurekaHttpClientsTest {
             assertThat(endpoints.size(), equalTo(applications.getInstancesByVirtualHostName(vipAddress).size()));
 
             // wait for the second cycle that hits the app source
-            verify(applicationsSource, timeout(1000).times(2)).getApplications(anyInt(), eq(TimeUnit.SECONDS));
+            verify(applicationsSource, timeout(3000).times(2)).getApplications(anyInt(), eq(TimeUnit.SECONDS));
             endpoints = resolver.getClusterEndpoints();
             assertThat(endpoints.size(), equalTo(applications.getInstancesByVirtualHostName(vipAddress).size()));
 
             // wait for the third cycle that triggers the mock http client (which is the third resolver cycle)
             // for the third cycle we have mocked the application resolver to return null data so should fall back
             // to calling the remote resolver again (which should return applications2)
-            verify(mockHttpClient, timeout(1000).times(3)).getVip(anyString());
+            verify(mockHttpClient, timeout(3000).times(3)).getVip(anyString());
             endpoints = resolver.getClusterEndpoints();
             assertThat(endpoints.size(), equalTo(applications2.getInstancesByVirtualHostName(vipAddress).size()));
         } finally {
@@ -214,8 +214,8 @@ public class EurekaHttpClientsTest {
         when(clientConfig.getRegion()).thenReturn("region");
 
         when(transportConfig.getAsyncExecutorThreadPoolSize()).thenReturn(3);
-        when(transportConfig.getAsyncResolverRefreshIntervalMs()).thenReturn(300);
-        when(transportConfig.getAsyncResolverWarmUpTimeoutMs()).thenReturn(200);
+        when(transportConfig.getAsyncResolverRefreshIntervalMs()).thenReturn(400);
+        when(transportConfig.getAsyncResolverWarmUpTimeoutMs()).thenReturn(400);
 
         Applications applications = InstanceInfoGenerator.newBuilder(5, "eurekaRead", "someOther").build().toApplications();
         String vipAddress = applications.getRegisteredApplications("eurekaRead").getInstances().get(0).getVIPAddress();
@@ -252,7 +252,7 @@ public class EurekaHttpClientsTest {
             verify(localResolver, times(1)).getClusterEndpoints();
 
             // wait for the second cycle that hits the app source
-            verify(applicationsSource, timeout(1000).times(2)).getApplications(anyInt(), eq(TimeUnit.SECONDS));
+            verify(applicationsSource, timeout(3000).times(2)).getApplications(anyInt(), eq(TimeUnit.SECONDS));
             endpoints = resolver.getClusterEndpoints();
             assertThat(endpoints.size(), equalTo(applications.getInstancesByVirtualHostName(vipAddress).size()));
 

--- a/eureka-core/src/test/java/com/netflix/eureka/cluster/JerseyReplicationClientTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/cluster/JerseyReplicationClientTest.java
@@ -62,7 +62,6 @@ public class JerseyReplicationClientTest {
     public void tearDown() {
         if (serverMockClient != null) {
             serverMockClient.reset();
-            serverMockClient.stop();
         }
     }
 

--- a/eureka-core/src/test/java/com/netflix/eureka/cluster/JerseyReplicationClientTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/cluster/JerseyReplicationClientTest.java
@@ -16,6 +16,7 @@ import com.netflix.eureka.resources.ASGResource.ASGStatus;
 import com.netflix.eureka.resources.DefaultServerCodecs;
 import com.netflix.eureka.resources.ServerCodecs;
 import com.netflix.eureka.transport.JerseyReplicationClient;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -55,6 +56,14 @@ public class JerseyReplicationClientTest {
         replicationClient = JerseyReplicationClient.createReplicationClient(
                 config, serverCodecs, "http://localhost:" + serverMockRule.getHttpPort() + "/eureka/v2"
         );
+    }
+
+    @After
+    public void tearDown() {
+        if (serverMockClient != null) {
+            serverMockClient.reset();
+            serverMockClient.stop();
+        }
     }
 
     @Test


### PR DESCRIPTION
Two features for multi-account, multi vpc type support:
- an option for (all) resolvers to use hostnames or ipAddresses for resolution
- an option to bootstrap with a composite strategy, where the bootstrap resolver prefers to load data from local registry, else attempts to make a remote get vips call for write servers. The remote call will make a dns/config look up for target hosts.