### PR TITLE
Update gradle version from 2.10 to 3.3

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-bin.zip


### PR DESCRIPTION
The version 3.3 brings a lot of performance improvements and bug fixes
As can be seen in the following link:
https://docs.gradle.org/current/release-notes

Signed-off-by: Bruno Bottazzini <bruno.bottazzini@targatelematics.com>