### PR TITLE
! Fix erroneous connectionIdleTimeout value

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/shared/transport/EurekaClientFactoryBuilder.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/transport/EurekaClientFactoryBuilder.java
@@ -18,7 +18,7 @@ public abstract class EurekaClientFactoryBuilder<F, B extends EurekaClientFactor
 
     private static final int DEFAULT_MAX_CONNECTIONS_PER_HOST = 50;
     private static final int DEFAULT_MAX_TOTAL_CONNECTIONS = 200;
-    private static final long DEFAULT_CONNECTION_IDLE_TIMEOUT = 30 * 1000;
+    private static final long DEFAULT_CONNECTION_IDLE_TIMEOUT = 30;
 
     protected InstanceInfo myInstanceInfo;
     protected boolean allowRedirect;

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/transport/jersey/JerseyEurekaHttpClientFactory.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/transport/jersey/JerseyEurekaHttpClientFactory.java
@@ -123,7 +123,7 @@ public class JerseyEurekaHttpClientFactory implements TransportClientFactory {
                 .withReadTimeout(clientConfig.getEurekaServerReadTimeoutSeconds() * 1000)
                 .withMaxConnectionsPerHost(clientConfig.getEurekaServerTotalConnectionsPerHost())
                 .withMaxTotalConnections(clientConfig.getEurekaServerTotalConnections())
-                .withConnectionIdleTimeout(clientConfig.getEurekaConnectionIdleTimeoutSeconds())
+                .withConnectionIdleTimeout(clientConfig.getEurekaConnectionIdleTimeoutSeconds() * 1000)
                 .withEncoder(clientConfig.getEncoderName())
                 .withDecoder(clientConfig.getDecoderName(), clientConfig.getClientDataAccept())
                 .withClientIdentity(clientIdentity);


### PR DESCRIPTION
This commit is related to issue [https://github.com/spring-cloud/spring-cloud-netflix/issues/729](https://github.com/spring-cloud/spring-cloud-netflix/issues/729).

When overriding the connectionIdleTimeout value, it was erroneously using a seconds value, although default value is in milliseconds.