### PR TITLE
EUREKA-1149 Add injectable customizable EndpointRandomizer

### DIFF
--- a/eureka-client-archaius2/src/main/java/com/netflix/discovery/guice/InternalEurekaClientModule.java
+++ b/eureka-client-archaius2/src/main/java/com/netflix/discovery/guice/InternalEurekaClientModule.java
@@ -20,6 +20,8 @@ import com.netflix.discovery.DiscoveryClient;
 import com.netflix.discovery.EurekaArchaius2ClientConfig;
 import com.netflix.discovery.EurekaClient;
 import com.netflix.discovery.EurekaClientConfig;
+import com.netflix.discovery.shared.resolver.EndpointRandomizer;
+import com.netflix.discovery.shared.resolver.ResolverUtils;
 import com.netflix.discovery.shared.transport.EurekaArchaius2TransportConfig;
 import com.netflix.discovery.shared.transport.EurekaTransportConfig;
 import com.netflix.discovery.shared.transport.jersey.Jersey1DiscoveryClientOptionalArgs;
@@ -73,6 +75,7 @@ final class InternalEurekaClientModule extends AbstractModule {
         bind(VipAddressResolver.class).to(Archaius2VipAddressResolver.class);
         bind(InstanceInfo.class).toProvider(EurekaConfigBasedInstanceInfoProvider.class);
         bind(EurekaClient.class).to(DiscoveryClient.class);
+        bind(EndpointRandomizer.class).toInstance(ResolverUtils::randomize);
 
 
         // Default to the jersey1 discovery client optional args

--- a/eureka-client-jersey2/src/main/java/com/netflix/discovery/guice/Jersey2EurekaModule.java
+++ b/eureka-client-jersey2/src/main/java/com/netflix/discovery/guice/Jersey2EurekaModule.java
@@ -14,6 +14,8 @@ import com.netflix.discovery.EurekaClient;
 import com.netflix.discovery.EurekaClientConfig;
 import com.netflix.discovery.Jersey2DiscoveryClientOptionalArgs;
 import com.netflix.discovery.providers.DefaultEurekaClientConfigProvider;
+import com.netflix.discovery.shared.resolver.EndpointRandomizer;
+import com.netflix.discovery.shared.resolver.ResolverUtils;
 import com.netflix.discovery.shared.transport.jersey.TransportClientFactories;
 import com.netflix.discovery.shared.transport.jersey2.Jersey2TransportClientFactories;
 
@@ -37,7 +39,7 @@ public final class Jersey2EurekaModule extends AbstractModule {
         bind(InstanceInfo.class).toProvider(EurekaConfigBasedInstanceInfoProvider.class).in(Scopes.SINGLETON);
 
         bind(EurekaClient.class).to(DiscoveryClient.class).in(Scopes.SINGLETON);
-
+        bind(EndpointRandomizer.class).toInstance(ResolverUtils::randomize);
         // jersey2 support bindings
         bind(AbstractDiscoveryClientOptionalArgs.class).to(Jersey2DiscoveryClientOptionalArgs.class).in(Scopes.SINGLETON);
     }

--- a/eureka-client/src/main/java/com/netflix/discovery/guice/EurekaModule.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/guice/EurekaModule.java
@@ -12,6 +12,8 @@ import com.netflix.discovery.AbstractDiscoveryClientOptionalArgs;
 import com.netflix.discovery.EurekaClient;
 import com.netflix.discovery.EurekaClientConfig;
 import com.netflix.discovery.providers.DefaultEurekaClientConfigProvider;
+import com.netflix.discovery.shared.resolver.EndpointRandomizer;
+import com.netflix.discovery.shared.resolver.ResolverUtils;
 import com.netflix.discovery.shared.transport.jersey.Jersey1DiscoveryClientOptionalArgs;
 
 /**
@@ -35,7 +37,7 @@ public final class EurekaModule extends AbstractModule {
         bind(InstanceInfo.class).toProvider(EurekaConfigBasedInstanceInfoProvider.class).in(Scopes.SINGLETON);
 
         bind(EurekaClient.class).to(DiscoveryClient.class).in(Scopes.SINGLETON);
-
+        bind(EndpointRandomizer.class).toInstance(ResolverUtils::randomize);
         // Default to the jersey1 discovery client optional args
         bind(AbstractDiscoveryClientOptionalArgs.class).to(Jersey1DiscoveryClientOptionalArgs.class).in(Scopes.SINGLETON);
     }

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/resolver/EndpointRandomizer.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/resolver/EndpointRandomizer.java
@@ -1,0 +1,7 @@
+package com.netflix.discovery.shared.resolver;
+
+import java.util.List;
+
+public interface EndpointRandomizer {
+    <T extends EurekaEndpoint> List<T> randomize(List<T> list);
+}

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/resolver/LegacyClusterResolver.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/resolver/LegacyClusterResolver.java
@@ -49,9 +49,9 @@ public class LegacyClusterResolver implements ClusterResolver<AwsEndpoint> {
 
     private final ClusterResolver<AwsEndpoint> delegate;
 
-    public LegacyClusterResolver(EurekaClientConfig clientConfig, String myZone) {
+    public LegacyClusterResolver(EurekaClientConfig clientConfig, String myZone, EndpointRandomizer randomizer) {
         this.delegate = new ReloadingClusterResolver<>(
-                new LegacyClusterResolverFactory(clientConfig, myZone),
+                new LegacyClusterResolverFactory(clientConfig, myZone, randomizer),
                 clientConfig.getEurekaServiceUrlPollIntervalSeconds() * 1000
         );
     }
@@ -71,11 +71,13 @@ public class LegacyClusterResolver implements ClusterResolver<AwsEndpoint> {
         private final EurekaClientConfig clientConfig;
         private final String myRegion;
         private final String myZone;
+        private final EndpointRandomizer randomizer;
 
-        LegacyClusterResolverFactory(EurekaClientConfig clientConfig, String myZone) {
+        LegacyClusterResolverFactory(EurekaClientConfig clientConfig, String myZone, EndpointRandomizer randomizer) {
             this.clientConfig = clientConfig;
             this.myRegion = clientConfig.getRegion();
             this.myZone = myZone;
+            this.randomizer = randomizer;
         }
 
         @Override
@@ -91,7 +93,7 @@ public class LegacyClusterResolver implements ClusterResolver<AwsEndpoint> {
                         false,
                         clientConfig.getEurekaServerURLContext()
                 );
-                newResolver = new ZoneAffinityClusterResolver(newResolver, myZone, clientConfig.shouldPreferSameZoneEureka());
+                newResolver = new ZoneAffinityClusterResolver(newResolver, myZone, clientConfig.shouldPreferSameZoneEureka(), randomizer);
             } else {
                 // FIXME Not randomized in the EndpointUtils.getServiceUrlsFromConfig, and no zone info to do this here
                 newResolver = new StaticClusterResolver<>(myRegion, createEurekaEndpointsFromConfig());

--- a/eureka-client/src/test/java/com/netflix/discovery/BackUpRegistryTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/BackUpRegistryTest.java
@@ -13,6 +13,7 @@ import com.netflix.appinfo.MyDataCenterInstanceConfig;
 import com.netflix.config.ConfigurationManager;
 import com.netflix.discovery.shared.Application;
 import com.netflix.discovery.shared.Applications;
+import com.netflix.discovery.shared.resolver.ResolverUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -72,7 +73,8 @@ public class BackUpRegistryTest {
                 applicationInfoManager,
                 new DefaultEurekaClientConfig(),
                 null,
-                Providers.of((BackupRegistry)backupRegistry)
+                Providers.of((BackupRegistry)backupRegistry),
+                ResolverUtils::randomize
         );
     }
 

--- a/eureka-client/src/test/java/com/netflix/discovery/EurekaClientLifecycleTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/EurekaClientLifecycleTest.java
@@ -14,6 +14,8 @@ import com.netflix.appinfo.InstanceInfo;
 import com.netflix.appinfo.PropertiesInstanceConfig;
 import com.netflix.discovery.shared.Application;
 import com.netflix.discovery.shared.Applications;
+import com.netflix.discovery.shared.resolver.EndpointRandomizer;
+import com.netflix.discovery.shared.resolver.ResolverUtils;
 import com.netflix.discovery.shared.transport.EurekaHttpClient;
 import com.netflix.discovery.shared.transport.EurekaHttpResponse;
 import com.netflix.discovery.shared.transport.SimpleEurekaHttpServer;
@@ -86,6 +88,7 @@ public class EurekaClientLifecycleTest {
                                 bind(EurekaInstanceConfig.class).to(LocalEurekaInstanceConfig.class);
                                 bind(EurekaClientConfig.class).to(LocalEurekaClientConfig.class);
                                 bind(AbstractDiscoveryClientOptionalArgs.class).to(Jersey1DiscoveryClientOptionalArgs.class).in(Scopes.SINGLETON);
+                                bind(EndpointRandomizer.class).toInstance(ResolverUtils::randomize);
                             }
                         }
                 )
@@ -122,6 +125,7 @@ public class EurekaClientLifecycleTest {
                                 bind(EurekaClientConfig.class).to(BadServerEurekaClientConfig1.class);
                                 bind(BackupRegistry.class).toInstance(backupRegistry);
                                 bind(AbstractDiscoveryClientOptionalArgs.class).to(Jersey1DiscoveryClientOptionalArgs.class).in(Scopes.SINGLETON);
+                                bind(EndpointRandomizer.class).toInstance(ResolverUtils::randomize);
                             }
                         }
                 )
@@ -144,6 +148,7 @@ public class EurekaClientLifecycleTest {
                                 bind(EurekaInstanceConfig.class).to(LocalEurekaInstanceConfig.class);
                                 bind(EurekaClientConfig.class).to(BadServerEurekaClientConfig2.class);
                                 bind(AbstractDiscoveryClientOptionalArgs.class).to(Jersey1DiscoveryClientOptionalArgs.class).in(Scopes.SINGLETON);
+                                bind(EndpointRandomizer.class).toInstance(ResolverUtils::randomize);
                             }
                         }
                 )

--- a/eureka-client/src/test/java/com/netflix/discovery/shared/resolver/aws/ZoneAffinityClusterResolverTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/shared/resolver/aws/ZoneAffinityClusterResolverTest.java
@@ -18,6 +18,7 @@ package com.netflix.discovery.shared.resolver.aws;
 
 import java.util.List;
 
+import com.netflix.discovery.shared.resolver.ResolverUtils;
 import com.netflix.discovery.shared.resolver.StaticClusterResolver;
 import org.junit.Test;
 
@@ -34,8 +35,11 @@ public class ZoneAffinityClusterResolverTest {
     public void testApplicationZoneIsFirstOnTheList() throws Exception {
         List<AwsEndpoint> endpoints = SampleCluster.merge(SampleCluster.UsEast1a, SampleCluster.UsEast1b, SampleCluster.UsEast1c);
 
-        ZoneAffinityClusterResolver resolver = new ZoneAffinityClusterResolver(new StaticClusterResolver<>("regionA", endpoints), "us-east-1b", true);
-
+        ZoneAffinityClusterResolver resolver = new ZoneAffinityClusterResolver(
+                new StaticClusterResolver<>("regionA", endpoints),
+                "us-east-1b",
+                true,
+                ResolverUtils::randomize);
         List<AwsEndpoint> result = resolver.getClusterEndpoints();
         assertThat(result.size(), is(equalTo(endpoints.size())));
         assertThat(result.get(0).getZone(), is(equalTo("us-east-1b")));
@@ -45,7 +49,7 @@ public class ZoneAffinityClusterResolverTest {
     public void testAntiAffinity() throws Exception {
         List<AwsEndpoint> endpoints = SampleCluster.merge(SampleCluster.UsEast1a, SampleCluster.UsEast1b);
 
-        ZoneAffinityClusterResolver resolver = new ZoneAffinityClusterResolver(new StaticClusterResolver<>("regionA", endpoints), "us-east-1b", false);
+        ZoneAffinityClusterResolver resolver = new ZoneAffinityClusterResolver(new StaticClusterResolver<>("regionA", endpoints), "us-east-1b", false, ResolverUtils::randomize);
 
         List<AwsEndpoint> result = resolver.getClusterEndpoints();
         assertThat(result.size(), is(equalTo(endpoints.size())));
@@ -56,7 +60,7 @@ public class ZoneAffinityClusterResolverTest {
     public void testUnrecognizedZoneIsIgnored() throws Exception {
         List<AwsEndpoint> endpoints = SampleCluster.merge(SampleCluster.UsEast1a, SampleCluster.UsEast1b);
 
-        ZoneAffinityClusterResolver resolver = new ZoneAffinityClusterResolver(new StaticClusterResolver<>("regionA", endpoints), "us-east-1c", true);
+        ZoneAffinityClusterResolver resolver = new ZoneAffinityClusterResolver(new StaticClusterResolver<>("regionA", endpoints), "us-east-1c", true, ResolverUtils::randomize);
 
         List<AwsEndpoint> result = resolver.getClusterEndpoints();
         assertThat(result.size(), is(equalTo(endpoints.size())));

--- a/eureka-client/src/test/java/com/netflix/discovery/shared/transport/EurekaHttpClientsTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/shared/transport/EurekaHttpClientsTest.java
@@ -33,14 +33,15 @@ import com.netflix.discovery.shared.Applications;
 import com.netflix.discovery.shared.resolver.ClosableResolver;
 import com.netflix.discovery.shared.resolver.ClusterResolver;
 import com.netflix.discovery.shared.resolver.DefaultEndpoint;
+import com.netflix.discovery.shared.resolver.EndpointRandomizer;
 import com.netflix.discovery.shared.resolver.EurekaEndpoint;
+import com.netflix.discovery.shared.resolver.ResolverUtils;
 import com.netflix.discovery.shared.resolver.StaticClusterResolver;
 import com.netflix.discovery.shared.resolver.aws.ApplicationsResolver;
 import com.netflix.discovery.shared.resolver.aws.AwsEndpoint;
 import com.netflix.discovery.shared.resolver.aws.EurekaHttpResolver;
 import com.netflix.discovery.shared.resolver.aws.TestEurekaHttpResolver;
 import com.netflix.discovery.shared.transport.jersey.Jersey1TransportClientFactories;
-import com.netflix.discovery.shared.transport.jersey.TransportClientFactories;
 import com.netflix.discovery.util.EurekaEntityComparators;
 import com.netflix.discovery.util.InstanceInfoGenerator;
 import com.sun.jersey.api.client.ClientHandlerException;
@@ -85,6 +86,7 @@ public class EurekaHttpClientsTest {
     private SimpleEurekaHttpServer readServer;
 
     private ClusterResolver<EurekaEndpoint> clusterResolver;
+    private EndpointRandomizer randomizer;
     private EurekaHttpClientFactory clientFactory;
 
     private String readServerURI;
@@ -95,6 +97,7 @@ public class EurekaHttpClientsTest {
     public void setUp() throws IOException {
         clientConfig = mock(EurekaClientConfig.class);
         transportConfig = mock(EurekaTransportConfig.class);
+        randomizer = ResolverUtils::randomize;
 
         when(clientConfig.getEurekaServerTotalConnectionsPerHost()).thenReturn(10);
         when(clientConfig.getEurekaServerTotalConnections()).thenReturn(10);
@@ -185,7 +188,8 @@ public class EurekaHttpClientsTest {
                     transportConfig,
                     transportClientFactory,
                     applicationInfoManager.getInfo(),
-                    applicationsSource
+                    applicationsSource,
+                    randomizer
             );
 
             List endpoints = resolver.getClusterEndpoints();
@@ -244,7 +248,8 @@ public class EurekaHttpClientsTest {
                     localResolver,
                     clientConfig,
                     transportConfig,
-                    applicationInfoManager.getInfo()
+                    applicationInfoManager.getInfo(),
+                    randomizer
             );
 
             List endpoints = resolver.getClusterEndpoints();


### PR DESCRIPTION
This is another attempt to fix #1149. This time tried to take comments from #1151 into account.

Difficult thing here is that there are actually two randomizers across Eureka codebase. And the one that is used by DiscoveryClient ends up being just a call to static method. So I decided to not touch existing randomizer that is a field of DiscoveryClient (because I have no idea where can it be used) and introduced new field. This EndpointRandomizer is passed to ZoneAffinityClusterResolver through some chain of calls. I have left behavior unchanged, just made it customizeable.