### PR TITLE
1.x EIPManager: if instance is not associated with one EIP, do not try to unbind

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/aws/EIPManager.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/aws/EIPManager.java
@@ -260,7 +260,8 @@ public class EIPManager implements AwsBinder {
             myPublicIP = ((AmazonInfo) myInfo.getDataCenterInfo())
                     .get(MetaDataKey.publicIpv4);
             if (myPublicIP == null) {
-                throw new RuntimeException("Cannot dissociate eip from this instance since instance does not have one");
+                logger.info("Instance is not associated with an EIP. Will not try to unbind");
+                return;
             }
 
             try {

--- a/eureka-core/src/main/java/com/netflix/eureka/aws/EIPManager.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/aws/EIPManager.java
@@ -259,6 +259,10 @@ public class EIPManager implements AwsBinder {
                 && myInfo.getDataCenterInfo().getName() == Name.Amazon) {
             myPublicIP = ((AmazonInfo) myInfo.getDataCenterInfo())
                     .get(MetaDataKey.publicIpv4);
+            if (myPublicIP == null) {
+                throw new RuntimeException("Cannot dissociate eip from this instance since instance does not have one");
+            }
+
             try {
                 AmazonEC2 ec2Service = getEC2Service();
                 DescribeAddressesRequest describeAddressRequest = new DescribeAddressesRequest()


### PR DESCRIPTION
Instead, throw exception
Reason: DescribeAddressRequest with null public ip returns list of all public address
If instance is not associated with one eip, Eureka will dissociate first ip on list which does not belong to the instance