### PR TITLE
Fix the missing logic in method isRegisterable

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/registry/PeerAwareInstanceRegistryImpl.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/PeerAwareInstanceRegistryImpl.java
@@ -606,6 +606,8 @@ public class PeerAwareInstanceRegistryImpl extends AbstractInstanceRegistry impl
                 // If in the same region as server, then consider it registerable
                 return true;
             }
+            // otherwise return false
+            return false;
         }
         return true; // Everything non-amazon is registrable.
     }


### PR DESCRIPTION
In the isRegisterable method, the logic seems allways return true.
But based on the comment in the method of isRegisterable(), it will return false otherwise.
I think there are missing a return false at the end of Amazon logic.
But it has not a big affect of applications, is need to repair it?