### PR TITLE
Concurrent register of custom healthcheck handler in DiscoveryClient

### DIFF
--- a/eureka-client/src/test/java/com/netflix/discovery/BaseDiscoveryClientTester.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/BaseDiscoveryClientTester.java
@@ -50,12 +50,16 @@ public abstract class BaseDiscoveryClientTester {
     }
 
     protected void setupDiscoveryClient() {
-        setupDiscoveryClient(30);
+        client = getSetupDiscoveryClient();
     }
 
-    protected void setupDiscoveryClient(int renewalIntervalInSecs) {
+    protected EurekaClient getSetupDiscoveryClient() {
+        return getSetupDiscoveryClient(30);
+    }
+
+    protected EurekaClient getSetupDiscoveryClient(int renewalIntervalInSecs) {
         InstanceInfo instanceInfo = newInstanceInfoBuilder(renewalIntervalInSecs).build();
-        client = DiscoveryClientResource.setupDiscoveryClient(instanceInfo);
+        return DiscoveryClientResource.setupDiscoveryClient(instanceInfo);
     }
 
     protected InstanceInfo.Builder newInstanceInfoBuilder(int renewalIntervalInSecs) {


### PR DESCRIPTION
Some clients try to register their health checks and fail since there is possibility to rewrite healthcheck handler by default one.

Root cause:
after not thread safe null check DiscoveryClient will register default healthcheck handler even if during creation of that, custom one will be provided.
Resolution summary:
wrap healthcheck handler in AtomicReference and set default implementation only if reference still contain null.

Example is spring-cloud-netflix project and https://github.com/spring-cloud/spring-cloud-netflix/issues/2490 issue.