### PR TITLE
Remove use of deprecated static accessor.

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/util/StatusInfo.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/util/StatusInfo.java
@@ -42,6 +42,11 @@ public class StatusInfo {
             return this;
         }
 
+        public Builder withInstanceInfo(InstanceInfo instanceInfo) {
+            result.instanceInfo = instanceInfo;
+            return this;
+        }
+
         /**
          * Add any application specific status data.
          */
@@ -58,6 +63,10 @@ public class StatusInfo {
          * built here too.
          */
         public StatusInfo build() {
+            if (result.instanceInfo == null) {
+                throw new IllegalStateException("instanceInfo can not be null");
+            }
+
             result.generalStats.put("server-uptime", getUpTime());
             result.generalStats.put("environment", ConfigurationManager
                     .getDeploymentContext().getDeploymentEnvironment());

--- a/eureka-core/src/main/java/com/netflix/eureka/util/StatusUtil.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/util/StatusUtil.java
@@ -20,11 +20,13 @@ public class StatusUtil {
     private final String myAppName;
     private final PeerAwareInstanceRegistry registry;
     private final PeerEurekaNodes peerEurekaNodes;
+    private final InstanceInfo instanceInfo;
 
     public StatusUtil(EurekaServerContext server) {
         this.myAppName = server.getApplicationInfoManager().getInfo().getAppName();
         this.registry = server.getRegistry();
         this.peerEurekaNodes = server.getPeerEurekaNodes();
+        this.instanceInfo = server.getApplicationInfoManager().getInfo();
     }
 
     public StatusInfo getStatusInfo() {
@@ -50,6 +52,8 @@ public class StatusUtil {
         builder.add("registered-replicas", replicaHostNames.toString());
         builder.add("available-replicas", upReplicas.toString());
         builder.add("unavailable-replicas", downReplicas.toString());
+
+        builder.withInstanceInfo(this.instanceInfo);
 
         return builder.build();
     }


### PR DESCRIPTION
Add a builder method and check that instanceInfo is not null in build().

Found this in a test where the static singleton was null :-(
