### PR TITLE
Check the sub-string index value before trying to sub-string on it.

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/aws/EIPManager.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/aws/EIPManager.java
@@ -343,10 +343,16 @@ public class EIPManager implements AwsBinder {
         }
         for (String cname : ec2Urls) {
             int beginIndex = cname.indexOf("ec2-") + 4;
-            int endIndex = cname.indexOf(regionPhrase + ".compute");
-            String eipStr = cname.substring(beginIndex, endIndex);
-            String eip = eipStr.replaceAll("\\-", ".");
-            returnedUrls.add(eip);
+
+            // Handle case where there are no cnames containing "ec2-"
+            // Reasons include:
+            //  Systems without public addresses - purely attached to corp lan via AWS Direct Connect
+            if (-1 < beginIndex) {
+                int endIndex = cname.indexOf(regionPhrase + ".compute");
+                String eipStr = cname.substring(beginIndex, endIndex);
+                String eip = eipStr.replaceAll("\\-", ".");
+                returnedUrls.add(eip);
+            }
         }
         return returnedUrls;
     }


### PR DESCRIPTION
See issue #818 -

In a private application with no elastic IPs exceptions will be thrown when there are no URLs containing "ec2-".  With this modification, the exception will not be thrown and the rest of the process will simply not bind to any EIPs.