### PR TITLE
prevent replication flood caused by socket read time out leads to some node CPU 100%

### DIFF
--- a/eureka-core/src/test/java/com/netflix/eureka/cluster/ReplicationTaskProcessorTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/cluster/ReplicationTaskProcessorTest.java
@@ -81,6 +81,18 @@ public class ReplicationTaskProcessorTest {
         assertThat(status, is(ProcessingResult.Congestion));
         assertThat(task.getProcessingState(), is(ProcessingState.Pending));
     }
+    
+    @Test
+    public void testBatchableTaskNetworkReadTimeOutHandling() throws Exception {
+        TestableInstanceReplicationTask task = aReplicationTask().build();
+
+        replicationClient.withReadtimeOut(1);
+        ProcessingResult status = replicationTaskProcessor.process(Collections.<ReplicationTask>singletonList(task));
+
+        assertThat(status, is(ProcessingResult.Congestion));
+        assertThat(task.getProcessingState(), is(ProcessingState.Pending));
+    }
+
 
     @Test
     public void testBatchableTaskNetworkFailureHandling() throws Exception {

--- a/eureka-core/src/test/java/com/netflix/eureka/cluster/TestableHttpReplicationClient.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/cluster/TestableHttpReplicationClient.java
@@ -151,7 +151,7 @@ public class TestableHttpReplicationClient implements HttpReplicationClient {
     public EurekaHttpResponse<ReplicationListResponse> submitBatchUpdates(ReplicationList replicationList) {
     	
         if (readTimeOutCounter.get() < readtimeOutRepeatCount) {
-            networkFailureCounter.incrementAndGet();
+            readTimeOutCounter.incrementAndGet();
             throw new RuntimeException(new SocketTimeoutException("Read timed out"));
         }
     	

--- a/eureka-core/src/test/java/com/netflix/eureka/cluster/TestableHttpReplicationClient.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/cluster/TestableHttpReplicationClient.java
@@ -2,6 +2,7 @@ package com.netflix.eureka.cluster;
 
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
@@ -32,12 +33,17 @@ public class TestableHttpReplicationClient implements HttpReplicationClient {
     private int[] networkStatusCodes;
     private InstanceInfo instanceInfoFromPeer;
     private int networkFailuresRepeatCount;
+    private int readtimeOutRepeatCount;
+
 
     private int batchStatusCode;
 
     private final AtomicInteger callCounter = new AtomicInteger();
     private final AtomicInteger networkFailureCounter = new AtomicInteger();
+    private final AtomicInteger readTimeOutCounter = new AtomicInteger();
+
     private long processingDelayMs;
+    
 
     private final BlockingQueue<HandledRequest> handledRequests = new LinkedBlockingQueue<>();
 
@@ -53,9 +59,12 @@ public class TestableHttpReplicationClient implements HttpReplicationClient {
         this.batchStatusCode = batchStatusCode;
     }
 
-
     public void withNetworkError(int networkFailuresRepeatCount) {
         this.networkFailuresRepeatCount = networkFailuresRepeatCount;
+    }
+
+    public void withReadtimeOut(int readtimeOutRepeatCount) {
+        this.readtimeOutRepeatCount = readtimeOutRepeatCount;
     }
 
     public void withProcessingDelay(long processingDelay, TimeUnit timeUnit) {
@@ -140,6 +149,13 @@ public class TestableHttpReplicationClient implements HttpReplicationClient {
 
     @Override
     public EurekaHttpResponse<ReplicationListResponse> submitBatchUpdates(ReplicationList replicationList) {
+    	
+        if (readTimeOutCounter.get() < readtimeOutRepeatCount) {
+            networkFailureCounter.incrementAndGet();
+            throw new RuntimeException(new SocketTimeoutException("Read timed out"));
+        }
+    	
+    	
         if (networkFailureCounter.get() < networkFailuresRepeatCount) {
             networkFailureCounter.incrementAndGet();
             throw new RuntimeException(new IOException("simulated network failure"));


### PR DESCRIPTION
when the instance become more then 3k,the batch replicated operation become easier to timeout.
because the replication request sender will retry the replication soon,it leads to a flood.
When it's happend,it appears to some eureka node ocupied 100% CPU and stucked.
This commit will help reduce the sympton,and write a clear log message to help debug.

By the way , i suggest to allow user to config the Congestion and TransientError retry delay time