### PR TITLE
  Add @Override toString() in InstanceInfo

### DIFF
--- a/eureka-client/src/main/java/com/netflix/appinfo/InstanceInfo.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/InstanceInfo.java
@@ -232,6 +232,14 @@ public class InstanceInfo {
         }
     }
 
+    @Override
+    public String toString(){
+        return "InstanceInfo [instanceId = " + this.instanceId + ", appName = " + this.appName +
+                ", hostName = " + this.hostName + ", status = " + this.status +
+                ", ipAddr = " + this.ipAddr + ", port = " + this.port + ", securePort = " + this.securePort +
+                ", dataCenterInfo = " + this.dataCenterInfo;
+    }
+
     private Map<String, String> removeMetadataMapLegacyValues(Map<String, String> metadata) {
         if (InstanceInfoSerializer.METADATA_COMPATIBILITY_VALUE.equals(metadata.get(InstanceInfoSerializer.METADATA_COMPATIBILITY_KEY))) {
             // TODO this else if can be removed once the server no longer uses legacy json

--- a/eureka-client/src/test/java/com/netflix/discovery/shared/ApplicationsTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/shared/ApplicationsTest.java
@@ -178,7 +178,41 @@ public class ApplicationsTest {
         assertNotNull(applications.getRegisteredApplications("TestApp").getByInstanceId("test.west.hostname"));
    
     }
-    
+
+    @Test
+    public void testInfoDetailApplications(){
+
+        DataCenterInfo myDCI = new DataCenterInfo() {
+            public DataCenterInfo.Name getName() {
+                return DataCenterInfo.Name.MyOwn;
+            }
+        };
+        InstanceInfo instanceInfo = InstanceInfo.Builder.newBuilder()
+                .setInstanceId("test.id")
+                .setAppName("test")
+                .setHostName("test.hostname")
+                .setStatus(InstanceStatus.UP)
+                .setIPAddr("test.testip:1")
+                .setPort(8080)
+                .setSecurePort(443)
+                .setDataCenterInfo(myDCI)
+                .build();
+
+        Application application = new Application("Test App");
+        application.addInstance(instanceInfo);
+
+        Applications applications = new Applications();
+        applications.addApplication(application);
+
+        List<InstanceInfo> instanceInfos = application.getInstances();
+        Assert.assertEquals(1, instanceInfos.size());
+        Assert.assertTrue(instanceInfos.contains(instanceInfo));
+
+        List<Application> appsList = applications.getRegisteredApplications();
+        Assert.assertEquals(1, appsList.size());
+        Assert.assertTrue(appsList.contains(application));
+        Assert.assertEquals(application, applications.getRegisteredApplications(application.getName()));
+    }
 
     @Test
     public void testRegisteredApplications() {


### PR DESCRIPTION
Application(class) can get simple information by @Override the toString().

-> toString() in Application.java

    @Override
    public String toString() {
        return "Application [name=" + name + ", isDirty=" + isDirty
                + ", instances=" + instances + ", shuffledInstances="
                + shuffledInstances + ", instancesMap=" + instancesMap + "]";
    }

It is simple to use some information immediately.

But What is more necessary is the information in InstanceInfo(class)?
InstanceInfo provides a detailed information about the eureka client.
InstanceInfo provides a getter, but it has about 30 member variables.

So it seems necessary to provide the overriden toString() of InstanceInfo