### PR TITLE
Tweak Staleness metrics

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
@@ -1677,6 +1677,10 @@ public class DiscoveryClient implements EurekaClient {
     @com.netflix.servo.annotations.Monitor(name = METRIC_REGISTRATION_PREFIX + "lastSuccessfulHeartbeatTimePeriod",
             description = "How much time has passed from last successful heartbeat", type = DataSourceType.GAUGE)
     private long getLastSuccessfulHeartbeatTimePeriodInternal() {
+        if (!clientConfig.shouldRegisterWithEureka() || isShutdown.get()) {
+            heartbeatStalenessMonitor.update(0);
+            return 0;
+        }
         long delay = getLastSuccessfulHeartbeatTimePeriod();
         heartbeatStalenessMonitor.update(computeStalenessMonitorDelay(delay));
         return delay;
@@ -1686,6 +1690,10 @@ public class DiscoveryClient implements EurekaClient {
     @com.netflix.servo.annotations.Monitor(name = METRIC_REGISTRY_PREFIX + "lastSuccessfulRegistryFetchTimePeriod",
             description = "How much time has passed from last successful local registry update", type = DataSourceType.GAUGE)
     private long getLastSuccessfulRegistryFetchTimePeriodInternal() {
+        if (!clientConfig.shouldFetchRegistry() || isShutdown.get()) {
+            registryStalenessMonitor.update(0);
+            return 0;
+        }
         long delay = getLastSuccessfulRegistryFetchTimePeriod();
         registryStalenessMonitor.update(computeStalenessMonitorDelay(delay));
         return delay;

--- a/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
@@ -1677,11 +1677,10 @@ public class DiscoveryClient implements EurekaClient {
     @com.netflix.servo.annotations.Monitor(name = METRIC_REGISTRATION_PREFIX + "lastSuccessfulHeartbeatTimePeriod",
             description = "How much time has passed from last successful heartbeat", type = DataSourceType.GAUGE)
     private long getLastSuccessfulHeartbeatTimePeriodInternal() {
-        if (!clientConfig.shouldRegisterWithEureka() || isShutdown.get()) {
-            heartbeatStalenessMonitor.update(0);
-            return 0;
-        }
-        long delay = getLastSuccessfulHeartbeatTimePeriod();
+        final long delay = (!clientConfig.shouldRegisterWithEureka() || isShutdown.get())
+            ? 0
+            : getLastSuccessfulHeartbeatTimePeriod();
+
         heartbeatStalenessMonitor.update(computeStalenessMonitorDelay(delay));
         return delay;
     }
@@ -1690,11 +1689,10 @@ public class DiscoveryClient implements EurekaClient {
     @com.netflix.servo.annotations.Monitor(name = METRIC_REGISTRY_PREFIX + "lastSuccessfulRegistryFetchTimePeriod",
             description = "How much time has passed from last successful local registry update", type = DataSourceType.GAUGE)
     private long getLastSuccessfulRegistryFetchTimePeriodInternal() {
-        if (!clientConfig.shouldFetchRegistry() || isShutdown.get()) {
-            registryStalenessMonitor.update(0);
-            return 0;
-        }
-        long delay = getLastSuccessfulRegistryFetchTimePeriod();
+        final long delay = (!clientConfig.shouldFetchRegistry() || isShutdown.get())
+            ? 0
+            : getLastSuccessfulRegistryFetchTimePeriod();
+
         registryStalenessMonitor.update(computeStalenessMonitorDelay(delay));
         return delay;
     }


### PR DESCRIPTION
Tweak the staleness guages to return 0 for when the client is shut down or when refreshes are not enabled.  Otherwise the metric can be misleading by incorrectly making it appear that refreshes are not working.