### PR TITLE
Cache capacity configurable

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/DefaultEurekaServerConfig.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/DefaultEurekaServerConfig.java
@@ -674,4 +674,9 @@ public class DefaultEurekaServerConfig implements EurekaServerConfig {
         return configInstance.getIntProperty(
                 namespace + "minAvailableInstancesForPeerReplication", -1).get();
     }
+
+    @Override
+    public int getInitialCapacityOfResponseCache() {
+        return configInstance.getIntProperty(namespace + "initialCapacityOfResponseCache", 1000).get();
+    }
 }

--- a/eureka-core/src/main/java/com/netflix/eureka/EurekaServerConfig.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/EurekaServerConfig.java
@@ -670,4 +670,11 @@ public interface EurekaServerConfig {
      * @return a property of experimental feature
      */
     String getExperimental(String name);
+
+    /**
+     * Get the capacity of responseCache, default value is 1000.
+     *
+     * @return the capacity of responseCache.
+     */
+    int getInitialCapacityOfResponseCache();
 }

--- a/eureka-core/src/main/java/com/netflix/eureka/registry/ResponseCacheImpl.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/ResponseCacheImpl.java
@@ -128,7 +128,7 @@ public class ResponseCacheImpl implements ResponseCache {
 
         long responseCacheUpdateIntervalMs = serverConfig.getResponseCacheUpdateIntervalMs();
         this.readWriteCacheMap =
-                CacheBuilder.newBuilder().initialCapacity(1000)
+                CacheBuilder.newBuilder().initialCapacity(serverConfig.getInitialCapacityOfResponseCache())
                         .expireAfterWrite(serverConfig.getResponseCacheAutoExpirationInSeconds(), TimeUnit.SECONDS)
                         .removalListener(new RemovalListener<Key, Value>() {
                             @Override


### PR DESCRIPTION
Hi @qiangdavidliu 

When `ResponseCacheImpl#readWriteCacheMap` init, it use hardcode to make initial capacity, so I add a parameter which can let customer decide the initial capacity.

Please check it.

Thanks : )