### PR TITLE
Support healthy status on server StatusInfo

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/DefaultEurekaServerConfig.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/DefaultEurekaServerConfig.java
@@ -668,4 +668,13 @@ public class DefaultEurekaServerConfig implements EurekaServerConfig {
     public String getExperimental(String name) {
         return configInstance.getStringProperty(namespace + "experimental." + name, null).get();
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getMinNumberOfAvailablePeers() {
+        return configInstance.getIntProperty(
+                namespace + "minAvailableInstancesForPeerReplication", 0).get();
+    }
 }

--- a/eureka-core/src/main/java/com/netflix/eureka/DefaultEurekaServerConfig.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/DefaultEurekaServerConfig.java
@@ -669,12 +669,9 @@ public class DefaultEurekaServerConfig implements EurekaServerConfig {
         return configInstance.getStringProperty(namespace + "experimental." + name, null).get();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public int getMinNumberOfAvailablePeers() {
+    public int getHealthStatusMinNumberOfAvailablePeers() {
         return configInstance.getIntProperty(
-                namespace + "minAvailableInstancesForPeerReplication", 0).get();
+                namespace + "minAvailableInstancesForPeerReplication", -1).get();
     }
 }

--- a/eureka-core/src/main/java/com/netflix/eureka/EurekaServerConfig.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/EurekaServerConfig.java
@@ -411,10 +411,18 @@ public interface EurekaServerConfig {
     
     /**
      * Get the minimum number of available peer replication instances
+     * for this instance to be considered healthy. The design of eureka allows
+     * for an instance to continue operating with zero peers, but that would not
+     * be ideal.
+     * <p>
+     * The default value of -1 is interpreted as a marker to not compare
+     * the number of replicas. This would be done to either disable this check
+     * or to run eureka in a single node configuration.
      * 
      * @return minimum number of available peer replication instances
+     *         for this instance to be considered healthy.
      */
-    int getMinNumberOfAvailablePeers();
+    int getHealthStatusMinNumberOfAvailablePeers();
 
     /**
      * Get the time in milliseconds to try to replicate before dropping

--- a/eureka-core/src/main/java/com/netflix/eureka/EurekaServerConfig.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/EurekaServerConfig.java
@@ -408,6 +408,13 @@ public interface EurekaServerConfig {
      * @return maximum number of threads to be used for replication.
      */
     int getMaxThreadsForPeerReplication();
+    
+    /**
+     * Get the minimum number of available peer replication instances
+     * 
+     * @return minimum number of available peer replication instances
+     */
+    int getMinNumberOfAvailablePeers();
 
     /**
      * Get the time in milliseconds to try to replicate before dropping

--- a/eureka-core/src/main/java/com/netflix/eureka/cluster/PeerEurekaNodes.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/cluster/PeerEurekaNodes.java
@@ -67,6 +67,10 @@ public class PeerEurekaNodes {
     public List<PeerEurekaNode> getPeerEurekaNodes() {
         return peerEurekaNodes;
     }
+    
+    public int getMinNumberOfAvailablePeers() {
+        return serverConfig.getMinNumberOfAvailablePeers();
+    }
 
     public void start() {
         taskExecutor = Executors.newSingleThreadScheduledExecutor(

--- a/eureka-core/src/main/java/com/netflix/eureka/cluster/PeerEurekaNodes.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/cluster/PeerEurekaNodes.java
@@ -69,7 +69,7 @@ public class PeerEurekaNodes {
     }
     
     public int getMinNumberOfAvailablePeers() {
-        return serverConfig.getMinNumberOfAvailablePeers();
+        return serverConfig.getHealthStatusMinNumberOfAvailablePeers();
     }
 
     public void start() {

--- a/eureka-core/src/main/java/com/netflix/eureka/util/StatusUtil.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/util/StatusUtil.java
@@ -54,7 +54,7 @@ public class StatusUtil {
         builder.add("unavailable-replicas", downReplicas.toString());
         
         // Only set the healthy flag if a threshold has been configured.
-        if (peerEurekaNodes.getMinNumberOfAvailablePeers() > 0) {
+        if (peerEurekaNodes.getMinNumberOfAvailablePeers() > -1) {
             builder.isHealthy(upReplicasCount >= peerEurekaNodes.getMinNumberOfAvailablePeers());
         }
 

--- a/eureka-core/src/main/java/com/netflix/eureka/util/StatusUtil.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/util/StatusUtil.java
@@ -64,13 +64,12 @@ public class StatusUtil {
     private boolean isReplicaAvailable(String url) {
 
         try {
-            String givenHostName = new URI(url).getHost();
             Application app = registry.getApplication(myAppName, false);
             if (app == null) {
                 return false;
             }
             for (InstanceInfo info : app.getInstances()) {
-                if (info.getHostName().equals(givenHostName)) {
+                if (peerEurekaNodes.isInstanceURL(url, info)) {
                     return true;
                 }
             }

--- a/eureka-core/src/main/java/com/netflix/eureka/util/StatusUtil.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/util/StatusUtil.java
@@ -29,8 +29,8 @@ public class StatusUtil {
 
     public StatusInfo getStatusInfo() {
         StatusInfo.Builder builder = StatusInfo.Builder.newBuilder();
-        builder.isHealthy(true);
         // Add application level status
+        int upReplicasCount = 0;
         StringBuilder upReplicas = new StringBuilder();
         StringBuilder downReplicas = new StringBuilder();
 
@@ -43,15 +43,20 @@ public class StatusUtil {
             replicaHostNames.append(node.getServiceUrl());
             if (isReplicaAvailable(node.getServiceUrl())) {
                 upReplicas.append(node.getServiceUrl()).append(',');
+                upReplicasCount++;
             } else {
                 downReplicas.append(node.getServiceUrl()).append(',');
-                builder.isHealthy(false);
             }
         }
 
         builder.add("registered-replicas", replicaHostNames.toString());
         builder.add("available-replicas", upReplicas.toString());
         builder.add("unavailable-replicas", downReplicas.toString());
+        
+        // Only set the healthy flag if a threshold has been configured.
+        if (peerEurekaNodes.getMinNumberOfAvailablePeers() > 0) {
+            builder.isHealthy(upReplicasCount >= peerEurekaNodes.getMinNumberOfAvailablePeers());
+        }
 
         return builder.build();
     }

--- a/eureka-core/src/main/java/com/netflix/eureka/util/StatusUtil.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/util/StatusUtil.java
@@ -29,6 +29,7 @@ public class StatusUtil {
 
     public StatusInfo getStatusInfo() {
         StatusInfo.Builder builder = StatusInfo.Builder.newBuilder();
+        builder.isHealthy(true);
         // Add application level status
         StringBuilder upReplicas = new StringBuilder();
         StringBuilder downReplicas = new StringBuilder();
@@ -40,10 +41,11 @@ public class StatusUtil {
                 replicaHostNames.append(", ");
             }
             replicaHostNames.append(node.getServiceUrl());
-            if (isReplicaAvailable(myAppName, node.getServiceUrl())) {
+            if (isReplicaAvailable(node.getServiceUrl())) {
                 upReplicas.append(node.getServiceUrl()).append(',');
             } else {
                 downReplicas.append(node.getServiceUrl()).append(',');
+                builder.isHealthy(false);
             }
         }
 
@@ -54,7 +56,7 @@ public class StatusUtil {
         return builder.build();
     }
 
-    private boolean isReplicaAvailable(String myAppName, String url) {
+    private boolean isReplicaAvailable(String url) {
 
         try {
             String givenHostName = new URI(url).getHost();
@@ -67,7 +69,6 @@ public class StatusUtil {
                     return true;
                 }
             }
-            givenHostName = new URI(url).getHost();
         } catch (Throwable e) {
             logger.error("Could not determine if the replica is available ", e);
         }

--- a/eureka-core/src/test/java/com/netflix/eureka/util/StatusUtilTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/util/StatusUtilTest.java
@@ -36,13 +36,13 @@ public class StatusUtilTest {
     
     @Test
     public void testGetStatusInfoUnsetHealth() {
-        StatusUtil statusUtil = getStatusUtil(5, 3, 0);
+        StatusUtil statusUtil = getStatusUtil(5, 3, -1);
         StatusInfo statusInfo = statusUtil.getStatusInfo();
         
         try {
             statusInfo.isHealthy();
         } catch (NullPointerException e) {
-            // Expected that the healthy flag is not set when the minimum value is 0
+            // Expected that the healthy flag is not set when the minimum value is -1
             return;
         }
         

--- a/eureka-core/src/test/java/com/netflix/eureka/util/StatusUtilTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/util/StatusUtilTest.java
@@ -1,0 +1,107 @@
+package com.netflix.eureka.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.netflix.appinfo.ApplicationInfoManager;
+import com.netflix.appinfo.InstanceInfo;
+import com.netflix.discovery.shared.Application;
+import com.netflix.eureka.EurekaServerContext;
+import com.netflix.eureka.cluster.PeerEurekaNode;
+import com.netflix.eureka.cluster.PeerEurekaNodes;
+import com.netflix.eureka.registry.PeerAwareInstanceRegistry;
+
+public class StatusUtilTest {
+    
+    @Test
+    public void testGetStatusInfoHealthy() {
+        StatusUtil statusUtil = getStatusUtil(3, 3, 2);
+        assertTrue(statusUtil.getStatusInfo().isHealthy());
+    }
+    
+    @Test
+    public void testGetStatusInfoUnhealthy() {
+        StatusUtil statusUtil = getStatusUtil(5, 3, 4);
+        assertFalse(statusUtil.getStatusInfo().isHealthy());
+    }
+    
+    @Test
+    public void testGetStatusInfoUnsetHealth() {
+        StatusUtil statusUtil = getStatusUtil(5, 3, 0);
+        StatusInfo statusInfo = statusUtil.getStatusInfo();
+        
+        try {
+            statusInfo.isHealthy();
+        } catch (NullPointerException e) {
+            // Expected that the healthy flag is not set when the minimum value is 0
+            return;
+        }
+        
+        fail("Excpected NPE to be thrown when healthy threshold is not set");
+    }
+    
+    /**
+     * @param replicas the number of replicas to mock
+     * @param instances the number of instances to mock
+     * @param minimum the minimum number of peers
+     * @return the status utility with the mocked replicas/instances
+     */
+    private StatusUtil getStatusUtil(int replicas, int instances, int minimum) {
+        EurekaServerContext mockEurekaServerContext = mock(EurekaServerContext.class);
+
+        List<InstanceInfo> mockInstanceInfos = getMockInstanceInfos(instances);
+        Application mockApplication = mock(Application.class);
+        when(mockApplication.getInstances()).thenReturn(mockInstanceInfos);
+        
+        PeerAwareInstanceRegistry mockRegistry = mock(PeerAwareInstanceRegistry.class);
+        when(mockRegistry.getApplication("stuff", false)).thenReturn(mockApplication);
+        when(mockEurekaServerContext.getRegistry()).thenReturn(mockRegistry);
+        
+        List<PeerEurekaNode> mockNodes = getMockNodes(replicas);
+        PeerEurekaNodes mockPeerEurekaNodes = mock(PeerEurekaNodes.class);
+        when(mockPeerEurekaNodes.getMinNumberOfAvailablePeers()).thenReturn(minimum);
+        when(mockPeerEurekaNodes.getPeerEurekaNodes()).thenReturn(mockNodes);
+        when(mockEurekaServerContext.getPeerEurekaNodes()).thenReturn(mockPeerEurekaNodes);
+        
+        ApplicationInfoManager mockAppInfoManager = mock(ApplicationInfoManager.class);
+        when(mockAppInfoManager.getInfo()).thenReturn(mockInstanceInfos.get(0));
+        when(mockEurekaServerContext.getApplicationInfoManager()).thenReturn(mockAppInfoManager);
+        
+        return new StatusUtil(mockEurekaServerContext);
+    }
+
+    List<InstanceInfo> getMockInstanceInfos(int size) {
+        List<InstanceInfo> instances = new ArrayList<>();
+        
+        for (int i = 0; i < size; i++) {
+            InstanceInfo mockInstance = mock(InstanceInfo.class);
+            when(mockInstance.getHostName()).thenReturn(String.valueOf(i));
+            when(mockInstance.getIPAddr()).thenReturn(String.valueOf(i));
+            when(mockInstance.getAppName()).thenReturn("stuff");
+            instances.add(mockInstance);
+        }
+        
+        return instances;
+    }
+    
+    List<PeerEurekaNode> getMockNodes(int size) {
+        List<PeerEurekaNode> nodes = new ArrayList<>();
+        
+        for (int i = 0; i < size; i++) {
+            PeerEurekaNode mockNode = mock(PeerEurekaNode.class);
+            when(mockNode.getServiceUrl()).thenReturn(String.format("http://%d:8080/v2", i));
+            nodes.add(mockNode);
+        }
+        
+        return nodes;
+    }
+}


### PR DESCRIPTION
When one of the replicas is down the eureka server status should reflect that in the healthy flag on `StatusInfo` and `/eureka/v2/status` endpoint.