### PR TITLE
Only append port to serviceUrl if port >= 0

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/shared/resolver/DefaultEndpoint.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/resolver/DefaultEndpoint.java
@@ -55,9 +55,11 @@ public class DefaultEndpoint implements EurekaEndpoint {
         StringBuilder sb = new StringBuilder()
                 .append(isSecure ? "https" : "http")
                 .append("://")
-                .append(networkAddress)
-                .append(':')
-                .append(port);
+                .append(networkAddress);
+		if (port >= 0) {
+			sb.append(':')
+				.append(port);
+		}
         if (relativeUri != null) {
             if (!relativeUri.startsWith("/")) {
                 sb.append('/');

--- a/eureka-client/src/test/java/com/netflix/discovery/shared/resolver/aws/ConfigClusterResolverTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/shared/resolver/aws/ConfigClusterResolverTest.java
@@ -32,7 +32,7 @@ public class ConfigClusterResolverTest {
             "http://1.1.2.2:8000/eureka/v2/"
     );
     private final List<String> endpointsE = Arrays.asList(
-            "https://1.1.3.1:8000/eureka/v2/"
+            "https://1.1.3.1/eureka/v2/"
     );
     private ConfigClusterResolver resolver;
 
@@ -59,7 +59,8 @@ public class ConfigClusterResolverTest {
 
 		for (AwsEndpoint endpoint : endpoints) {
 			if (endpoint.getZone().equals("us-east-1e")) {
-				assertThat(endpoint.isSecure(), equalTo(true));
+				assertThat("secure was wrong", endpoint.isSecure(), equalTo(true));
+				assertThat("serviceUrl contains -1", endpoint.getServiceUrl().contains("-1"), equalTo(false));
 			}
 		}
     }


### PR DESCRIPTION
Fixes a problem communicating with an eureka server that is running on port 80 or 443 (such as the case in cloud foundry). serviceUrl looked like this http://eurekahost:-1

I can confirm this works on a local build.

See https://github.com/spring-cloud/spring-cloud-netflix/issues/840 for the original issue.