### PR TITLE
Fix the inconsistency logic in method updateRenewalThreshold(). 

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/registry/PeerAwareInstanceRegistryImpl.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/PeerAwareInstanceRegistryImpl.java
@@ -531,8 +531,8 @@ public class PeerAwareInstanceRegistryImpl extends AbstractInstanceRegistry impl
             }
             synchronized (lock) {
                 // Update threshold only if the threshold is greater than the
-                // current expected threshold of if the self preservation is disabled.
-                if ((count * 2) > (serverConfig.getRenewalPercentThreshold() * numberOfRenewsPerMinThreshold)
+                // current expected threshold or if self preservation is disabled.
+                if ((count * 2) > (serverConfig.getRenewalPercentThreshold() * expectedNumberOfRenewsPerMin)
                         || (!this.isSelfPreservationModeEnabled())) {
                     this.expectedNumberOfRenewsPerMin = count * 2;
                     this.numberOfRenewsPerMinThreshold = (int) ((count * 2) * serverConfig.getRenewalPercentThreshold());

--- a/eureka-core/src/test/java/com/netflix/eureka/AbstractTester.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/AbstractTester.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import com.google.common.collect.Lists;
 import com.netflix.appinfo.AmazonInfo;
 import com.netflix.appinfo.ApplicationInfoManager;
 import com.netflix.appinfo.DataCenterInfo;
@@ -25,6 +26,7 @@ import com.netflix.eureka.mock.MockRemoteEurekaServer;
 import com.netflix.eureka.registry.PeerAwareInstanceRegistryImpl;
 import com.netflix.eureka.resources.DefaultServerCodecs;
 import com.netflix.eureka.resources.ServerCodecs;
+import com.netflix.eureka.test.async.executor.SingleEvent;
 import org.junit.After;
 import org.junit.Before;
 
@@ -66,6 +68,9 @@ public class AbstractTester {
         ConfigurationManager.getConfigInstance().clearProperty("eureka.remoteRegion." + REMOTE_REGION_NAME + ".appWhiteList");
         ConfigurationManager.getConfigInstance().setProperty("eureka.deltaRetentionTimerIntervalInMs", "600000");
         ConfigurationManager.getConfigInstance().setProperty("eureka.remoteRegion.registryFetchIntervalInSeconds", "5");
+        ConfigurationManager.getConfigInstance().setProperty("eureka.renewalThresholdUpdateIntervalMs", "5000");
+        ConfigurationManager.getConfigInstance().setProperty("eureka.evictionIntervalTimerInMs", "10000");
+
         populateRemoteRegistryAtStartup();
         mockRemoteEurekaServer = newMockRemoteServer();
         mockRemoteEurekaServer.start();
@@ -101,6 +106,8 @@ public class AbstractTester {
         );
 
         serverContext.initialize();
+        int registryCount = registry.syncUp();
+        registry.openForTraffic(applicationInfoManager, registryCount);
     }
 
     protected DataCenterInfo getDataCenterInfo() {
@@ -174,6 +181,18 @@ public class AbstractTester {
         return createLocalInstanceWithStatus(hostname, InstanceInfo.InstanceStatus.OUT_OF_SERVICE);
     }
 
+    protected static InstanceInfo createLocalInstanceWithIdAndStatus(String hostname, String id, InstanceInfo.InstanceStatus status) {
+        InstanceInfo.Builder instanceBuilder = InstanceInfo.Builder.newBuilder();
+        instanceBuilder.setInstanceId(id);
+        instanceBuilder.setAppName(LOCAL_REGION_APP_NAME);
+        instanceBuilder.setHostName(hostname);
+        instanceBuilder.setIPAddr("10.10.101.1");
+        instanceBuilder.setDataCenterInfo(getAmazonInfo(null, hostname));
+        instanceBuilder.setLeaseInfo(LeaseInfo.Builder.newBuilder().build());
+        instanceBuilder.setStatus(status);
+        return instanceBuilder.build();
+    }
+
     private static InstanceInfo createLocalInstanceWithStatus(String hostname, InstanceInfo.InstanceStatus status) {
         InstanceInfo.Builder instanceBuilder = InstanceInfo.Builder.newBuilder();
         instanceBuilder.setInstanceId("foo");
@@ -215,11 +234,6 @@ public class AbstractTester {
         }
 
         @Override
-        public boolean isLeaseExpirationEnabled() {
-            return false;
-        }
-
-        @Override
         public InstanceInfo getNextServerFromEureka(String virtualHostname, boolean secure) {
             return null;
         }
@@ -233,6 +247,60 @@ public class AbstractTester {
 
     protected void registerInstanceLocally(InstanceInfo remoteInstance) {
         registry.register(remoteInstance, 10000000, false);
-        registeredApps.add(new Pair<String, String>(LOCAL_REGION_APP_NAME, LOCAL_REGION_APP_NAME));
+        registeredApps.add(new Pair<String, String>(LOCAL_REGION_APP_NAME, remoteInstance.getId()));
+    }
+
+    protected void registerInstanceLocallyWithLeaseDurationInSecs(InstanceInfo remoteInstance, int leaseDurationInSecs) {
+        registry.register(remoteInstance, leaseDurationInSecs, false);
+        registeredApps.add(new Pair<String, String>(LOCAL_REGION_APP_NAME, remoteInstance.getId()));
+    }
+
+
+    /**
+     * Send renewal request to Eureka server to renew lease for 45 instances.
+     *
+     * @return action.
+     */
+    protected SingleEvent.Action renewPartOfTheWholeInstancesAction() {
+        return new SingleEvent.Action() {
+            @Override
+            public void execute() {
+                for (int j = 0; j < 45; j++) {
+                    registry.renew(LOCAL_REGION_APP_NAME,
+                        LOCAL_REGION_INSTANCE_1_HOSTNAME + j, false);
+                }
+            }
+        };
+    }
+
+    /**
+     * Build one single event.
+     *
+     * @param intervalTimeInSecs the interval time from previous event.
+     * @param action             action to take.
+     * @return single event.
+     */
+    protected SingleEvent buildEvent(int intervalTimeInSecs, SingleEvent.Action action) {
+        return SingleEvent.Builder.newBuilder()
+            .withIntervalTimeInMs(intervalTimeInSecs * 1000)
+            .withAction(action).build();
+    }
+
+    /**
+     * Build multiple {@link SingleEvent}.
+     *
+     * @param intervalTimeInSecs the interval time between those events.
+     * @param eventCount         total event count.
+     * @param action             action to take for every event.
+     * @return list consisting of multiple single events.
+     */
+    protected List<SingleEvent> buildEvents(int intervalTimeInSecs, int eventCount, SingleEvent.Action action) {
+        List<SingleEvent> result = Lists.newArrayListWithCapacity(eventCount);
+        for (int i = 0; i < eventCount; i++) {
+            result.add(SingleEvent.Builder.newBuilder()
+                .withIntervalTimeInMs(intervalTimeInSecs * 1000)
+                .withAction(action).build());
+        }
+        return result;
     }
 }

--- a/eureka-core/src/test/java/com/netflix/eureka/AbstractTester.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/AbstractTester.java
@@ -106,8 +106,8 @@ public class AbstractTester {
         );
 
         serverContext.initialize();
-        int registryCount = registry.syncUp();
-        registry.openForTraffic(applicationInfoManager, registryCount);
+
+        registry.openForTraffic(applicationInfoManager, 1);
     }
 
     protected DataCenterInfo getDataCenterInfo() {

--- a/eureka-core/src/test/java/com/netflix/eureka/mock/MockRemoteEurekaServer.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/mock/MockRemoteEurekaServer.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.util.Map;
 
 import com.netflix.appinfo.AbstractEurekaIdentity;
+import com.netflix.appinfo.InstanceInfo;
 import com.netflix.discovery.converters.jackson.EurekaJsonJacksonCodec;
 import com.netflix.discovery.shared.Application;
 import com.netflix.discovery.shared.Applications;
@@ -149,6 +150,12 @@ public class MockRemoteEurekaServer extends ExternalResource {
                     sendOkResponseWithContent((Request) request, response, toJson(apps));
                     handled = true;
                     sentDelta = true;
+                } else if (request.getMethod().equals("PUT") && pathInfo.startsWith("apps")) {
+                    InstanceInfo instanceInfo = InstanceInfo.Builder.newBuilder()
+                        .setAppName("TEST-APP").build();
+                    sendOkResponseWithContent((Request) request, response,
+                        new EurekaJsonJacksonCodec().getObjectMapper(Applications.class).writeValueAsString(instanceInfo));
+                    handled = true;
                 } else if (pathInfo.startsWith("apps")) {
                     Applications apps = new Applications();
                     for (Application application : applicationMap.values()) {

--- a/eureka-core/src/test/java/com/netflix/eureka/registry/InstanceRegistryTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/registry/InstanceRegistryTest.java
@@ -2,12 +2,19 @@ package com.netflix.eureka.registry;
 
 import java.util.List;
 
+import com.google.common.base.Preconditions;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.appinfo.InstanceInfo.InstanceStatus;
 import com.netflix.discovery.shared.Application;
 import com.netflix.discovery.shared.Applications;
 import com.netflix.eureka.AbstractTester;
+import com.netflix.eureka.EurekaServerConfig;
+import com.netflix.eureka.test.async.executor.AsyncResult;
+import com.netflix.eureka.test.async.executor.AsyncSequentialExecutor;
+import com.netflix.eureka.test.async.executor.SequentialEvents;
+import com.netflix.eureka.test.async.executor.SingleEvent;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -267,5 +274,145 @@ public class InstanceRegistryTest extends AbstractTester {
         assertThat(testTask.getCompensationTimeMs(), is(0l));
         assertThat(testTask.getCompensationTimeMs(), is(10l));
         assertThat(testTask.getCompensationTimeMs(), is(0l));
+    }
+
+    /**
+     * Verify the following behaviors:
+     * <ul>
+     * <li>1. Registration of new instances.</li>
+     * <li>2. Lease expiration.</li>
+     * <li>3. NumOfRenewsPerMinThreshold will be updated. Since this threshold will be updated according to
+     * {@link EurekaServerConfig#getRenewalThresholdUpdateIntervalMs()}, and discovery client will try to get
+     * applications count from peer or remote Eureka servers, the count number will be used to update threshold.</li>
+     * </ul>
+     * Below shows the time line of a bunch of events in 120 seconds. Here the following setting are configured during registry startup:
+     * eureka.renewalThresholdUpdateIntervalMs=5000,
+     * eureka.evictionIntervalTimerInMs=10000
+     * <pre>
+     * TimeInSecs 0          15         30    40   45         60        75   80      90         105       120
+     *            |----------|----------|------|----|----------|---------|----|-------|----------|---------|
+     * Events    (1)        (2)               (3)  (4)        (5)       (6)  (7)                (8)       (9)
+     * </pre>
+     * <ul>
+     * <li>(1). Remote server started on random port, local registry started as well.
+     * 50 instances will be registered to local registry with application name of {@link #LOCAL_REGION_APP_NAME}
+     * and lease duration set to 30 seconds.
+     * At this time isLeaseExpirationEnabled=false, getNumOfRenewsPerMinThreshold=
+     * (50*2 + 2(which comes from remote registry))*85%=86</li>
+     * <li>(2). 45 out of the 50 instances send heartbeats to local registry.</li>
+     * <li>(3). Check registry status, isLeaseExpirationEnabled=false, getNumOfRenewsInLastMin=0,
+     * getNumOfRenewsPerMinThreshold=86, registeredInstancesNumberOfMYLOCALAPP=50</li>
+     * <li>(4). 45 out of the 50 instances send heartbeats to local registry.</li>
+     * <li>(5). Accumulate one minutes data, and from now on, isLeaseExpirationEnabled=true,
+     * getNumOfRenewsInLastMin=90. Because lease expiration is enabled, and lease for 5 instance are expired,
+     * so evict 5 instances.</li>
+     * <li>(6). 45 out of the 50 instances send heartbeats to local registry.</li>
+     * <li>(7). Check registry status, isLeaseExpirationEnabled=true, getNumOfRenewsInLastMin=90,
+     * getNumOfRenewsPerMinThreshold=86, registeredInstancesNumberOfMYLOCALAPP=45</li>
+     * Remote region add another 150 instances to application of {@link #LOCAL_REGION_APP_NAME}.
+     * This will make {@link PeerAwareInstanceRegistryImpl#updateRenewalThreshold()} to refresh
+     * {@link AbstractInstanceRegistry#numberOfRenewsPerMinThreshold}.</li>
+     * <li>(8). 45 out of the 50 instances send heartbeats to local registry.</li>
+     * <li>(9). Check registry status, isLeaseExpirationEnabled=false, getNumOfRenewsInLastMin=90,
+     * getNumOfRenewsPerMinThreshold=256, registeredInstancesNumberOfMYLOCALAPP=45</li>
+     * </ul>
+     */
+    @Test
+    @Ignore
+    public void testLeaseExpirationAndUpdateRenewalThreshold() throws Exception {
+        final int registeredInstanceCount = 50;
+        final int leaseDurationInSecs = 30;
+
+        AsyncSequentialExecutor executor = new AsyncSequentialExecutor();
+
+        SequentialEvents registerMyLocalAppAndInstancesEvents = SequentialEvents.of(
+            buildEvent(0, new SingleEvent.Action() {
+                @Override
+                public void execute() {
+                    for (int j = 0; j < registeredInstanceCount; j++) {
+                        registerInstanceLocallyWithLeaseDurationInSecs(createLocalInstanceWithIdAndStatus(LOCAL_REGION_APP_NAME,
+                            LOCAL_REGION_INSTANCE_1_HOSTNAME + j, InstanceStatus.UP), leaseDurationInSecs);
+                    }
+                }
+            })
+        );
+
+        SequentialEvents showRegistryStatusEvents = SequentialEvents.of(
+            buildEvents(5, 24, new SingleEvent.Action() {
+                @Override
+                public void execute() {
+                    System.out.println(String.format("isLeaseExpirationEnabled=%s, getNumOfRenewsInLastMin=%d, "
+                            + "getNumOfRenewsPerMinThreshold=%s, instanceNumberOfMYLOCALAPP=%d", registry.isLeaseExpirationEnabled(),
+                        registry.getNumOfRenewsInLastMin(), registry.getNumOfRenewsPerMinThreshold(),
+                        registry.getApplication(LOCAL_REGION_APP_NAME).getInstances().size()));
+                }
+            })
+        );
+
+        SequentialEvents renewEvents = SequentialEvents.of(
+            buildEvent(15, renewPartOfTheWholeInstancesAction()),
+            buildEvent(30, renewPartOfTheWholeInstancesAction()),
+            buildEvent(30, renewPartOfTheWholeInstancesAction()),
+            buildEvent(30, renewPartOfTheWholeInstancesAction())
+        );
+
+        SequentialEvents remoteRegionAddMoreInstancesEvents = SequentialEvents.of(
+            buildEvent(90, new SingleEvent.Action() {
+                @Override
+                public void execute() {
+                    for (int i = 0; i < 150; i++) {
+                        InstanceInfo newlyCreatedInstance = createLocalInstanceWithIdAndStatus(REMOTE_REGION_APP_NAME,
+                            LOCAL_REGION_INSTANCE_1_HOSTNAME + i, InstanceStatus.UP);
+                        remoteRegionApps.get(REMOTE_REGION_APP_NAME).addInstance(newlyCreatedInstance);
+                        remoteRegionAppsDelta.get(REMOTE_REGION_APP_NAME).addInstance(newlyCreatedInstance);
+                    }
+                }
+            })
+        );
+
+        SequentialEvents checkEvents = SequentialEvents.of(
+            buildEvent(40, new SingleEvent.Action() {
+                @Override
+                public void execute() {
+                    System.out.println("checking on 40s");
+                    Preconditions.checkState(Boolean.FALSE.equals(registry.isLeaseExpirationEnabled()), "Lease expiration should be disabled");
+                    Preconditions.checkState(registry.getNumOfRenewsInLastMin() == 0, "Renewals in last min should be 0");
+                    Preconditions.checkState(registry.getApplication(LOCAL_REGION_APP_NAME).getInstances().size() == 50,
+                        "There should be 50 instances in application - MYLOCAPP");
+                }
+            }),
+            buildEvent(40, new SingleEvent.Action() {
+                @Override
+                public void execute() {
+                    System.out.println("checking on 80s");
+                    Preconditions.checkState(Boolean.TRUE.equals(registry.isLeaseExpirationEnabled()), "Lease expiration should be enabled");
+                    Preconditions.checkState(registry.getNumOfRenewsInLastMin() == 90, "Renewals in last min should be 90");
+                    Preconditions.checkState(registry.getApplication(LOCAL_REGION_APP_NAME).getInstances().size() == 45,
+                        "There should be 45 instances in application - MYLOCAPP");
+                }
+            }),
+            buildEvent(40, new SingleEvent.Action() {
+                @Override
+                public void execute() {
+                    System.out.println("checking on 120s");
+                    System.out.println("getNumOfRenewsPerMinThreshold=" + registry.getNumOfRenewsPerMinThreshold());
+                    Preconditions.checkState(registry.getNumOfRenewsPerMinThreshold() == 256, "NumOfRenewsPerMinThreshold should be updated to 256");
+                    Preconditions.checkState(registry.getApplication(LOCAL_REGION_APP_NAME).getInstances().size() == 45,
+                        "There should be 45 instances in application - MYLOCAPP");
+                }
+            })
+        );
+
+        AsyncResult<AsyncSequentialExecutor.ResultStatus> registerMyLocalAppAndInstancesResult = executor.run(registerMyLocalAppAndInstancesEvents);
+        AsyncResult<AsyncSequentialExecutor.ResultStatus> showRegistryStatusEventResult = executor.run(showRegistryStatusEvents);
+        AsyncResult<AsyncSequentialExecutor.ResultStatus> renewResult = executor.run(renewEvents);
+        AsyncResult<AsyncSequentialExecutor.ResultStatus> remoteRegionAddMoreInstancesResult = executor.run(remoteRegionAddMoreInstancesEvents);
+        AsyncResult<AsyncSequentialExecutor.ResultStatus> checkResult = executor.run(checkEvents);
+
+        Assert.assertEquals("Register application and instances failed", AsyncSequentialExecutor.ResultStatus.DONE, registerMyLocalAppAndInstancesResult.getResult());
+        Assert.assertEquals("Show registry status failed", AsyncSequentialExecutor.ResultStatus.DONE, showRegistryStatusEventResult.getResult());
+        Assert.assertEquals("Renew lease did not succeed", AsyncSequentialExecutor.ResultStatus.DONE, renewResult.getResult());
+        Assert.assertEquals("More instances are registered to remote region did not succeed", AsyncSequentialExecutor.ResultStatus.DONE, remoteRegionAddMoreInstancesResult.getResult());
+        Assert.assertEquals("Check failed", AsyncSequentialExecutor.ResultStatus.DONE, checkResult.getResult());
     }
 }

--- a/eureka-core/src/test/java/com/netflix/eureka/registry/InstanceRegistryTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/registry/InstanceRegistryTest.java
@@ -2,19 +2,12 @@ package com.netflix.eureka.registry;
 
 import java.util.List;
 
-import com.google.common.base.Preconditions;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.appinfo.InstanceInfo.InstanceStatus;
 import com.netflix.discovery.shared.Application;
 import com.netflix.discovery.shared.Applications;
 import com.netflix.eureka.AbstractTester;
-import com.netflix.eureka.EurekaServerConfig;
-import com.netflix.eureka.test.async.executor.AsyncResult;
-import com.netflix.eureka.test.async.executor.AsyncSequentialExecutor;
-import com.netflix.eureka.test.async.executor.SequentialEvents;
-import com.netflix.eureka.test.async.executor.SingleEvent;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -274,145 +267,5 @@ public class InstanceRegistryTest extends AbstractTester {
         assertThat(testTask.getCompensationTimeMs(), is(0l));
         assertThat(testTask.getCompensationTimeMs(), is(10l));
         assertThat(testTask.getCompensationTimeMs(), is(0l));
-    }
-
-    /**
-     * Verify the following behaviors:
-     * <ul>
-     * <li>1. Registration of new instances.</li>
-     * <li>2. Lease expiration.</li>
-     * <li>3. NumOfRenewsPerMinThreshold will be updated. Since this threshold will be updated according to
-     * {@link EurekaServerConfig#getRenewalThresholdUpdateIntervalMs()}, and discovery client will try to get
-     * applications count from peer or remote Eureka servers, the count number will be used to update threshold.</li>
-     * </ul>
-     * Below shows the time line of a bunch of events in 120 seconds. Here the following setting are configured during registry startup:
-     * eureka.renewalThresholdUpdateIntervalMs=5000,
-     * eureka.evictionIntervalTimerInMs=10000
-     * <pre>
-     * TimeInSecs 0          15         30    40   45         60        75   80      90         105       120
-     *            |----------|----------|------|----|----------|---------|----|-------|----------|---------|
-     * Events    (1)        (2)               (3)  (4)        (5)       (6)  (7)                (8)       (9)
-     * </pre>
-     * <ul>
-     * <li>(1). Remote server started on random port, local registry started as well.
-     * 50 instances will be registered to local registry with application name of {@link #LOCAL_REGION_APP_NAME}
-     * and lease duration set to 30 seconds.
-     * At this time isLeaseExpirationEnabled=false, getNumOfRenewsPerMinThreshold=
-     * (50*2 + 2(which comes from remote registry))*85%=86</li>
-     * <li>(2). 45 out of the 50 instances send heartbeats to local registry.</li>
-     * <li>(3). Check registry status, isLeaseExpirationEnabled=false, getNumOfRenewsInLastMin=0,
-     * getNumOfRenewsPerMinThreshold=86, registeredInstancesNumberOfMYLOCALAPP=50</li>
-     * <li>(4). 45 out of the 50 instances send heartbeats to local registry.</li>
-     * <li>(5). Accumulate one minutes data, and from now on, isLeaseExpirationEnabled=true,
-     * getNumOfRenewsInLastMin=90. Because lease expiration is enabled, and lease for 5 instance are expired,
-     * so evict 5 instances.</li>
-     * <li>(6). 45 out of the 50 instances send heartbeats to local registry.</li>
-     * <li>(7). Check registry status, isLeaseExpirationEnabled=true, getNumOfRenewsInLastMin=90,
-     * getNumOfRenewsPerMinThreshold=86, registeredInstancesNumberOfMYLOCALAPP=45</li>
-     * Remote region add another 150 instances to application of {@link #LOCAL_REGION_APP_NAME}.
-     * This will make {@link PeerAwareInstanceRegistryImpl#updateRenewalThreshold()} to refresh
-     * {@link AbstractInstanceRegistry#numberOfRenewsPerMinThreshold}.</li>
-     * <li>(8). 45 out of the 50 instances send heartbeats to local registry.</li>
-     * <li>(9). Check registry status, isLeaseExpirationEnabled=false, getNumOfRenewsInLastMin=90,
-     * getNumOfRenewsPerMinThreshold=256, registeredInstancesNumberOfMYLOCALAPP=45</li>
-     * </ul>
-     */
-    @Test
-    @Ignore
-    public void testLeaseExpirationAndUpdateRenewalThreshold() throws Exception {
-        final int registeredInstanceCount = 50;
-        final int leaseDurationInSecs = 30;
-
-        AsyncSequentialExecutor executor = new AsyncSequentialExecutor();
-
-        SequentialEvents registerMyLocalAppAndInstancesEvents = SequentialEvents.of(
-            buildEvent(0, new SingleEvent.Action() {
-                @Override
-                public void execute() {
-                    for (int j = 0; j < registeredInstanceCount; j++) {
-                        registerInstanceLocallyWithLeaseDurationInSecs(createLocalInstanceWithIdAndStatus(LOCAL_REGION_APP_NAME,
-                            LOCAL_REGION_INSTANCE_1_HOSTNAME + j, InstanceStatus.UP), leaseDurationInSecs);
-                    }
-                }
-            })
-        );
-
-        SequentialEvents showRegistryStatusEvents = SequentialEvents.of(
-            buildEvents(5, 24, new SingleEvent.Action() {
-                @Override
-                public void execute() {
-                    System.out.println(String.format("isLeaseExpirationEnabled=%s, getNumOfRenewsInLastMin=%d, "
-                            + "getNumOfRenewsPerMinThreshold=%s, instanceNumberOfMYLOCALAPP=%d", registry.isLeaseExpirationEnabled(),
-                        registry.getNumOfRenewsInLastMin(), registry.getNumOfRenewsPerMinThreshold(),
-                        registry.getApplication(LOCAL_REGION_APP_NAME).getInstances().size()));
-                }
-            })
-        );
-
-        SequentialEvents renewEvents = SequentialEvents.of(
-            buildEvent(15, renewPartOfTheWholeInstancesAction()),
-            buildEvent(30, renewPartOfTheWholeInstancesAction()),
-            buildEvent(30, renewPartOfTheWholeInstancesAction()),
-            buildEvent(30, renewPartOfTheWholeInstancesAction())
-        );
-
-        SequentialEvents remoteRegionAddMoreInstancesEvents = SequentialEvents.of(
-            buildEvent(90, new SingleEvent.Action() {
-                @Override
-                public void execute() {
-                    for (int i = 0; i < 150; i++) {
-                        InstanceInfo newlyCreatedInstance = createLocalInstanceWithIdAndStatus(REMOTE_REGION_APP_NAME,
-                            LOCAL_REGION_INSTANCE_1_HOSTNAME + i, InstanceStatus.UP);
-                        remoteRegionApps.get(REMOTE_REGION_APP_NAME).addInstance(newlyCreatedInstance);
-                        remoteRegionAppsDelta.get(REMOTE_REGION_APP_NAME).addInstance(newlyCreatedInstance);
-                    }
-                }
-            })
-        );
-
-        SequentialEvents checkEvents = SequentialEvents.of(
-            buildEvent(40, new SingleEvent.Action() {
-                @Override
-                public void execute() {
-                    System.out.println("checking on 40s");
-                    Preconditions.checkState(Boolean.FALSE.equals(registry.isLeaseExpirationEnabled()), "Lease expiration should be disabled");
-                    Preconditions.checkState(registry.getNumOfRenewsInLastMin() == 0, "Renewals in last min should be 0");
-                    Preconditions.checkState(registry.getApplication(LOCAL_REGION_APP_NAME).getInstances().size() == 50,
-                        "There should be 50 instances in application - MYLOCAPP");
-                }
-            }),
-            buildEvent(40, new SingleEvent.Action() {
-                @Override
-                public void execute() {
-                    System.out.println("checking on 80s");
-                    Preconditions.checkState(Boolean.TRUE.equals(registry.isLeaseExpirationEnabled()), "Lease expiration should be enabled");
-                    Preconditions.checkState(registry.getNumOfRenewsInLastMin() == 90, "Renewals in last min should be 90");
-                    Preconditions.checkState(registry.getApplication(LOCAL_REGION_APP_NAME).getInstances().size() == 45,
-                        "There should be 45 instances in application - MYLOCAPP");
-                }
-            }),
-            buildEvent(40, new SingleEvent.Action() {
-                @Override
-                public void execute() {
-                    System.out.println("checking on 120s");
-                    System.out.println("getNumOfRenewsPerMinThreshold=" + registry.getNumOfRenewsPerMinThreshold());
-                    Preconditions.checkState(registry.getNumOfRenewsPerMinThreshold() == 256, "NumOfRenewsPerMinThreshold should be updated to 256");
-                    Preconditions.checkState(registry.getApplication(LOCAL_REGION_APP_NAME).getInstances().size() == 45,
-                        "There should be 45 instances in application - MYLOCAPP");
-                }
-            })
-        );
-
-        AsyncResult<AsyncSequentialExecutor.ResultStatus> registerMyLocalAppAndInstancesResult = executor.run(registerMyLocalAppAndInstancesEvents);
-        AsyncResult<AsyncSequentialExecutor.ResultStatus> showRegistryStatusEventResult = executor.run(showRegistryStatusEvents);
-        AsyncResult<AsyncSequentialExecutor.ResultStatus> renewResult = executor.run(renewEvents);
-        AsyncResult<AsyncSequentialExecutor.ResultStatus> remoteRegionAddMoreInstancesResult = executor.run(remoteRegionAddMoreInstancesEvents);
-        AsyncResult<AsyncSequentialExecutor.ResultStatus> checkResult = executor.run(checkEvents);
-
-        Assert.assertEquals("Register application and instances failed", AsyncSequentialExecutor.ResultStatus.DONE, registerMyLocalAppAndInstancesResult.getResult());
-        Assert.assertEquals("Show registry status failed", AsyncSequentialExecutor.ResultStatus.DONE, showRegistryStatusEventResult.getResult());
-        Assert.assertEquals("Renew lease did not succeed", AsyncSequentialExecutor.ResultStatus.DONE, renewResult.getResult());
-        Assert.assertEquals("More instances are registered to remote region did not succeed", AsyncSequentialExecutor.ResultStatus.DONE, remoteRegionAddMoreInstancesResult.getResult());
-        Assert.assertEquals("Check failed", AsyncSequentialExecutor.ResultStatus.DONE, checkResult.getResult());
     }
 }

--- a/eureka-core/src/test/java/com/netflix/eureka/registry/TimeConsumingInstanceRegistryTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/registry/TimeConsumingInstanceRegistryTest.java
@@ -28,27 +28,31 @@ public class TimeConsumingInstanceRegistryTest extends AbstractTester {
      * {@link EurekaServerConfig#getRenewalThresholdUpdateIntervalMs()}, and discovery client will try to get
      * applications count from peer or remote Eureka servers, the count number will be used to update threshold.</li>
      * </ul>
+     * </p>
      * Below shows the time line of a bunch of events in 120 seconds. Here the following setting are configured during registry startup:
-     * eureka.renewalThresholdUpdateIntervalMs=5000,
-     * eureka.evictionIntervalTimerInMs=10000
+     * <code>eureka.renewalThresholdUpdateIntervalMs=5000</code>,
+     * <code>eureka.evictionIntervalTimerInMs=10000</code>,
+     * <code>eureka.renewalPercentThreshold=0.85</code>
+     * </p>
      * <pre>
      * TimeInSecs 0          15         30    40   45         60        75   80      90         105       120
      *            |----------|----------|------|----|----------|---------|----|-------|----------|---------|
      * Events    (1)        (2)               (3)  (4)        (5)       (6)  (7)                (8)       (9)
      * </pre>
+     * </p>
      * <ul>
      * <li>(1). Remote server started on random port, local registry started as well.
      * 50 instances will be registered to local registry with application name of {@link #LOCAL_REGION_APP_NAME}
      * and lease duration set to 30 seconds.
      * At this time isLeaseExpirationEnabled=false, getNumOfRenewsPerMinThreshold=
-     * (50*2 + 2(which comes from remote registry))*85%=86</li>
+     * (50*2 + 1(initial value))*85%=86</li>
      * <li>(2). 45 out of the 50 instances send heartbeats to local registry.</li>
      * <li>(3). Check registry status, isLeaseExpirationEnabled=false, getNumOfRenewsInLastMin=0,
      * getNumOfRenewsPerMinThreshold=86, registeredInstancesNumberOfMYLOCALAPP=50</li>
      * <li>(4). 45 out of the 50 instances send heartbeats to local registry.</li>
      * <li>(5). Accumulate one minutes data, and from now on, isLeaseExpirationEnabled=true,
      * getNumOfRenewsInLastMin=90. Because lease expiration is enabled, and lease for 5 instance are expired,
-     * so evict 5 instances.</li>
+     * so when eviction thread is working, the 5 instances will be marked as deleted.</li>
      * <li>(6). 45 out of the 50 instances send heartbeats to local registry.</li>
      * <li>(7). Check registry status, isLeaseExpirationEnabled=true, getNumOfRenewsInLastMin=90,
      * getNumOfRenewsPerMinThreshold=86, registeredInstancesNumberOfMYLOCALAPP=45</li>
@@ -59,6 +63,7 @@ public class TimeConsumingInstanceRegistryTest extends AbstractTester {
      * <li>(9). Check registry status, isLeaseExpirationEnabled=false, getNumOfRenewsInLastMin=90,
      * getNumOfRenewsPerMinThreshold=256, registeredInstancesNumberOfMYLOCALAPP=45</li>
      * </ul>
+     * </p>
      * Note that there is a thread retrieving and printing out registry status for debugging purpose.
      */
     @Test

--- a/eureka-core/src/test/java/com/netflix/eureka/registry/TimeConsumingInstanceRegistryTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/registry/TimeConsumingInstanceRegistryTest.java
@@ -1,0 +1,161 @@
+package com.netflix.eureka.registry;
+
+import com.google.common.base.Preconditions;
+import com.netflix.appinfo.InstanceInfo;
+import com.netflix.appinfo.InstanceInfo.InstanceStatus;
+import com.netflix.eureka.AbstractTester;
+import com.netflix.eureka.EurekaServerConfig;
+import com.netflix.eureka.test.async.executor.AsyncResult;
+import com.netflix.eureka.test.async.executor.AsyncSequentialExecutor;
+import com.netflix.eureka.test.async.executor.SequentialEvents;
+import com.netflix.eureka.test.async.executor.SingleEvent;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Time consuming test case for {@link InstanceRegistry}.
+ *
+ * @author neoremind
+ */
+public class TimeConsumingInstanceRegistryTest extends AbstractTester {
+
+    /**
+     * Verify the following behaviors, the test case will run for 2 minutes.
+     * <ul>
+     * <li>1. Registration of new instances.</li>
+     * <li>2. Lease expiration.</li>
+     * <li>3. NumOfRenewsPerMinThreshold will be updated. Since this threshold will be updated according to
+     * {@link EurekaServerConfig#getRenewalThresholdUpdateIntervalMs()}, and discovery client will try to get
+     * applications count from peer or remote Eureka servers, the count number will be used to update threshold.</li>
+     * </ul>
+     * Below shows the time line of a bunch of events in 120 seconds. Here the following setting are configured during registry startup:
+     * eureka.renewalThresholdUpdateIntervalMs=5000,
+     * eureka.evictionIntervalTimerInMs=10000
+     * <pre>
+     * TimeInSecs 0          15         30    40   45         60        75   80      90         105       120
+     *            |----------|----------|------|----|----------|---------|----|-------|----------|---------|
+     * Events    (1)        (2)               (3)  (4)        (5)       (6)  (7)                (8)       (9)
+     * </pre>
+     * <ul>
+     * <li>(1). Remote server started on random port, local registry started as well.
+     * 50 instances will be registered to local registry with application name of {@link #LOCAL_REGION_APP_NAME}
+     * and lease duration set to 30 seconds.
+     * At this time isLeaseExpirationEnabled=false, getNumOfRenewsPerMinThreshold=
+     * (50*2 + 2(which comes from remote registry))*85%=86</li>
+     * <li>(2). 45 out of the 50 instances send heartbeats to local registry.</li>
+     * <li>(3). Check registry status, isLeaseExpirationEnabled=false, getNumOfRenewsInLastMin=0,
+     * getNumOfRenewsPerMinThreshold=86, registeredInstancesNumberOfMYLOCALAPP=50</li>
+     * <li>(4). 45 out of the 50 instances send heartbeats to local registry.</li>
+     * <li>(5). Accumulate one minutes data, and from now on, isLeaseExpirationEnabled=true,
+     * getNumOfRenewsInLastMin=90. Because lease expiration is enabled, and lease for 5 instance are expired,
+     * so evict 5 instances.</li>
+     * <li>(6). 45 out of the 50 instances send heartbeats to local registry.</li>
+     * <li>(7). Check registry status, isLeaseExpirationEnabled=true, getNumOfRenewsInLastMin=90,
+     * getNumOfRenewsPerMinThreshold=86, registeredInstancesNumberOfMYLOCALAPP=45</li>
+     * Remote region add another 150 instances to application of {@link #LOCAL_REGION_APP_NAME}.
+     * This will make {@link PeerAwareInstanceRegistryImpl#updateRenewalThreshold()} to refresh
+     * {@link AbstractInstanceRegistry#numberOfRenewsPerMinThreshold}.</li>
+     * <li>(8). 45 out of the 50 instances send heartbeats to local registry.</li>
+     * <li>(9). Check registry status, isLeaseExpirationEnabled=false, getNumOfRenewsInLastMin=90,
+     * getNumOfRenewsPerMinThreshold=256, registeredInstancesNumberOfMYLOCALAPP=45</li>
+     * </ul>
+     * Note that there is a thread retrieving and printing out registry status for debugging purpose.
+     */
+    @Test
+    public void testLeaseExpirationAndUpdateRenewalThreshold() throws InterruptedException {
+        final int registeredInstanceCount = 50;
+        final int leaseDurationInSecs = 30;
+
+        AsyncSequentialExecutor executor = new AsyncSequentialExecutor();
+
+        SequentialEvents registerMyLocalAppAndInstancesEvents = SequentialEvents.of(
+            buildEvent(0, new SingleEvent.Action() {
+                @Override
+                public void execute() {
+                    for (int j = 0; j < registeredInstanceCount; j++) {
+                        registerInstanceLocallyWithLeaseDurationInSecs(createLocalInstanceWithIdAndStatus(LOCAL_REGION_APP_NAME,
+                            LOCAL_REGION_INSTANCE_1_HOSTNAME + j, InstanceStatus.UP), leaseDurationInSecs);
+                    }
+                }
+            })
+        );
+
+        SequentialEvents showRegistryStatusEvents = SequentialEvents.of(
+            buildEvents(5, 24, new SingleEvent.Action() {
+                @Override
+                public void execute() {
+                    System.out.println(String.format("isLeaseExpirationEnabled=%s, getNumOfRenewsInLastMin=%d, "
+                            + "getNumOfRenewsPerMinThreshold=%s, instanceNumberOfMYLOCALAPP=%d", registry.isLeaseExpirationEnabled(),
+                        registry.getNumOfRenewsInLastMin(), registry.getNumOfRenewsPerMinThreshold(),
+                        registry.getApplication(LOCAL_REGION_APP_NAME).getInstances().size()));
+                }
+            })
+        );
+
+        SequentialEvents renewEvents = SequentialEvents.of(
+            buildEvent(15, renewPartOfTheWholeInstancesAction()),
+            buildEvent(30, renewPartOfTheWholeInstancesAction()),
+            buildEvent(30, renewPartOfTheWholeInstancesAction()),
+            buildEvent(30, renewPartOfTheWholeInstancesAction())
+        );
+
+        SequentialEvents remoteRegionAddMoreInstancesEvents = SequentialEvents.of(
+            buildEvent(90, new SingleEvent.Action() {
+                @Override
+                public void execute() {
+                    for (int i = 0; i < 150; i++) {
+                        InstanceInfo newlyCreatedInstance = createLocalInstanceWithIdAndStatus(REMOTE_REGION_APP_NAME,
+                            LOCAL_REGION_INSTANCE_1_HOSTNAME + i, InstanceStatus.UP);
+                        remoteRegionApps.get(REMOTE_REGION_APP_NAME).addInstance(newlyCreatedInstance);
+                        remoteRegionAppsDelta.get(REMOTE_REGION_APP_NAME).addInstance(newlyCreatedInstance);
+                    }
+                }
+            })
+        );
+
+        SequentialEvents checkEvents = SequentialEvents.of(
+            buildEvent(40, new SingleEvent.Action() {
+                @Override
+                public void execute() {
+                    System.out.println("checking on 40s");
+                    Preconditions.checkState(Boolean.FALSE.equals(registry.isLeaseExpirationEnabled()), "Lease expiration should be disabled");
+                    Preconditions.checkState(registry.getNumOfRenewsInLastMin() == 0, "Renewals in last min should be 0");
+                    Preconditions.checkState(registry.getApplication(LOCAL_REGION_APP_NAME).getInstances().size() == 50,
+                        "There should be 50 instances in application - MYLOCAPP");
+                }
+            }),
+            buildEvent(40, new SingleEvent.Action() {
+                @Override
+                public void execute() {
+                    System.out.println("checking on 80s");
+                    Preconditions.checkState(Boolean.TRUE.equals(registry.isLeaseExpirationEnabled()), "Lease expiration should be enabled");
+                    Preconditions.checkState(registry.getNumOfRenewsInLastMin() == 90, "Renewals in last min should be 90");
+                    Preconditions.checkState(registry.getApplication(LOCAL_REGION_APP_NAME).getInstances().size() == 45,
+                        "There should be 45 instances in application - MYLOCAPP");
+                }
+            }),
+            buildEvent(40, new SingleEvent.Action() {
+                @Override
+                public void execute() {
+                    System.out.println("checking on 120s");
+                    System.out.println("getNumOfRenewsPerMinThreshold=" + registry.getNumOfRenewsPerMinThreshold());
+                    Preconditions.checkState(registry.getNumOfRenewsPerMinThreshold() == 256, "NumOfRenewsPerMinThreshold should be updated to 256");
+                    Preconditions.checkState(registry.getApplication(LOCAL_REGION_APP_NAME).getInstances().size() == 45,
+                        "There should be 45 instances in application - MYLOCAPP");
+                }
+            })
+        );
+
+        AsyncResult<AsyncSequentialExecutor.ResultStatus> registerMyLocalAppAndInstancesResult = executor.run(registerMyLocalAppAndInstancesEvents);
+        AsyncResult<AsyncSequentialExecutor.ResultStatus> showRegistryStatusEventResult = executor.run(showRegistryStatusEvents);
+        AsyncResult<AsyncSequentialExecutor.ResultStatus> renewResult = executor.run(renewEvents);
+        AsyncResult<AsyncSequentialExecutor.ResultStatus> remoteRegionAddMoreInstancesResult = executor.run(remoteRegionAddMoreInstancesEvents);
+        AsyncResult<AsyncSequentialExecutor.ResultStatus> checkResult = executor.run(checkEvents);
+
+        Assert.assertEquals("Register application and instances failed", AsyncSequentialExecutor.ResultStatus.DONE, registerMyLocalAppAndInstancesResult.getResult());
+        Assert.assertEquals("Show registry status failed", AsyncSequentialExecutor.ResultStatus.DONE, showRegistryStatusEventResult.getResult());
+        Assert.assertEquals("Renew lease did not succeed", AsyncSequentialExecutor.ResultStatus.DONE, renewResult.getResult());
+        Assert.assertEquals("More instances are registered to remote region did not succeed", AsyncSequentialExecutor.ResultStatus.DONE, remoteRegionAddMoreInstancesResult.getResult());
+        Assert.assertEquals("Check failed", AsyncSequentialExecutor.ResultStatus.DONE, checkResult.getResult());
+    }
+}

--- a/eureka-core/src/test/java/com/netflix/eureka/test/async/executor/AsyncExecutorException.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/test/async/executor/AsyncExecutorException.java
@@ -1,0 +1,29 @@
+package com.netflix.eureka.test.async.executor;
+
+/**
+ * Async executor exception for {@link ConcreteAsyncResult}.
+ */
+public class AsyncExecutorException extends RuntimeException {
+
+    public AsyncExecutorException() {
+    }
+
+    public AsyncExecutorException(String message) {
+        super(message);
+    }
+
+    public AsyncExecutorException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public AsyncExecutorException(Throwable cause) {
+        super(cause);
+    }
+
+    public AsyncExecutorException(String message,
+                                  Throwable cause,
+                                  boolean enableSuppression,
+                                  boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/eureka-core/src/test/java/com/netflix/eureka/test/async/executor/AsyncResult.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/test/async/executor/AsyncResult.java
@@ -1,0 +1,37 @@
+package com.netflix.eureka.test.async.executor;
+
+import java.util.concurrent.Future;
+
+/**
+ * Async result which extends {@link Future}.
+ *
+ * @param <T> The result type.
+ */
+public interface AsyncResult<T> extends Future<T> {
+
+    /**
+     * Handle result normally.
+     *
+     * @param result result.
+     */
+    void handleResult(T result);
+
+    /**
+     * Handle error.
+     *
+     * @param error error during execution.
+     */
+    void handleError(Throwable error);
+
+    /**
+     * Get result which will be blocked until the result is available or an error occurs.
+     */
+    T getResult() throws AsyncExecutorException;
+
+    /**
+     * Get error if possible.
+     *
+     * @return error.
+     */
+    Throwable getError();
+}

--- a/eureka-core/src/test/java/com/netflix/eureka/test/async/executor/AsyncSequentialExecutor.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/test/async/executor/AsyncSequentialExecutor.java
@@ -1,0 +1,95 @@
+package com.netflix.eureka.test.async.executor;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.amazonaws.util.CollectionUtils;
+import com.google.common.base.Optional;
+
+/**
+ * Run a sequential events in asynchronous way.
+ */
+public class AsyncSequentialExecutor {
+
+    /**
+     * Index for thread naming
+     */
+    private static final AtomicInteger INDEX = new AtomicInteger(0);
+
+    /**
+     * Result status, if events are executed successfully in sequential manner, then return this by default
+     */
+    public enum ResultStatus {
+        DONE
+    }
+
+    /**
+     * Run a sequential events in asynchronous way. An result holder will be returned to the caller.
+     * If calling is successful, then will return {@link ResultStatus#DONE}, or else exception will
+     * be thrown and {@link AsyncResult} will be filled with the error.
+     *
+     * @param events sequential events.
+     * @return result holder.
+     */
+    public AsyncResult<ResultStatus> run(SequentialEvents events) {
+        return run(new Callable<ResultStatus>() {
+            @Override
+            public ResultStatus call() throws Exception {
+                if (events == null || CollectionUtils.isNullOrEmpty(events.getEventList())) {
+                    throw new IllegalArgumentException("SequentialEvents does not contain any event to run");
+                }
+                for (SingleEvent singleEvent : events.getEventList()) {
+                    new Backoff(singleEvent.getIntervalTimeInMs()).backoff();
+                    singleEvent.getAction().execute();
+                }
+                return ResultStatus.DONE;
+            }
+        });
+    }
+
+    /**
+     * Run task in a thread.
+     *
+     * @param task task to run.
+     */
+    protected <T> AsyncResult<T> run(Callable<T> task) {
+        final AsyncResult<T> result = new ConcreteAsyncResult<T>();
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                T value = null;
+                Optional<Exception> e = Optional.absent();
+                try {
+                    value = task.call();
+                    result.handleResult(value);
+                } catch (Exception e1) {
+                    e = Optional.of(e1);
+                    result.handleError(e1);
+                }
+            }
+        }, "AsyncSequentialExecutor-" + INDEX.incrementAndGet()).start();
+        return result;
+    }
+
+    class Backoff {
+
+        private final int pauseTimeInMs;
+
+        /**
+         * Prepare to pause for one duration.
+         *
+         * @param pauseTimeInMs pause time in milliseconds
+         */
+        public Backoff(int pauseTimeInMs) {
+            this.pauseTimeInMs = pauseTimeInMs;
+        }
+
+        /**
+         * Backoff for one duration.
+         */
+        public void backoff() throws InterruptedException {
+            Thread.sleep(pauseTimeInMs);
+        }
+    }
+
+}

--- a/eureka-core/src/test/java/com/netflix/eureka/test/async/executor/AsyncSequentialExecutor.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/test/async/executor/AsyncSequentialExecutor.java
@@ -71,25 +71,4 @@ public class AsyncSequentialExecutor {
         return result;
     }
 
-    class Backoff {
-
-        private final int pauseTimeInMs;
-
-        /**
-         * Prepare to pause for one duration.
-         *
-         * @param pauseTimeInMs pause time in milliseconds
-         */
-        public Backoff(int pauseTimeInMs) {
-            this.pauseTimeInMs = pauseTimeInMs;
-        }
-
-        /**
-         * Backoff for one duration.
-         */
-        public void backoff() throws InterruptedException {
-            Thread.sleep(pauseTimeInMs);
-        }
-    }
-
 }

--- a/eureka-core/src/test/java/com/netflix/eureka/test/async/executor/Backoff.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/test/async/executor/Backoff.java
@@ -1,0 +1,28 @@
+package com.netflix.eureka.test.async.executor;
+
+/**
+ * Backoff for pausing for a duration
+ */
+public class Backoff {
+
+    /**
+     * Pause time in milliseconds
+     */
+    private final int pauseTimeInMs;
+
+    /**
+     * Prepare to pause for one duration.
+     *
+     * @param pauseTimeInMs pause time in milliseconds
+     */
+    public Backoff(int pauseTimeInMs) {
+        this.pauseTimeInMs = pauseTimeInMs;
+    }
+
+    /**
+     * Backoff for one duration.
+     */
+    public void backoff() throws InterruptedException {
+        Thread.sleep(pauseTimeInMs);
+    }
+}

--- a/eureka-core/src/test/java/com/netflix/eureka/test/async/executor/ConcreteAsyncResult.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/test/async/executor/ConcreteAsyncResult.java
@@ -1,0 +1,135 @@
+package com.netflix.eureka.test.async.executor;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Async result which is usually hold be caller to retrieve result or error.
+ */
+public class ConcreteAsyncResult<T> implements AsyncResult<T> {
+
+    private final CountDownLatch latch = new CountDownLatch(1);
+
+    private T result = null;
+
+    private Throwable error = null;
+
+    public ConcreteAsyncResult() {
+
+    }
+
+    /**
+     * Sets the result and unblocks all threads waiting on {@link #get()} or {@link #get(long, TimeUnit)}.
+     *
+     * @param result the result to set.
+     */
+    @Override
+    public void handleResult(T result) {
+        this.result = result;
+        latch.countDown();
+    }
+
+    /**
+     * Sets an error thrown during execution, and unblocks all threads waiting on {@link #get()} or
+     * {@link #get(long, TimeUnit)}.
+     *
+     * @param error the RPC error to set.
+     */
+    public void handleError(Throwable error) {
+        this.error = error;
+        latch.countDown();
+    }
+
+    /**
+     * Gets the value of the result in blocking way. Using {@link #get()} or {@link #get(long, TimeUnit)} is
+     * usually preferred because these methods block until the result is available or an error occurs.
+     *
+     * @return the value of the response, or null if no result was returned or the RPC has not yet completed.
+     */
+    public T getResult() throws AsyncExecutorException {
+        return get();
+    }
+
+    /**
+     * Gets the error that was thrown during execution. Does not block. Either {@link #get()} or
+     * {@link #get(long, TimeUnit)} should be called first because these methods block until execution has completed.
+     *
+     * @return the error that was thrown, or null if no error has occurred or if the execution has not yet completed.
+     */
+    public Throwable getError() {
+        return error;
+    }
+
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        latch.countDown();
+        return false;
+    }
+
+    public boolean isCancelled() {
+        return false;
+    }
+
+    public T get() throws AsyncExecutorException {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            throw new AsyncExecutorException("Interrupted", error);
+        }
+        if (error != null) {
+            if (error instanceof AsyncExecutorException) {
+                throw (AsyncExecutorException) error;
+            } else {
+                throw new AsyncExecutorException("Execution exception", error);
+            }
+        }
+        return result;
+    }
+
+    public T get(long timeout, TimeUnit unit) throws AsyncExecutorException {
+        try {
+            if (latch.await(timeout, unit)) {
+                if (error != null) {
+                    if (error instanceof AsyncExecutorException) {
+                        throw (AsyncExecutorException) error;
+                    } else {
+                        throw new RuntimeException("call future get exception", error);
+                    }
+                }
+                return result;
+            } else {
+                throw new AsyncExecutorException("async get time out");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AsyncExecutorException("call future is interuptted", e);
+        }
+    }
+
+    /**
+     * Waits for the CallFuture to complete without returning the result.
+     *
+     * @throws InterruptedException if interrupted.
+     */
+    public void await() throws InterruptedException {
+        latch.await();
+    }
+
+    /**
+     * Waits for the CallFuture to complete without returning the result.
+     *
+     * @param timeout the maximum time to wait.
+     * @param unit    the time unit of the timeout argument.
+     * @throws InterruptedException if interrupted.
+     * @throws TimeoutException     if the wait timed out.
+     */
+    public void await(long timeout, TimeUnit unit) throws InterruptedException, TimeoutException {
+        if (!latch.await(timeout, unit)) {
+            throw new TimeoutException();
+        }
+    }
+
+    public boolean isDone() {
+        return latch.getCount() <= 0;
+    }
+}

--- a/eureka-core/src/test/java/com/netflix/eureka/test/async/executor/SequentialEvents.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/test/async/executor/SequentialEvents.java
@@ -1,0 +1,95 @@
+package com.netflix.eureka.test.async.executor;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * SequentialEvents represents multiple events which should be executed in a
+ * sequential manner.
+ */
+public class SequentialEvents {
+
+    /**
+     * Multiple single events.
+     */
+    private List<SingleEvent> eventList;
+
+    /**
+     * Default constructor.
+     *
+     * @param eventList event list.
+     */
+    private SequentialEvents(List<SingleEvent> eventList) {
+        this.eventList = eventList;
+    }
+
+    /**
+     * Instance creator.
+     *
+     * @return SequentialEvents.
+     */
+    public static SequentialEvents newInstance() {
+        return new SequentialEvents(new ArrayList<>());
+    }
+
+    /**
+     * Instance creator with expected event list size.
+     *
+     * @param expectedEventListSize expected event list size.
+     * @return SequentialEvents.
+     */
+    public static SequentialEvents newInstance(int expectedEventListSize) {
+        return new SequentialEvents(new ArrayList<>(expectedEventListSize));
+    }
+
+    /**
+     * Build sequential events from multiple single events.
+     *
+     * @param event a bunch of single events.
+     * @return SequentialEvents.
+     */
+    public static SequentialEvents of(SingleEvent... events) {
+        return new SequentialEvents(Arrays.asList(events));
+    }
+
+    /**
+     * Build sequential events from multiple single events.
+     *
+     * @param eventList a bunch of single events.
+     * @return SequentialEvents.
+     */
+    public static SequentialEvents of(List<SingleEvent> eventList) {
+        return new SequentialEvents(eventList);
+    }
+
+    /**
+     * Add one more single event to sequential events.
+     *
+     * @param event one event.
+     * @return SequentialEvents.
+     */
+    public SequentialEvents with(SingleEvent event) {
+        Preconditions.checkNotNull(eventList, "eventList should not be null");
+        this.eventList.add(event);
+        return this;
+    }
+
+    /**
+     * Get event lists.
+     *
+     * @return event lists.
+     */
+    public List<SingleEvent> getEventList() {
+        return eventList;
+    }
+
+    @Override
+    public String toString() {
+        return "SequentialEvents{" +
+            "eventList=" + eventList +
+            '}';
+    }
+}

--- a/eureka-core/src/test/java/com/netflix/eureka/test/async/executor/SingleEvent.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/test/async/executor/SingleEvent.java
@@ -1,0 +1,90 @@
+package com.netflix.eureka.test.async.executor;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Single event which represents the action that will be executed in a time line.
+ */
+public class SingleEvent {
+
+    /**
+     * Interval time between the previous event.
+     */
+    private int intervalTimeInMs;
+
+    /**
+     * Action to take.
+     */
+    private Action action;
+
+    /**
+     * Constructor.
+     */
+    public SingleEvent(int intervalTimeInMs, Action action) {
+        this.intervalTimeInMs = intervalTimeInMs;
+        this.action = action;
+    }
+
+    public int getIntervalTimeInMs() {
+        return intervalTimeInMs;
+    }
+
+    public Action getAction() {
+        return action;
+    }
+
+    /**
+     * SingleEvent builder.
+     */
+    public static final class Builder {
+
+        /**
+         * Interval time between the previous event.
+         */
+        private int intervalTimeInMs;
+
+        /**
+         * Action to take.
+         */
+        private Action action;
+
+        private Builder() {
+        }
+
+        public static Builder newBuilder() {
+            return new Builder();
+        }
+
+        public Builder withIntervalTimeInMs(int intervalTimeInMs) {
+            this.intervalTimeInMs = intervalTimeInMs;
+            return this;
+        }
+
+        public Builder withAction(Action action) {
+            this.action = action;
+            return this;
+        }
+
+        public SingleEvent build() {
+            Preconditions.checkNotNull(intervalTimeInMs, "IntervalTimeInMs is not set for SingleEvent");
+            Preconditions.checkNotNull(action, "Action is not set for SingleEvent");
+            return new SingleEvent(intervalTimeInMs, action);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "SingleEvent{" +
+            "intervalTimeInMs=" + intervalTimeInMs +
+            ", action=" + action +
+            '}';
+    }
+
+    /**
+     * Action to perform.
+     */
+    public interface Action {
+        void execute();
+    }
+
+}


### PR DESCRIPTION
Fix the inconsistency logic in method `updateRenewalThreshold()`. Because it does not reflect the expected intention based on the comment. 
`updateRenewalThreshold` will be qualified to run if renewal count * 2 is bigger than 
```
serverConfig.getRenewalPercentThreshold() * expectedNumberOfRenewsPerMin
```
NOT
```
serverConfig.getRenewalPercentThreshold() * numberOfRenewsPerMinThreshold
```

