### PR TITLE
Add fail fast option to AmazonInfo init

### DIFF
--- a/eureka-client/src/main/java/com/netflix/appinfo/AmazonInfo.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/AmazonInfo.java
@@ -61,7 +61,8 @@ public class AmazonInfo implements DataCenterInfo, UniqueIdentifier {
     private static DynamicIntProperty awsMetaDataRetries;
 
     /**
-     * A fail fast mechanism exist for autoBuilding AmazonInfo based on the below configurations.
+     * When creating an AmazonInfo via {@link com.netflix.appinfo.AmazonInfo.Builder#autoBuild(String)},
+     * a fail fast mechanism exist based on the below configuration.
      * If enabled (default to true), the {@link com.netflix.appinfo.AmazonInfo.Builder#autoBuild(String)}
      * method will exit early after failing to load the value for the first metadata key (instanceId),
      * after the expected number of retries as defined by {@link #awsMetaDataRetries}.
@@ -69,8 +70,7 @@ public class AmazonInfo implements DataCenterInfo, UniqueIdentifier {
     private static DynamicBooleanProperty awsMetaDataFailFastOnFirstLoad;
 
     private static final String AWS_API_VERSION = "latest";
-    private static final String AWS_METADATA_URL = "http://169.254.169.254/"
-            + AWS_API_VERSION + "/meta-data/";
+    private static final String AWS_METADATA_URL = "http://169.254.169.254/" + AWS_API_VERSION + "/meta-data/";
 
     public enum MetaDataKey {
         instanceId("instance-id"),  // always have this first as we use it as a fail fast mechanism
@@ -163,8 +163,7 @@ public class AmazonInfo implements DataCenterInfo, UniqueIdentifier {
 
 
     public static final class Builder {
-        private static final Logger logger = LoggerFactory
-                .getLogger(Builder.class);
+        private static final Logger logger = LoggerFactory.getLogger(Builder.class);
         private static final int SLEEP_TIME_MS = 100;
 
         @XStreamOmitField

--- a/eureka-client/src/main/java/com/netflix/appinfo/ApplicationInfoManager.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/ApplicationInfoManager.java
@@ -159,7 +159,7 @@ public class ApplicationInfoManager {
         String newAddress;
         if (config instanceof CloudInstanceConfig) {
             // Refresh data center info, and return up to date address
-            newAddress = ((CloudInstanceConfig) config).resolveDefaultAddress();
+            newAddress = ((CloudInstanceConfig) config).resolveDefaultAddress(true);
         } else {
             newAddress = config.getHostName(true);
         }

--- a/eureka-client/src/main/java/com/netflix/appinfo/CloudInstanceConfig.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/CloudInstanceConfig.java
@@ -81,7 +81,7 @@ public class CloudInstanceConfig extends PropertiesInstanceConfig {
     private AmazonInfo initDataCenterInfo() {
         AmazonInfo info;
         try {
-            info = AmazonInfo.Builder.newBuilder().autoBuild(namespace, true /* fail fast */);
+            info = AmazonInfo.Builder.newBuilder().autoBuild(namespace);
             logger.info("Datacenter is: " + Name.Amazon);
         } catch (Throwable e) {
             logger.error("Cannot initialize amazon info :", e);

--- a/eureka-client/src/main/java/com/netflix/appinfo/CloudInstanceConfig.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/CloudInstanceConfig.java
@@ -81,7 +81,7 @@ public class CloudInstanceConfig extends PropertiesInstanceConfig {
     private AmazonInfo initDataCenterInfo() {
         AmazonInfo info;
         try {
-            info = AmazonInfo.Builder.newBuilder().autoBuild(namespace);
+            info = AmazonInfo.Builder.newBuilder().autoBuild(namespace, true /* fail fast */);
             logger.info("Datacenter is: " + Name.Amazon);
         } catch (Throwable e) {
             logger.error("Cannot initialize amazon info :", e);
@@ -113,9 +113,17 @@ public class CloudInstanceConfig extends PropertiesInstanceConfig {
         return info;
     }
 
+    /**
+     * @deprecated use {@link #resolveDefaultAddress(boolean)}
+     */
+    @Deprecated
     public String resolveDefaultAddress() {
+        return this.resolveDefaultAddress(true);
+    }
+
+    public String resolveDefaultAddress(boolean refresh) {
         // In this method invocation data center info will be refreshed.
-        String result = getHostName(true);
+        String result = getHostName(refresh);
 
         for (String name : getDefaultAddressResolutionOrder()) {
             try {

--- a/eureka-client/src/main/java/com/netflix/appinfo/providers/EurekaConfigBasedInstanceInfoProvider.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/providers/EurekaConfigBasedInstanceInfoProvider.java
@@ -64,7 +64,7 @@ public class EurekaConfigBasedInstanceInfoProvider implements Provider<InstanceI
             String defaultAddress;
             if (config instanceof CloudInstanceConfig) {
                 // Refresh AWS data center info, and return up to date address
-                defaultAddress = ((CloudInstanceConfig) config).resolveDefaultAddress();
+                defaultAddress = ((CloudInstanceConfig) config).resolveDefaultAddress(false);
             } else {
                 defaultAddress = config.getHostName(false);
             }

--- a/eureka-client/src/test/java/com/netflix/appinfo/CloudInstanceConfigTest.java
+++ b/eureka-client/src/test/java/com/netflix/appinfo/CloudInstanceConfigTest.java
@@ -62,13 +62,13 @@ public class CloudInstanceConfigTest {
     public void testResolveDefaultAddress() {
         config.info = (AmazonInfo) instanceInfo.getDataCenterInfo();
         AmazonInfo info = (AmazonInfo) instanceInfo.getDataCenterInfo();
-        assertThat(config.resolveDefaultAddress(), is(info.get(publicHostname)));
+        assertThat(config.resolveDefaultAddress(false), is(info.get(publicHostname)));
 
         config.info.getMetadata().remove(publicHostname.getName());
-        assertThat(config.resolveDefaultAddress(), is(info.get(localIpv4)));
+        assertThat(config.resolveDefaultAddress(false), is(info.get(localIpv4)));
 
         config.info.getMetadata().remove(localIpv4.getName());
-        assertThat(config.resolveDefaultAddress(), is(dummyDefault));
+        assertThat(config.resolveDefaultAddress(false), is(dummyDefault));
     }
 
     @Test


### PR DESCRIPTION
Add fail fast option to AmazonInfo init (esp at bootstrap time) so that running with VPN will not unncecessarily cause long hang times waiting on each key's ReadTimeout.