### PR TITLE
Handle on demand update within InstanceInfoReplicator initial delay

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/InstanceInfoReplicator.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/InstanceInfoReplicator.java
@@ -62,7 +62,8 @@ class InstanceInfoReplicator implements Runnable {
     public void start(int initialDelayMs) {
         if (started.compareAndSet(false, true)) {
             instanceInfo.setIsDirty();  // for initial register
-            scheduler.schedule(this, initialDelayMs, TimeUnit.SECONDS);
+            Future next = scheduler.schedule(this, initialDelayMs, TimeUnit.SECONDS);
+            scheduledPeriodicRef.set(next);
         }
     }
 
@@ -78,9 +79,9 @@ class InstanceInfoReplicator implements Runnable {
                 public void run() {
                     logger.debug("Executing on-demand update of local InstanceInfo");
 
-                    // cancel the latest scheduled update, it will be rescheduled at the end of run()
                     Future latestPeriodic = scheduledPeriodicRef.get();
                     if (latestPeriodic != null && !latestPeriodic.isDone()) {
+                        logger.debug("Canceling the latest scheduled update, it will be rescheduled at the end of on demand update");
                         latestPeriodic.cancel(false);
                     }
 

--- a/eureka-client/src/test/java/com/netflix/discovery/InstanceInfoReplicatorTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/InstanceInfoReplicatorTest.java
@@ -96,4 +96,15 @@ public class InstanceInfoReplicatorTest {
         verify(discoveryClient, times(3)).refreshInstanceInfo(); // 1 initial refresh, 1 onDemand, 1 auto
         verify(discoveryClient, times(1)).register();  // all but 1 is no-op
     }
+
+    @Test
+    public void testOnDemandUpdateResetAutomaticRefreshWithInitialDelay() throws Throwable {
+        replicator.start(1000 * refreshRateSeconds);
+
+        assertTrue(replicator.onDemandUpdate());
+
+        Thread.sleep(1000 * refreshRateSeconds + 100);
+        verify(discoveryClient, times(2)).refreshInstanceInfo(); // 1 onDemand, 1 auto
+        verify(discoveryClient, times(1)).register();  // all but 1 is no-op
+    }
 }


### PR DESCRIPTION
When performing an on demand status update within the InstanceInfoReplicator start's initial delay the originally scheduled task is not cancelled which results in two scheduled tasks being executed for the life of the process.