### PR TITLE
Improving conditional statement for map

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
@@ -135,7 +135,7 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
 
     protected void initRemoteRegionRegistry() throws MalformedURLException {
         Map<String, String> remoteRegionUrlsWithName = serverConfig.getRemoteRegionUrlsWithName();
-        if (remoteRegionUrlsWithName != null) {
+        if (remoteRegionUrlsWithName.size() > 0) {
             allKnownRemoteRegions = new String[remoteRegionUrlsWithName.size()];
             int remoteRegionArrayIndex = 0;
             for (Map.Entry<String, String> remoteRegionUrlWithName : remoteRegionUrlsWithName.entrySet()) {


### PR DESCRIPTION
remoteRegionUrlsWithName can never null, so change null check condition

According to EurekaServerConfig.java's remoteRegionUrlsWithName comment
  Empty map if no remote region url is defined.

Now, Always running
https://github.com/Netflix/eureka/blob/4f24d9dcf90713b421f6c092fa63e707cbf74df3/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java#L138-L151