### PR TITLE
Add possibility to configure expected interval between clients' renew…

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/DefaultEurekaServerConfig.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/DefaultEurekaServerConfig.java
@@ -225,9 +225,10 @@ public class DefaultEurekaServerConfig implements EurekaServerConfig {
      */
     @Override
     public int getExpectedClientRenewalIntervalSeconds() {
-        return configInstance.getIntProperty(
+        final int configured = configInstance.getIntProperty(
                 namespace + "expectedClientRenewalIntervalSeconds",
                 30).get();
+        return configured > 0 ? configured : 30;
     }
 
     @Override

--- a/eureka-core/src/main/java/com/netflix/eureka/DefaultEurekaServerConfig.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/DefaultEurekaServerConfig.java
@@ -217,6 +217,19 @@ public class DefaultEurekaServerConfig implements EurekaServerConfig {
                 (15 * 60 * 1000)).get();
     }
 
+    /*
+     * (non-Javadoc)
+     *
+     * @see
+     * com.netflix.eureka.EurekaServerConfig#getExpectedClientRenewalIntervalSeconds()
+     */
+    @Override
+    public int getExpectedClientRenewalIntervalSeconds() {
+        return configInstance.getIntProperty(
+                namespace + "expectedClientRenewalIntervalSeconds",
+                30).get();
+    }
+
     @Override
     public double getRenewalPercentThreshold() {
         return configInstance.getDoubleProperty(

--- a/eureka-core/src/main/java/com/netflix/eureka/EurekaServerConfig.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/EurekaServerConfig.java
@@ -135,6 +135,16 @@ public interface EurekaServerConfig {
     int getRenewalThresholdUpdateIntervalMs();
 
     /**
+     * The interval with which clients are expected to send their heartbeats. Defaults to 30
+     * seconds. If clients send heartbeats with different frequency, say, every 15 seconds, then
+     * this parameter should be tuned accordingly, otherwise, self-preservation won't work as
+     * expected.
+     *
+     * @return time in seconds indicating the expected interval
+     */
+    int getExpectedClientRenewalIntervalSeconds();
+
+    /**
      * The interval with which the information about the changes in peer eureka
      * nodes is updated. The user can use the DNS mechanism or dynamic
      * configuration provided by <a href="https://github.com/Netflix/archaius">Archaius</a> to

--- a/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
@@ -101,7 +101,7 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
 
     protected String[] allKnownRemoteRegions = EMPTY_STR_ARRAY;
     protected volatile int numberOfRenewsPerMinThreshold;
-    protected volatile int expectedNumberOfRenewsPerMin;
+    protected volatile int expectedNumberOfClientsSendingRenews;
 
     protected final EurekaServerConfig serverConfig;
     protected final EurekaClientConfig clientConfig;
@@ -218,13 +218,13 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
             } else {
                 // The lease does not exist and hence it is a new registration
                 synchronized (lock) {
-                    if (this.expectedNumberOfRenewsPerMin > 0) {
-                        // Since the client wants to cancel it, reduce the threshold
-                        // (1
-                        // for 30 seconds, 2 for a minute)
-                        this.expectedNumberOfRenewsPerMin = this.expectedNumberOfRenewsPerMin + 2;
+                    if (this.expectedNumberOfClientsSendingRenews > 0) {
+                        // Since the client wants to register it, increase the number of clients sending renews
+                        this.expectedNumberOfClientsSendingRenews = this.expectedNumberOfClientsSendingRenews + 1;
                         this.numberOfRenewsPerMinThreshold =
-                                (int) (this.expectedNumberOfRenewsPerMin * serverConfig.getRenewalPercentThreshold());
+                                (int) (this.expectedNumberOfClientsSendingRenews
+                                        * (60.0 / serverConfig.getExpectedClientRenewalIntervalSeconds())
+                                        * serverConfig.getRenewalPercentThreshold());
                     }
                 }
                 logger.debug("No previous lease information found; it is new registration");

--- a/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
@@ -221,10 +221,7 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
                     if (this.expectedNumberOfClientsSendingRenews > 0) {
                         // Since the client wants to register it, increase the number of clients sending renews
                         this.expectedNumberOfClientsSendingRenews = this.expectedNumberOfClientsSendingRenews + 1;
-                        this.numberOfRenewsPerMinThreshold =
-                                (int) (this.expectedNumberOfClientsSendingRenews
-                                        * (60.0 / serverConfig.getExpectedClientRenewalIntervalSeconds())
-                                        * serverConfig.getRenewalPercentThreshold());
+                        updateRenewsPerMinThreshold();
                     }
                 }
                 logger.debug("No previous lease information found; it is new registration");
@@ -1190,6 +1187,12 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
     private void invalidateCache(String appName, @Nullable String vipAddress, @Nullable String secureVipAddress) {
         // invalidate cache
         responseCache.invalidate(appName, vipAddress, secureVipAddress);
+    }
+
+    protected void updateRenewsPerMinThreshold() {
+        this.numberOfRenewsPerMinThreshold = (int) (this.expectedNumberOfClientsSendingRenews
+                * (60.0 / serverConfig.getExpectedClientRenewalIntervalSeconds())
+                * serverConfig.getRenewalPercentThreshold());
     }
 
     private static final class RecentlyChangedItem {

--- a/eureka-core/src/main/java/com/netflix/eureka/registry/PeerAwareInstanceRegistryImpl.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/PeerAwareInstanceRegistryImpl.java
@@ -236,9 +236,11 @@ public class PeerAwareInstanceRegistryImpl extends AbstractInstanceRegistry impl
     @Override
     public void openForTraffic(ApplicationInfoManager applicationInfoManager, int count) {
         // Renewals happen every 30 seconds and for a minute it should be a factor of 2.
-        this.expectedNumberOfRenewsPerMin = count * 2;
+        this.expectedNumberOfClientsSendingRenews = count;
         this.numberOfRenewsPerMinThreshold =
-                (int) (this.expectedNumberOfRenewsPerMin * serverConfig.getRenewalPercentThreshold());
+                (int) (this.expectedNumberOfClientsSendingRenews
+                        * (60.0 / serverConfig.getExpectedClientRenewalIntervalSeconds())
+                        * serverConfig.getRenewalPercentThreshold());
         logger.info("Got {} instances from neighboring DS node", count);
         logger.info("Renew threshold is: {}", numberOfRenewsPerMinThreshold);
         this.startupTime = System.currentTimeMillis();
@@ -378,11 +380,13 @@ public class PeerAwareInstanceRegistryImpl extends AbstractInstanceRegistry impl
         if (super.cancel(appName, id, isReplication)) {
             replicateToPeers(Action.Cancel, appName, id, null, null, isReplication);
             synchronized (lock) {
-                if (this.expectedNumberOfRenewsPerMin > 0) {
-                    // Since the client wants to cancel it, reduce the threshold (1 for 30 seconds, 2 for a minute)
-                    this.expectedNumberOfRenewsPerMin = this.expectedNumberOfRenewsPerMin - 2;
+                if (this.expectedNumberOfClientsSendingRenews > 0) {
+                    // Since the client wants to cancel it, reduce the number of clients to send renews
+                    this.expectedNumberOfClientsSendingRenews = this.expectedNumberOfClientsSendingRenews - 1;
                     this.numberOfRenewsPerMinThreshold =
-                            (int) (this.expectedNumberOfRenewsPerMin * serverConfig.getRenewalPercentThreshold());
+                            (int) (this.expectedNumberOfClientsSendingRenews
+                                    * (60.0 / serverConfig.getExpectedClientRenewalIntervalSeconds())
+                                    * serverConfig.getRenewalPercentThreshold());
                 }
             }
             return true;
@@ -532,10 +536,12 @@ public class PeerAwareInstanceRegistryImpl extends AbstractInstanceRegistry impl
             synchronized (lock) {
                 // Update threshold only if the threshold is greater than the
                 // current expected threshold or if self preservation is disabled.
-                if ((count * 2) > (serverConfig.getRenewalPercentThreshold() * expectedNumberOfRenewsPerMin)
+                if ((count) > (serverConfig.getRenewalPercentThreshold() * expectedNumberOfClientsSendingRenews)
                         || (!this.isSelfPreservationModeEnabled())) {
-                    this.expectedNumberOfRenewsPerMin = count * 2;
-                    this.numberOfRenewsPerMinThreshold = (int) ((count * 2) * serverConfig.getRenewalPercentThreshold());
+                    this.expectedNumberOfClientsSendingRenews = count;
+                    this.numberOfRenewsPerMinThreshold = (int) ((count
+                            * (60.0 / serverConfig.getExpectedClientRenewalIntervalSeconds()))
+                            * serverConfig.getRenewalPercentThreshold());
                 }
             }
             logger.info("Current renewal threshold is : {}", numberOfRenewsPerMinThreshold);

--- a/eureka-core/src/main/java/com/netflix/eureka/registry/PeerAwareInstanceRegistryImpl.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/PeerAwareInstanceRegistryImpl.java
@@ -237,10 +237,7 @@ public class PeerAwareInstanceRegistryImpl extends AbstractInstanceRegistry impl
     public void openForTraffic(ApplicationInfoManager applicationInfoManager, int count) {
         // Renewals happen every 30 seconds and for a minute it should be a factor of 2.
         this.expectedNumberOfClientsSendingRenews = count;
-        this.numberOfRenewsPerMinThreshold =
-                (int) (this.expectedNumberOfClientsSendingRenews
-                        * (60.0 / serverConfig.getExpectedClientRenewalIntervalSeconds())
-                        * serverConfig.getRenewalPercentThreshold());
+        updateRenewsPerMinThreshold();
         logger.info("Got {} instances from neighboring DS node", count);
         logger.info("Renew threshold is: {}", numberOfRenewsPerMinThreshold);
         this.startupTime = System.currentTimeMillis();
@@ -383,10 +380,7 @@ public class PeerAwareInstanceRegistryImpl extends AbstractInstanceRegistry impl
                 if (this.expectedNumberOfClientsSendingRenews > 0) {
                     // Since the client wants to cancel it, reduce the number of clients to send renews
                     this.expectedNumberOfClientsSendingRenews = this.expectedNumberOfClientsSendingRenews - 1;
-                    this.numberOfRenewsPerMinThreshold =
-                            (int) (this.expectedNumberOfClientsSendingRenews
-                                    * (60.0 / serverConfig.getExpectedClientRenewalIntervalSeconds())
-                                    * serverConfig.getRenewalPercentThreshold());
+                    updateRenewsPerMinThreshold();
                 }
             }
             return true;
@@ -539,9 +533,7 @@ public class PeerAwareInstanceRegistryImpl extends AbstractInstanceRegistry impl
                 if ((count) > (serverConfig.getRenewalPercentThreshold() * expectedNumberOfClientsSendingRenews)
                         || (!this.isSelfPreservationModeEnabled())) {
                     this.expectedNumberOfClientsSendingRenews = count;
-                    this.numberOfRenewsPerMinThreshold = (int) ((count
-                            * (60.0 / serverConfig.getExpectedClientRenewalIntervalSeconds()))
-                            * serverConfig.getRenewalPercentThreshold());
+                    updateRenewsPerMinThreshold();
                 }
             }
             logger.info("Current renewal threshold is : {}", numberOfRenewsPerMinThreshold);


### PR DESCRIPTION
…s and not break self-preservation

Currently, if one sets renewal interval different from 30 seconds on clients, self-preservation doesn't work correctly. For example, see https://github.com/spring-cloud/spring-cloud-netflix/issues/373 . This PR adds possibility to configure expected renewal interval on Eureka server, so that if clients send renews every, say, 20 seconds, then SP threshold is `0.85 * 3 * count`, not `0.85 * 2 * count`.