### PR TITLE
bugfixing: Eureka Proxy Setting is not working

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/shared/transport/jersey/JerseyEurekaHttpClientFactory.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/transport/jersey/JerseyEurekaHttpClientFactory.java
@@ -204,7 +204,8 @@ public class JerseyEurekaHttpClientFactory implements TransportClientFactory {
                     .withMaxTotalConnections(maxTotalConnections)
                     .withConnectionIdleTimeout((int) connectionIdleTimeout)
                     .withEncoderWrapper(encoderWrapper)
-                    .withDecoderWrapper(decoderWrapper);
+                    .withDecoderWrapper(decoderWrapper)
+                    .withProxy(proxyHost,String.valueOf(proxyPort),proxyUserName,proxyPassword);
 
             if (systemSSL) {
                 clientBuilder.withSystemSSLConfiguration();


### PR DESCRIPTION
   Eureka proxy settings is not working because of EurekaJerseyClientBuilder instance have no chance to set proxy settings during it's lifecycle.

related issue: #1056 