### PR TITLE
Move back to java7 compatibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ At Netflix, Eureka is used for the following purposes apart from playing a criti
 * For carrying other additional application specific metadata about services for various other reasons.
 
 
+Building
+----------
+The build requires java8 because of some required libraries that are java8 (servo), but the source and target compatibility are still set to 1.7.
+
+
 Support
 ----------
 [Eureka Google Group] (https://groups.google.com/forum/?fromgroups#!forum/eureka_netflix)

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ ext {
 
 idea {
     project {
-        languageLevel = '1.8'
+        languageLevel = '1.7'
     }
 }
 
@@ -44,8 +44,8 @@ subprojects {
 
     group = "com.netflix.${githubProjectName}"
 
-    sourceCompatibility = 1.8
-    targetCompatibility = 1.8
+    sourceCompatibility = 1.7
+    targetCompatibility = 1.7
 
     repositories {
         jcenter()

--- a/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
@@ -444,7 +444,7 @@ public class DiscoveryClient implements EurekaClient {
                 .newBootstrapResolver(clientConfig, applicationInfoManager.getInfo());
 
         Collection<ClientFilter> additionalFilters = args == null
-                ? Collections.emptyList()
+                ? Collections.<ClientFilter>emptyList()
                 : args.additionalFilters;
 
         EurekaJerseyClient providedJerseyClient = args == null

--- a/eureka-client/src/test/java/com/netflix/discovery/shared/transport/EurekaHttpClientsTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/shared/transport/EurekaHttpClientsTest.java
@@ -192,7 +192,7 @@ public class EurekaHttpClientsTest {
     @Test
     public void testAddingAdditionalFilters() throws Exception {
         TestFilter testFilter = new TestFilter();
-        Collection<ClientFilter> additionalFilters = Arrays.asList(testFilter);
+        Collection<ClientFilter> additionalFilters = Arrays.<ClientFilter>asList(testFilter);
 
         TransportClientFactory transportClientFactory = TransportClientFactories.newTransportClientFactory(
                 clientConfig,

--- a/eureka-core/src/main/java/com/netflix/eureka/transport/JerseyRemoteRegionClientFactory.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/transport/JerseyRemoteRegionClientFactory.java
@@ -61,7 +61,7 @@ public class JerseyRemoteRegionClientFactory implements TransportClientFactory {
 
     @Override
     public EurekaHttpClient newClient(EurekaEndpoint endpoint) {
-        return new JerseyApplicationClient(getOrCreateJerseyClient(region, endpoint).getClient(), endpoint.getServiceUrl(), Collections.emptyMap());
+        return new JerseyApplicationClient(getOrCreateJerseyClient(region, endpoint).getClient(), endpoint.getServiceUrl(), Collections.<String, String>emptyMap());
     }
 
     @Override


### PR DESCRIPTION
Spring Cloud Netflix is still java7 compatible.

When using java7 to build, the following error occurs because servo is java8 only.

java.lang.UnsupportedClassVersionError: com/netflix/servo/monitor/Monitors
	at com.netflix.discovery.DiscoveryClient.<init>(DiscoveryClient.java:126)
	at com.netflix.discovery.BackUpRegistryTest.setUp(BackUpRegistryTest.java:71)

Spring Cloud Netflix still uses the java7 servo.

Building with java8 and targeting java7 still works and maintains the required compatibility.

@twicksell 