### PR TITLE
Fixed missing url in log output

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/shared/resolver/LegacyClusterResolver.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/resolver/LegacyClusterResolver.java
@@ -115,7 +115,7 @@ public class LegacyClusterResolver implements ClusterResolver<AwsEndpoint> {
                             myZone
                     ));
                 } catch (URISyntaxException ignore) {
-                    logger.warn("Invalid eureka server URI: ; removing from the server pool", serviceUrl);
+                    logger.warn("Invalid eureka server URI: {}; removing from the server pool", serviceUrl);
                 }
             }
             return endpoints;

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/resolver/aws/ConfigClusterResolver.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/resolver/aws/ConfigClusterResolver.java
@@ -7,8 +7,6 @@ import com.netflix.discovery.shared.resolver.ClusterResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -79,11 +77,11 @@ public class ConfigClusterResolver implements ClusterResolver<AwsEndpoint> {
 
         List<AwsEndpoint> endpoints = new ArrayList<>();
         for (String zone : serviceUrls.keySet()) {
-            for(String url : serviceUrls.get(zone)) {
+            for (String url : serviceUrls.get(zone)) {
                 try {
                     endpoints.add(new AwsEndpoint(url, getRegion(), zone));
                 } catch (Exception ignore) {
-                    logger.warn("Invalid eureka server URI: ; removing from the server pool", url);
+                    logger.warn("Invalid eureka server URI: {}; removing from the server pool", url);
                 }
             }
         }


### PR DESCRIPTION
We get a lot of these log messages in our logfiles. We can't see which URL is causing the log message, as the placeholder {} is missing in the text. This pull request fixes this.