### PR TITLE
update: compatible txt value format: "host1 host2 host3"

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/endpoint/DnsResolver.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/endpoint/DnsResolver.java
@@ -134,6 +134,14 @@ public final class DnsResolver {
         String txtRecord = null;
         if (attr != null) {
             txtRecord = attr.get().toString();
+
+            /**
+             * compatible splited txt record of "host1 host2 host3" but not "host1" "host2" "host3".
+             * some dns service provider support txt value only format "host1 host2 host3"
+             */
+            if (txtRecord.startsWith("\"") && txtRecord.endsWith("\"")) {
+                txtRecord = txtRecord.substring(1, txtRecord.length() - 1);
+            }
         }
 
         Set<String> cnamesSet = new TreeSet<String>();


### PR DESCRIPTION
fix #1053 

Remove the opening and closing quotes when the TXT dns record as format:
> "host1 host2 host3"

to compatible with aws route53 format:
>"host1" "host2" "host3"

(this format will remove quotes before the return of call dirContext.getAttributes(...))