### PR TITLE
Optimized CircularQueue by extending LinkedList with constant time size implementation

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
@@ -1297,12 +1297,6 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
                 this.remove();
             }
         }
-
-        @Override
-        public boolean offer(E e) {
-            this.makeSpaceIfNotAvailable();
-            return super.offer(e);
-        }
     }
 
     /**

--- a/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -1278,8 +1279,8 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
 
     }
 
-    private class CircularQueue<E> extends ConcurrentLinkedQueue<E> {
-        private int size = 0;
+    private static class CircularQueue<E> extends LinkedList<E> {
+        private final int size;
 
         public CircularQueue(int size) {
             this.size = size;
@@ -1289,7 +1290,6 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
         public boolean add(E e) {
             this.makeSpaceIfNotAvailable();
             return super.add(e);
-
         }
 
         private void makeSpaceIfNotAvailable() {
@@ -1298,6 +1298,7 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
             }
         }
 
+        @Override
         public boolean offer(E e) {
             this.makeSpaceIfNotAvailable();
             return super.offer(e);

--- a/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.NoSuchElementException;
 import java.util.Random;
 import java.util.Set;
 import java.util.Timer;
@@ -1303,6 +1304,9 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
                 @Override
                 @SuppressWarnings("unchecked")
                 public E next() {
+                    if (!hasNext()) {
+                        throw new NoSuchElementException();
+                    }
                     counter++;
                     E value = (E) storage[index];
                     index = inc(index);

--- a/eureka-core/src/test/java/com/netflix/eureka/registry/InstanceRegistryTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/registry/InstanceRegistryTest.java
@@ -1,5 +1,8 @@
 package com.netflix.eureka.registry;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import com.netflix.appinfo.InstanceInfo;
@@ -7,6 +10,8 @@ import com.netflix.appinfo.InstanceInfo.InstanceStatus;
 import com.netflix.discovery.shared.Application;
 import com.netflix.discovery.shared.Applications;
 import com.netflix.eureka.AbstractTester;
+import com.netflix.eureka.registry.AbstractInstanceRegistry.CircularQueue;
+import com.netflix.eureka.registry.AbstractInstanceRegistry.EvictionTask;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -267,5 +272,48 @@ public class InstanceRegistryTest extends AbstractTester {
         assertThat(testTask.getCompensationTimeMs(), is(0l));
         assertThat(testTask.getCompensationTimeMs(), is(10l));
         assertThat(testTask.getCompensationTimeMs(), is(0l));
+    }
+
+    @Test
+    public void testCircularQueue() throws Exception {
+        CircularQueue<Integer> queue = new CircularQueue<>(5);
+
+        Assert.assertEquals(0, queue.size());
+        Assert.assertNull(queue.peek());
+        Assert.assertEquals(Collections.emptyList(), new ArrayList<>(queue));
+
+        queue.add(1);
+        queue.add(2);
+        queue.add(3);
+        queue.add(4);
+
+        Assert.assertEquals(4, queue.size());
+        Assert.assertEquals(Arrays.asList(1, 2, 3, 4), new ArrayList<>(queue));
+
+        queue.offer(5);
+
+        Assert.assertEquals(5, queue.size());
+        Assert.assertEquals(Arrays.asList(1, 2, 3, 4, 5), new ArrayList<>(queue));
+
+        queue.offer(6);
+
+        Assert.assertEquals(5, queue.size());
+        Assert.assertEquals(Arrays.asList(2, 3, 4, 5, 6), new ArrayList<>(queue));
+
+        Integer poll = queue.poll();
+
+        Assert.assertEquals(4, queue.size());
+        Assert.assertEquals((Object) 2, poll);
+        Assert.assertEquals(Arrays.asList(3, 4, 5, 6), new ArrayList<>(queue));
+
+        queue.add(7);
+
+        Assert.assertEquals(5, queue.size());
+        Assert.assertEquals(Arrays.asList(3, 4, 5, 6, 7), new ArrayList<>(queue));
+
+        queue.clear();
+
+        Assert.assertEquals(0, queue.size());
+        Assert.assertEquals(Collections.emptyList(), new ArrayList<>(queue));
     }
 }


### PR DESCRIPTION
Since `AbstractInstanceRegistry` already have synchronization on `recentRegisteredQueue` and `recentCanceledQueue` it's safe to change `CircularQueue` implementation to extend `LinkedList` with constant time `size()`.

Benchmark:
```
import org.openjdk.jmh.annotations.Benchmark;
import org.openjdk.jmh.annotations.BenchmarkMode;
import org.openjdk.jmh.annotations.Fork;
import org.openjdk.jmh.annotations.Level;
import org.openjdk.jmh.annotations.Measurement;
import org.openjdk.jmh.annotations.Mode;
import org.openjdk.jmh.annotations.OutputTimeUnit;
import org.openjdk.jmh.annotations.Scope;
import org.openjdk.jmh.annotations.Setup;
import org.openjdk.jmh.annotations.State;
import org.openjdk.jmh.annotations.Warmup;
import org.openjdk.jmh.runner.Runner;
import org.openjdk.jmh.runner.RunnerException;
import org.openjdk.jmh.runner.options.Options;
import org.openjdk.jmh.runner.options.OptionsBuilder;

import java.util.concurrent.TimeUnit;

@BenchmarkMode(Mode.Throughput)
@OutputTimeUnit(TimeUnit.SECONDS)
@State(Scope.Benchmark)
@Fork(value = 2)
@Warmup(iterations = 3, batchSize = 10000)
@Measurement(iterations = 3, batchSize = 10000)
public class CircularQueueBenchmark {

    private final EurekaCircularQueue<String> eureka = new EurekaCircularQueue<>(10000);
    private final EurekaCircularQueueLinkedList<String> eurekaLinkedList = new EurekaCircularQueueLinkedList<>(10000);

    @Setup(Level.Iteration)
    public void setup(){
        eureka.clear();
        eurekaLinkedList.clear();
    }

    @Benchmark
    public EurekaCircularQueue<String> eureka() {
        synchronized (eureka) {
            eureka.add("something");
        }
        return eureka;
    }

    @Benchmark
    public EurekaCircularQueueLinkedList<String> eurekaLinkedList() {
        synchronized (eurekaLinkedList) {
            eurekaLinkedList.add("something");
        }
        return eurekaLinkedList;
    }

    public static void main(String[] args) throws RunnerException {
        Options opt = new OptionsBuilder()
                .include(CircularQueueBenchmark.class.getSimpleName())
                .build();

        new Runner(opt).run();
    }
}
```
Results:
```
Benchmark                                 Mode  Cnt     Score     Error  Units
CircularQueueBenchmark.eureka            thrpt    6     3.297 ±   0.005  ops/s
CircularQueueBenchmark.eurekaLinkedList  thrpt    6  3893.782 ± 110.320  ops/s
```

fixes #1236