### PR TITLE
Fix Override Status Regression

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 
 idea {
     project {
-        languageLevel = '1.7'
+        languageLevel = '1.8'
     }
 }
 

--- a/eureka-client/src/main/java/com/netflix/appinfo/InstanceInfo.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/InstanceInfo.java
@@ -1237,6 +1237,16 @@ public class InstanceInfo {
         lastDirtyTimestamp = System.currentTimeMillis();
     }
 
+    /**
+     * Set the dirty flag, and also return the timestamp of the isDirty event
+     *
+     * @return the timestamp when the isDirty flag is set
+     */
+    public synchronized long setIsDirtyWithTime() {
+        setIsDirty();
+        return lastDirtyTimestamp;
+    }
+
 
     /**
      * Unset the dirty flag iff the unsetDirtyTimestamp matches the lastDirtyTimestamp. No-op if

--- a/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
@@ -826,7 +826,10 @@ public class DiscoveryClient implements EurekaClient {
             if (httpResponse.getStatusCode() == 404) {
                 REREGISTER_COUNTER.increment();
                 logger.info("{} - Re-registering apps/{}", PREFIX + appPathIdentifier, instanceInfo.getAppName());
-                return register();
+                long timestamp = instanceInfo.setIsDirtyWithTime();
+                boolean result = register();
+                instanceInfo.unsetIsDirty(timestamp);
+                return result;
             }
             return httpResponse.getStatusCode() == 200;
         } catch (Throwable e) {

--- a/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
@@ -207,6 +207,9 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
                 Long existingLastDirtyTimestamp = existingLease.getHolder().getLastDirtyTimestamp();
                 Long registrationLastDirtyTimestamp = registrant.getLastDirtyTimestamp();
                 logger.debug("Existing lease found (existing={}, provided={}", existingLastDirtyTimestamp, registrationLastDirtyTimestamp);
+
+                // this is a > instead of a >= because if the timestamps are equal, we still take the remote transmitted
+                // InstanceInfo instead of the server local copy.
                 if (existingLastDirtyTimestamp > registrationLastDirtyTimestamp) {
                     logger.warn("There is an existing lease and the existing lease's dirty timestamp {} is greater" +
                             " than the one that is being registered {}", existingLastDirtyTimestamp, registrationLastDirtyTimestamp);
@@ -374,7 +377,7 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
                     logger.info(
                             "The instance status {} is different from overridden instance status {} for instance {}. "
                                     + "Hence setting the status to overridden status", args);
-                    instanceInfo.setStatus(overriddenInstanceStatus);
+                    instanceInfo.setStatusWithoutDirty(overriddenInstanceStatus);
                 }
             }
             renewsLastMin.increment();

--- a/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
@@ -487,6 +487,7 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
                     // replica start up
                     info.setOverriddenStatus(newStatus);
                     long replicaDirtyTimestamp = 0;
+                    info.setStatusWithoutDirty(newStatus);
                     if (lastDirtyTimestamp != null) {
                         replicaDirtyTimestamp = Long.valueOf(lastDirtyTimestamp);
                     }
@@ -494,9 +495,6 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
                     // it to the replica's.
                     if (replicaDirtyTimestamp > info.getLastDirtyTimestamp()) {
                         info.setLastDirtyTimestamp(replicaDirtyTimestamp);
-                        info.setStatusWithoutDirty(newStatus);
-                    } else {
-                        info.setStatus(newStatus);
                     }
                     info.setActionType(ActionType.MODIFIED);
                     recentlyChangedQueue.add(new RecentlyChangedItem(lease));
@@ -549,7 +547,7 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
                 InstanceStatus currentOverride = overriddenInstanceStatusMap.remove(id);
                 if (currentOverride != null && info != null) {
                     info.setOverriddenStatus(InstanceStatus.UNKNOWN);
-                    info.setStatus(newStatus);
+                    info.setStatusWithoutDirty(newStatus);
                     long replicaDirtyTimestamp = 0;
                     if (lastDirtyTimestamp != null) {
                         replicaDirtyTimestamp = Long.valueOf(lastDirtyTimestamp);

--- a/eureka-core/src/main/java/com/netflix/eureka/resources/ApplicationResource.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/resources/ApplicationResource.java
@@ -149,6 +149,8 @@ public class ApplicationResource {
             return Response.status(400).entity("Missing instanceId").build();
         } else if (isBlank(info.getHostName())) {
             return Response.status(400).entity("Missing hostname").build();
+        } else if (isBlank(info.getIPAddr())) {
+            return Response.status(400).entity("Missing ip address").build();
         } else if (isBlank(info.getAppName())) {
             return Response.status(400).entity("Missing appName").build();
         } else if (!appName.equals(info.getAppName())) {

--- a/eureka-core/src/test/java/com/netflix/eureka/AbstractTester.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/AbstractTester.java
@@ -176,6 +176,7 @@ public class AbstractTester {
 
     private static InstanceInfo createLocalInstanceWithStatus(String hostname, InstanceInfo.InstanceStatus status) {
         InstanceInfo.Builder instanceBuilder = InstanceInfo.Builder.newBuilder();
+        instanceBuilder.setInstanceId("foo");
         instanceBuilder.setAppName(LOCAL_REGION_APP_NAME);
         instanceBuilder.setHostName(hostname);
         instanceBuilder.setIPAddr("10.10.101.1");

--- a/eureka-core/src/test/java/com/netflix/eureka/resources/ApplicationResourceTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/resources/ApplicationResourceTest.java
@@ -102,6 +102,11 @@ public class ApplicationResourceTest extends AbstractTester {
         assertThat(response.getStatus(), is(400));
 
         instanceInfo = spy(InstanceInfoGenerator.takeOne());
+        when(instanceInfo.getIPAddr()).thenReturn(null);
+        response = applicationResource.addInstance(instanceInfo, false+"");
+        assertThat(response.getStatus(), is(400));
+
+        instanceInfo = spy(InstanceInfoGenerator.takeOne());
         when(instanceInfo.getAppName()).thenReturn("");
         response = applicationResource.addInstance(instanceInfo, false+"");
         assertThat(response.getStatus(), is(400));


### PR DESCRIPTION
Setting and deleting the override status on an eureka server has a regression due to the `lastDirtyTimestamp` being updated by the server in response to the set and delete, which can in turn lead to client update/registers potentially being ignored due to the timestamp being ahead on the server compared to client local.