### PR TITLE
Prevent "null" url server url prefix

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/endpoint/EndpointUtils.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/endpoint/EndpointUtils.java
@@ -145,10 +145,18 @@ public class EndpointUtils {
                     randomizer.randomize(ec2Urls);
                 }
                 for (String ec2Url : ec2Urls) {
-                    String serviceUrl = "http://" + ec2Url + ":"
-                            + clientConfig.getEurekaServerPort()
-                            + "/" + clientConfig.getEurekaServerURLContext()
-                            + "/";
+                    StringBuilder sb = new StringBuilder()
+                            .append("http://")
+                            .append(ec2Url)
+                            .append(":")
+                            .append(clientConfig.getEurekaServerPort());
+                    if (clientConfig.getEurekaServerURLContext() != null) {
+                        if (!clientConfig.getEurekaServerURLContext().startsWith("/")) {
+                            sb.append("/");
+                        }
+                        sb.append(clientConfig.getEurekaServerURLContext());
+                    }
+                    String serviceUrl = sb.toString();
                     logger.debug("The EC2 url is {}", serviceUrl);
                     serviceUrls.add(serviceUrl);
                 }

--- a/eureka-client/src/main/java/com/netflix/discovery/endpoint/EndpointUtils.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/endpoint/EndpointUtils.java
@@ -155,6 +155,8 @@ public class EndpointUtils {
                             sb.append("/");
                         }
                         sb.append(clientConfig.getEurekaServerURLContext());
+                    } else {
+                        sb.append("/");
                     }
                     String serviceUrl = sb.toString();
                     logger.debug("The EC2 url is {}", serviceUrl);


### PR DESCRIPTION
When set `shouldUseDns` as true with null `eurekaServer.context`, `EndpointUtils#getServiceUrlsFromDNS` appends "null" string to service url postfix.

e.g. http://ec2-10-0-0-1.ap-northeast-2.compute.amazonaws.com/null/

Fixed this.