### PR TITLE
Uses HashMap if CompactHashMap is not available on classpath.

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/converters/EurekaJacksonCodec.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/converters/EurekaJacksonCodec.java
@@ -105,6 +105,22 @@ public class EurekaJacksonCodec {
 
     public static EurekaJacksonCodec INSTANCE = new EurekaJacksonCodec();
 
+    public static final Supplier<? extends Map<String, String>> METADATA_MAP_SUPPLIER;
+
+    static {
+        boolean useCompact = true;
+        try {
+            Class.forName("vlsi.utils.CompactHashMap");
+        } catch (ClassNotFoundException e) {
+            useCompact = false;
+        }
+        if (useCompact) {
+            METADATA_MAP_SUPPLIER = CompactHashMap::new;
+        } else {
+            METADATA_MAP_SUPPLIER = HashMap::new;
+        }
+    }
+
     /**
      * XStream codec supports character replacement in field names to generate XML friendly
      * names. This feature is also configurable, and replacement strings can be provided by a user.
@@ -622,7 +638,7 @@ public class EurekaJacksonCodec {
                                 String key = intern.apply(jp, CacheScope.GLOBAL_SCOPE);
                                 jsonToken = jp.nextToken();
                                 String value = intern.apply(jp, CacheScope.APPLICATION_SCOPE );
-                                metadataMap = Optional.ofNullable(metadataMap).orElseGet(CompactHashMap::new);
+                                metadataMap = Optional.ofNullable(metadataMap).orElseGet(METADATA_MAP_SUPPLIER);
                                 metadataMap.put(key, value);
                             }
                         };   

--- a/eureka-client/src/main/java/com/netflix/discovery/converters/jackson/builder/StringInterningAmazonInfoBuilder.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/converters/jackson/builder/StringInterningAmazonInfoBuilder.java
@@ -28,11 +28,10 @@ import com.netflix.appinfo.AmazonInfo;
 import com.netflix.appinfo.AmazonInfo.MetaDataKey;
 import com.netflix.appinfo.DataCenterInfo.Name;
 import com.netflix.discovery.converters.EnumLookup;
+import com.netflix.discovery.converters.EurekaJacksonCodec;
 import com.netflix.discovery.util.DeserializerStringCache;
 import com.netflix.discovery.util.DeserializerStringCache.CacheScope;
 import com.netflix.discovery.util.StringCache;
-
-import vlsi.utils.CompactHashMap;
 
 /**
  * Amazon instance info builder that is doing key names interning, together with
@@ -109,7 +108,7 @@ public class StringInterningAmazonInfoBuilder extends JsonDeserializer<AmazonInf
     @Override
     public AmazonInfo deserialize(JsonParser jp, DeserializationContext context)
             throws IOException {
-        Map<String,String> metadata = new CompactHashMap<>();
+        Map<String,String> metadata = EurekaJacksonCodec.METADATA_MAP_SUPPLIER.get();
         DeserializerStringCache intern = DeserializerStringCache.from(context);        
 
         if (skipToMetadata(jp)) {


### PR DESCRIPTION
This allows eureka users to exclude compactmap library if they so choose.