### PR TITLE
Prefer javax.inject Provider over guice Provider for #807

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
@@ -44,6 +44,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import javax.annotation.Nullable;
 import javax.annotation.PreDestroy;
+import javax.inject.Provider;
 import javax.inject.Singleton;
 import javax.ws.rs.core.Response.Status;
 
@@ -54,7 +55,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
-import com.google.inject.Provider;
 import com.netflix.appinfo.ApplicationInfoManager;
 import com.netflix.appinfo.HealthCheckCallback;
 import com.netflix.appinfo.HealthCheckCallbackToHandlerBridge;

--- a/eureka-client/src/main/java/com/netflix/discovery/InternalEurekaStatusModule.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/InternalEurekaStatusModule.java
@@ -1,11 +1,11 @@
 package com.netflix.discovery;
 
 import javax.inject.Inject;
+import javax.inject.Provider;
 import javax.inject.Singleton;
 
 import com.google.common.base.Supplier;
 import com.google.inject.AbstractModule;
-import com.google.inject.Provider;
 import com.google.inject.TypeLiteral;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.governator.annotations.binding.DownStatus;

--- a/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientOptionalArgsTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientOptionalArgsTest.java
@@ -1,0 +1,54 @@
+package com.netflix.discovery;
+
+import javax.inject.Provider;
+
+import org.junit.Test;
+
+import com.netflix.appinfo.HealthCheckCallback;
+import com.netflix.appinfo.HealthCheckHandler;
+import com.netflix.discovery.DiscoveryClient.DiscoveryClientOptionalArgs;
+
+/**
+ * @author Matt Nelson
+ */
+public class DiscoveryClientOptionalArgsTest {
+    
+    @Test
+    public void testHealthCheckCallbackGuiceProvider() {
+        DiscoveryClientOptionalArgs args = new DiscoveryClientOptionalArgs();
+        args.setHealthCheckCallbackProvider(new GuiceProvider<HealthCheckCallback>());
+    }
+    
+    @Test
+    public void testHealthCheckCallbackJavaxProvider() {
+        DiscoveryClientOptionalArgs args = new DiscoveryClientOptionalArgs();
+        args.setHealthCheckCallbackProvider(new JavaxProvider<HealthCheckCallback>());
+    }
+    
+    @Test
+    public void testHealthCheckHandlerGuiceProvider() {
+        DiscoveryClientOptionalArgs args = new DiscoveryClientOptionalArgs();
+        args.setHealthCheckHandlerProvider(new GuiceProvider<HealthCheckHandler>());
+    }
+    
+    @Test
+    public void testHealthCheckHandlerJavaxProvider() {
+        DiscoveryClientOptionalArgs args = new DiscoveryClientOptionalArgs();
+        args.setHealthCheckHandlerProvider(new JavaxProvider<HealthCheckHandler>());
+    }
+    
+    private class JavaxProvider<T> implements Provider<T> {
+        @Override
+        public T get() {
+            return null;
+        }
+    }
+    
+    private class GuiceProvider<T> implements com.google.inject.Provider<T> {
+        
+        @Override
+        public T get() {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Made the changes to prefer the javax.inject Provider over the guice Provider where possible. The remaining usages of the guice provider are blocked by https://github.com/google/guice/pull/926.