### PR TITLE
Support eureka servers configured with IP addresses

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/cluster/PeerEurekaNodes.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/cluster/PeerEurekaNodes.java
@@ -18,6 +18,7 @@ import com.netflix.appinfo.ApplicationInfoManager;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.discovery.EurekaClientConfig;
 import com.netflix.discovery.endpoint.EndpointUtils;
+import com.netflix.discovery.shared.Application;
 import com.netflix.eureka.EurekaServerConfig;
 import com.netflix.eureka.registry.PeerAwareInstanceRegistry;
 import com.netflix.eureka.resources.ServerCodecs;
@@ -228,9 +229,23 @@ public class PeerEurekaNodes {
      *         replicate, false otherwise.
      */
     public boolean isThisMyUrl(String url) {
-        InstanceInfo myInfo = applicationInfoManager.getInfo();
+        return isInstanceURL(url, applicationInfoManager.getInfo());
+    }
+    
+    /**
+     * Checks if the given service url matches the supplied instance
+     *
+     * @param url the service url of the replica node that the check is made.
+     * @param instance the instance to check the service url against
+     * @return true, if the url represents the supplied instance, false otherwise.
+     */
+    public boolean isInstanceURL(String url, InstanceInfo instance) {
         String hostName = hostFromUrl(url);
-        return hostName != null && hostName.equals(myInfo.getHostName());
+        String myInfoComparator = instance.getHostName();
+        if (clientConfig.getTransportConfig().applicationsResolverUseIp()) {
+            myInfoComparator = instance.getIPAddr();
+        }
+        return hostName != null && hostName.equals(myInfoComparator);
     }
 
     public static String hostFromUrl(String url) {

--- a/eureka-core/src/main/java/com/netflix/eureka/util/StatusUtil.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/util/StatusUtil.java
@@ -57,17 +57,15 @@ public class StatusUtil {
     private boolean isReplicaAvailable(String myAppName, String url) {
 
         try {
-            String givenHostName = new URI(url).getHost();
             Application app = registry.getApplication(myAppName, false);
             if (app == null) {
                 return false;
             }
             for (InstanceInfo info : app.getInstances()) {
-                if (info.getHostName().equals(givenHostName)) {
+                if (peerEurekaNodes.isInstanceURL(url, info)) {
                     return true;
                 }
             }
-            givenHostName = new URI(url).getHost();
         } catch (Throwable e) {
             logger.error("Could not determine if the replica is available ", e);
         }


### PR DESCRIPTION
When configuring the `eureka.serviceUrl.default` with IP addresses the comparisons performed in `PeerEurekaNodes` and `StatusUtil` prevent the instances from recognizing themselves and therefore never report themselves as available.

As discussed on #821 (https://github.com/Netflix/eureka/pull/821#issuecomment-237416131) follow PR.