### PR TITLE
Remove assignment of instanceInfo from static instance.

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/util/StatusInfo.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/util/StatusInfo.java
@@ -84,9 +84,6 @@ public class StatusInfo {
                     String.valueOf(totalMem - freeMem) + "mb" + " ("
                             + usedPercent + "%)");
 
-            result.instanceInfo = ApplicationInfoManager.getInstance()
-                    .getInfo();
-
             return result;
         }
     }


### PR DESCRIPTION
f40f54a03d135379845aeb8c060b4f768fe7e7b5 made instanceInfo a required field to be set, but an assignment was still happening from `ApplicationInfoManager.getInstance().getInfo()` overwriting assigned field.