### PR TITLE
Add possibility to register Eureka Server metrics to Spectator registry

### DIFF
--- a/eureka-core/build.gradle
+++ b/eureka-core/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     compile "javax.servlet:servlet-api:${servletVersion}"
     compile 'com.thoughtworks.xstream:xstream:1.4.10'
     compile 'javax.ws.rs:jsr311-api:1.1.1'
+    compile 'com.netflix.spectator:spectator-api:0.74.2'
 
     // These dependencies are marked 'provided' in the client, but we need them always on the server
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${jacksonVersion}"


### PR DESCRIPTION
Hi, this adds possibility to register `EurekaMonitors` to some Spectator registry. Helps if Eureka is deployed not as Tomcat web app. Users may provide own registry and get metrics reported to Atlas, for example.

However, if you think this is not enough and would be nice to add some Atlas configuration, so that even Tomcat web app could post metrics to Atlas, please let me know. However, I don't know how to pick proper `commonTags`, and we would need to provide own implementation of `AtlasConfig`, etc, etc. I bet if people are using Eureka and considering necessity of Atlas metrics, they already have some company-specific solutions for this, which can easily be applied with my PR.