### PR TITLE
Convert all remaining guice provider references to javax

### DIFF
--- a/eureka-client/src/main/java/com/netflix/appinfo/providers/CloudInstanceConfigProvider.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/providers/CloudInstanceConfigProvider.java
@@ -1,7 +1,8 @@
 package com.netflix.appinfo.providers;
 
+import javax.inject.Provider;
+
 import com.google.inject.Inject;
-import com.google.inject.Provider;
 import com.netflix.appinfo.CloudInstanceConfig;
 import com.netflix.discovery.DiscoveryManager;
 import com.netflix.discovery.EurekaNamespace;

--- a/eureka-client/src/main/java/com/netflix/appinfo/providers/EurekaConfigBasedInstanceInfoProvider.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/providers/EurekaConfigBasedInstanceInfoProvider.java
@@ -1,11 +1,10 @@
 package com.netflix.appinfo.providers;
 
 import javax.inject.Singleton;
+import javax.inject.Provider;
 import java.util.Map;
 
 import com.google.inject.Inject;
-import com.google.inject.Provider;
-import com.netflix.appinfo.CloudInstanceConfig;
 import com.netflix.appinfo.DataCenterInfo;
 import com.netflix.appinfo.EurekaInstanceConfig;
 import com.netflix.appinfo.InstanceInfo;

--- a/eureka-client/src/main/java/com/netflix/appinfo/providers/MyDataCenterInstanceConfigProvider.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/providers/MyDataCenterInstanceConfigProvider.java
@@ -1,7 +1,8 @@
 package com.netflix.appinfo.providers;
 
+import javax.inject.Provider;
+
 import com.google.inject.Inject;
-import com.google.inject.Provider;
 import com.netflix.appinfo.EurekaInstanceConfig;
 import com.netflix.appinfo.MyDataCenterInstanceConfig;
 import com.netflix.discovery.DiscoveryManager;

--- a/eureka-client/src/main/java/com/netflix/discovery/providers/DefaultEurekaClientConfigProvider.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/providers/DefaultEurekaClientConfigProvider.java
@@ -1,7 +1,8 @@
 package com.netflix.discovery.providers;
 
+import javax.inject.Provider;
+
 import com.google.inject.Inject;
-import com.google.inject.Provider;
 import com.netflix.discovery.DefaultEurekaClientConfig;
 import com.netflix.discovery.DiscoveryManager;
 import com.netflix.discovery.EurekaClientConfig;


### PR DESCRIPTION
Follow up to #808 now that guice has been released and pulled in.