### PR TITLE
Scope governator dependencies to reflect actual usage

### DIFF
--- a/eureka-client-archaius2/build.gradle
+++ b/eureka-client-archaius2/build.gradle
@@ -21,5 +21,5 @@ dependencies {
     testCompile "org.mockito:mockito-core:${mockitoVersion}"
     testCompile "org.mock-server:mockserver-netty:${mockserverVersion}"
     testCompile "com.netflix.archaius:archaius2-guice:${archaius2Version}"
-
+    testCompile "com.netflix.governator:governator:${governatorVersion}"
 }

--- a/eureka-client-jersey2/build.gradle
+++ b/eureka-client-jersey2/build.gradle
@@ -38,4 +38,5 @@ dependencies {
 
     testCompile "junit:junit:${junit_version}"
     testCompile "org.mockito:mockito-core:${mockitoVersion}"
+    testCompile "com.netflix.governator:governator:${governatorVersion}"
 }

--- a/eureka-client/build.gradle
+++ b/eureka-client/build.gradle
@@ -34,4 +34,5 @@ dependencies {
     testCompile 'org.mortbay.jetty:jetty:6.1H.22'
     testCompile "org.mockito:mockito-core:${mockitoVersion}"
     testCompile "org.mock-server:mockserver-netty:${mockserverVersion}"
+    testCompile "com.netflix.governator:governator:${governatorVersion}"
 }

--- a/eureka-core/build.gradle
+++ b/eureka-core/build.gradle
@@ -7,7 +7,6 @@ dependencies {
     compile "com.amazonaws:aws-java-sdk-sts:${awsVersion}"
     compile "com.amazonaws:aws-java-sdk-route53:${awsVersion}"
     compile "javax.servlet:servlet-api:${servletVersion}"
-    compile "com.netflix.governator:governator:${governatorVersion}"
     compile 'com.thoughtworks.xstream:xstream:1.4.9'
     compile 'javax.ws.rs:jsr311-api:1.1.1'
 


### PR DESCRIPTION
Governator was scoped as a compile dependency of eureka-core incorrectly. A few other modules needed it for testing. This fixes consumers from pulling in this dependency transitively when it is not used.