### PR TITLE
update default server's eureka-client property

### DIFF
--- a/eureka-server/src/main/resources/eureka-client.properties
+++ b/eureka-server/src/main/resources/eureka-client.properties
@@ -50,6 +50,10 @@ eureka.serviceUrl.default=http://localhost:8080/eureka/v2/
 # resource initialization
 eureka.shouldOnDemandUpdateStatusChange=false
 
+# = false to get instances for all statuses, not just UP. This is necessary to properly calculate the correct
+# self preservation threshold. See issue https://github.com/Netflix/eureka/issues/1127 for a discussion.
+eureka.shouldFilterOnlyUpInstances=false
+
 # the default eureka server application context is /eureka/v2 if deployed with eureka.war
 # Set this property for custom application context.
 #eureka.eurekaServer.context=eureka/v2


### PR DESCRIPTION
The eureka server internal eureka-client need to be configured to get instances for all statuses, not just UP. This is necessary to properly calculate the correct self preservation threshold. See issue https://github.com/Netflix/eureka/issues/1127 for a discussion.