### PR TITLE
Avoid scheduling when DiscoveryClient.shutdown called (fix for #973)

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/InstanceInfoReplicator.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/InstanceInfoReplicator.java
@@ -68,7 +68,11 @@ class InstanceInfoReplicator implements Runnable {
     }
 
     public void stop() {
-        scheduler.shutdownNow();
+        try {
+            scheduler.awaitTermination(3, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            logger.warn("Scheduler stop interrupted");
+        }
         started.set(false);
     }
 

--- a/eureka-client/src/main/java/com/netflix/discovery/InstanceInfoReplicator.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/InstanceInfoReplicator.java
@@ -69,12 +69,6 @@ class InstanceInfoReplicator implements Runnable {
     }
 
     public void stop() {
-        Future latestPeriodic = scheduledPeriodicRef.get();
-        if (latestPeriodic != null && !latestPeriodic.isDone()) {
-            logger.info("Canceling the latest scheduled before stop");
-            boolean result = latestPeriodic.cancel(false);
-            System.out.println("Result:" + result);
-        }
         shutdownAndAwaitTermination(scheduler);
         started.set(false);
     }

--- a/eureka-client/src/main/java/com/netflix/discovery/InstanceInfoReplicator.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/InstanceInfoReplicator.java
@@ -6,6 +6,7 @@ import com.netflix.discovery.util.RateLimiter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;


### PR DESCRIPTION
Based off code cleanup comments for pull #974, this should fix #973.

`awaitTermination` should block until the  DOWN replication thread is completed before finishing shutdown/registration.  This should prevent race conditions between registration:DOWN and de-register.