### PR TITLE
Cleanup resources on web-app shutdown (#1207)

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/TimedSupervisorTask.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/TimedSupervisorTask.java
@@ -31,6 +31,7 @@ public class TimedSupervisorTask extends TimerTask {
     private final Counter throwableCounter;
     private final LongGauge threadPoolLevelGauge;
 
+    private final String name;
     private final ScheduledExecutorService scheduler;
     private final ThreadPoolExecutor executor;
     private final long timeoutMillis;
@@ -41,6 +42,7 @@ public class TimedSupervisorTask extends TimerTask {
 
     public TimedSupervisorTask(String name, ScheduledExecutorService scheduler, ThreadPoolExecutor executor,
                                int timeout, TimeUnit timeUnit, int expBackOffBound, Runnable task) {
+        this.name = name;
         this.scheduler = scheduler;
         this.executor = executor;
         this.timeoutMillis = timeUnit.toMillis(timeout);
@@ -100,5 +102,11 @@ public class TimedSupervisorTask extends TimerTask {
                 scheduler.schedule(this, delay.get(), TimeUnit.MILLISECONDS);
             }
         }
+    }
+
+    @Override
+    public boolean cancel() {
+        Monitors.unregisterObject(name, this);
+        return super.cancel();
     }
 }

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/transport/EurekaClientFactoryBuilder.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/transport/EurekaClientFactoryBuilder.java
@@ -50,7 +50,7 @@ public abstract class EurekaClientFactoryBuilder<F, B extends EurekaClientFactor
         withReadTimeout(clientConfig.getEurekaServerReadTimeoutSeconds() * 1000);
         withMaxConnectionsPerHost(clientConfig.getEurekaServerTotalConnectionsPerHost());
         withMaxTotalConnections(clientConfig.getEurekaServerTotalConnections());
-        withConnectionIdleTimeout(clientConfig.getEurekaConnectionIdleTimeoutSeconds() * 1000);
+        withConnectionIdleTimeout(clientConfig.getEurekaConnectionIdleTimeoutSeconds());
         withEncoder(clientConfig.getEncoderName());
         return withDecoder(clientConfig.getDecoderName(), clientConfig.getClientDataAccept());
     }

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/transport/jersey/ApacheHttpClientConnectionCleaner.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/transport/jersey/ApacheHttpClientConnectionCleaner.java
@@ -49,7 +49,7 @@ public class ApacheHttpClientConnectionCleaner {
 
                 @Override
                 public Thread newThread(Runnable r) {
-                    Thread thread = new Thread(r, "Eureka-JerseyClient-Conn-Cleaner" + threadNumber.incrementAndGet());
+                    Thread thread = new Thread(r, "Apache-HttpClient-Conn-Cleaner" + threadNumber.incrementAndGet());
                     thread.setDaemon(true);
                     return thread;
                 }
@@ -87,6 +87,7 @@ public class ApacheHttpClientConnectionCleaner {
     public void shutdown() {
         cleanIdle(0);
         eurekaConnCleaner.shutdown();
+        Monitors.unregisterObject(this);
     }
 
     public void cleanIdle(long delayMs) {

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/transport/jersey/EurekaJerseyClientImpl.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/transport/jersey/EurekaJerseyClientImpl.java
@@ -23,7 +23,6 @@ import org.apache.http.conn.scheme.Scheme;
 import org.apache.http.conn.scheme.SchemeRegistry;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.SSLSocketFactory;
-import org.apache.http.conn.ssl.X509HostnameVerifier;
 import org.apache.http.impl.conn.SchemeRegistryFactory;
 import org.apache.http.params.CoreProtocolPNames;
 import org.apache.http.params.HttpConnectionParams;
@@ -74,6 +73,12 @@ public class EurekaJerseyClientImpl implements EurekaJerseyClient {
     public void destroyResources() {
         apacheHttpClientConnectionCleaner.shutdown();
         apacheHttpClient.destroy();
+
+        final Object connectionManager =
+                jerseyClientConfig.getProperty(ApacheHttpClient4Config.PROPERTY_CONNECTION_MANAGER);
+        if (connectionManager instanceof MonitoredConnectionManager) {
+            ((MonitoredConnectionManager) connectionManager).shutdown();
+        }
     }
 
     public static class EurekaJerseyClientBuilder {

--- a/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientCloseJerseyThreadTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientCloseJerseyThreadTest.java
@@ -13,14 +13,14 @@ public class DiscoveryClientCloseJerseyThreadTest extends AbstractDiscoveryClien
 
     @Test
     public void testThreadCount() throws InterruptedException {
-        assertThat(containsJerseyThread(), equalTo(true));
+        assertThat(containsClientThread(), equalTo(true));
         client.shutdown();
         // Give up control for cleaner thread to die
         Thread.sleep(5);
-        assertThat(containsJerseyThread(), equalTo(false));
+        assertThat(containsClientThread(), equalTo(false));
     }
 
-    private boolean containsJerseyThread() {
+    private boolean containsClientThread() {
         Set<Thread> threads = Thread.getAllStackTraces().keySet();
         for (Thread t : threads) {
             if (t.getName().contains(JERSEY_THREAD_NAME) || t.getName().contains(APACHE_THREAD_NAME)) {

--- a/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientCloseJerseyThreadTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientCloseJerseyThreadTest.java
@@ -8,7 +8,8 @@ import static org.junit.Assert.assertThat;
 
 public class DiscoveryClientCloseJerseyThreadTest extends AbstractDiscoveryClientTester {
 
-    private static final String THREAD_NAME = "Eureka-JerseyClient-Conn-Cleaner";
+    private static final String JERSEY_THREAD_NAME = "Eureka-JerseyClient-Conn-Cleaner";
+    private static final String APACHE_THREAD_NAME = "Apache-HttpClient-Conn-Cleaner";
 
     @Test
     public void testThreadCount() throws InterruptedException {
@@ -22,7 +23,7 @@ public class DiscoveryClientCloseJerseyThreadTest extends AbstractDiscoveryClien
     private boolean containsJerseyThread() {
         Set<Thread> threads = Thread.getAllStackTraces().keySet();
         for (Thread t : threads) {
-            if (t.getName().contains(THREAD_NAME)) {
+            if (t.getName().contains(JERSEY_THREAD_NAME) || t.getName().contains(APACHE_THREAD_NAME)) {
                 return true;
             }
         }

--- a/eureka-core/src/main/java/com/netflix/eureka/DefaultEurekaServerContext.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/DefaultEurekaServerContext.java
@@ -17,9 +17,12 @@
 package com.netflix.eureka;
 
 import com.netflix.appinfo.ApplicationInfoManager;
+import com.netflix.discovery.DiscoveryManager;
 import com.netflix.eureka.cluster.PeerEurekaNodes;
 import com.netflix.eureka.registry.PeerAwareInstanceRegistry;
 import com.netflix.eureka.resources.ServerCodecs;
+import com.netflix.eureka.util.EurekaMonitors;
+import com.netflix.eureka.util.ServoControl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,6 +79,8 @@ public class DefaultEurekaServerContext implements EurekaServerContext {
         logger.info("Shutting down ...");
         registry.shutdown();
         peerEurekaNodes.shutdown();
+        ServoControl.shutdown();
+        EurekaMonitors.shutdown();
         logger.info("Shut down");
     }
 

--- a/eureka-core/src/main/java/com/netflix/eureka/cluster/PeerEurekaNode.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/cluster/PeerEurekaNode.java
@@ -349,6 +349,7 @@ public class PeerEurekaNode {
     public void shutDown() {
         batchingDispatcher.shutdown();
         nonBatchingDispatcher.shutdown();
+        replicationClient.shutdown();
     }
 
     /**

--- a/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
@@ -1219,6 +1219,7 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
         deltaRetentionTimer.cancel();
         evictionTimer.cancel();
         renewsLastMin.stop();
+        responseCache.stop();
     }
 
     @com.netflix.servo.annotations.Monitor(name = "numOfElementsinInstanceCache", description = "Number of overrides in the instance Cache", type = DataSourceType.GAUGE)

--- a/eureka-core/src/main/java/com/netflix/eureka/registry/PeerAwareInstanceRegistryImpl.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/PeerAwareInstanceRegistryImpl.java
@@ -176,6 +176,7 @@ public class PeerAwareInstanceRegistryImpl extends AbstractInstanceRegistry impl
             logger.error("Cannot shutdown ReplicaAwareInstanceRegistry", t);
         }
         numberOfReplicationsLastMin.stop();
+        timer.cancel();
 
         super.shutdown();
     }
@@ -647,7 +648,7 @@ public class PeerAwareInstanceRegistryImpl extends AbstractInstanceRegistry impl
                                                  String id, InstanceInfo info, InstanceStatus newStatus,
                                                  PeerEurekaNode node) {
         try {
-            InstanceInfo infoFromRegistry = null;
+            InstanceInfo infoFromRegistry;
             CurrentRequestVersion.set(Version.V2);
             switch (action) {
                 case Cancel:
@@ -672,6 +673,8 @@ public class PeerAwareInstanceRegistryImpl extends AbstractInstanceRegistry impl
             }
         } catch (Throwable t) {
             logger.error("Cannot replicate information to {} for action {}", node.getServiceUrl(), action.name(), t);
+        } finally {
+            CurrentRequestVersion.remove();
         }
     }
 
@@ -686,6 +689,8 @@ public class PeerAwareInstanceRegistryImpl extends AbstractInstanceRegistry impl
             node.statusUpdate(asgName, newStatus);
         } catch (Throwable e) {
             logger.error("Cannot replicate ASG status information to {}", node.getServiceUrl(), e);
+        } finally {
+            CurrentRequestVersion.remove();
         }
     }
 

--- a/eureka-core/src/main/java/com/netflix/eureka/registry/ResponseCache.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/ResponseCache.java
@@ -35,4 +35,10 @@ public interface ResponseCache {
      * @return compressed payload which contains information about the applications.
      */
     byte[] getGZIP(Key key);
+
+    /**
+     * Performs a shutdown of this cache by stopping internal threads and unregistering
+     * Servo monitors.
+     */
+    void stop();
 }

--- a/eureka-core/src/main/java/com/netflix/eureka/registry/ResponseCacheImpl.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/ResponseCacheImpl.java
@@ -185,6 +185,8 @@ public class ResponseCacheImpl implements ResponseCache {
                         }
                     } catch (Throwable th) {
                         logger.error("Error while updating the client cache from response cache for key {}", key.toStringCompact(), th);
+                    } finally {
+                        CurrentRequestVersion.remove();
                     }
                 }
             }
@@ -232,6 +234,12 @@ public class ResponseCacheImpl implements ResponseCache {
             return null;
         }
         return payload.getGzipped();
+    }
+
+    @Override
+    public void stop() {
+        timer.cancel();
+        Monitors.unregisterObject(this);
     }
 
     /**

--- a/eureka-core/src/main/java/com/netflix/eureka/resources/AbstractVIPResource.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/resources/AbstractVIPResource.java
@@ -69,6 +69,7 @@ abstract class AbstractVIPResource {
         );
 
         String payLoad = responseCache.get(cacheKey);
+        CurrentRequestVersion.remove();
 
         if (payLoad != null) {
             logger.debug("Found: {}", entityName);

--- a/eureka-core/src/main/java/com/netflix/eureka/resources/ApplicationResource.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/resources/ApplicationResource.java
@@ -107,6 +107,7 @@ public class ApplicationResource {
         );
 
         String payLoad = responseCache.get(cacheKey);
+        CurrentRequestVersion.remove();
 
         if (payLoad != null) {
             logger.debug("Found: {}", appName);

--- a/eureka-core/src/main/java/com/netflix/eureka/resources/CurrentRequestVersion.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/resources/CurrentRequestVersion.java
@@ -33,7 +33,7 @@ import com.netflix.eureka.Version;
 public final class CurrentRequestVersion {
 
     private static final ThreadLocal<Version> CURRENT_REQ_VERSION =
-            new ThreadLocal<Version>();
+            new ThreadLocal<>();
 
     private CurrentRequestVersion() {
     }
@@ -48,9 +48,19 @@ public final class CurrentRequestVersion {
 
     /**
      * Sets the current {@link Version}.
+     *
+     * Use {@link #remove()} as soon as the version is no longer required
+     * in order to purge the ThreadLocal used for storing it.
      */
     public static void set(Version version) {
         CURRENT_REQ_VERSION.set(version);
+    }
+
+    /**
+     * Clears the {@link ThreadLocal} used to store the version.
+     */
+    public static void remove() {
+        CURRENT_REQ_VERSION.remove();
     }
 
 }

--- a/eureka-core/src/main/java/com/netflix/eureka/resources/InstancesResource.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/resources/InstancesResource.java
@@ -62,6 +62,7 @@ public class InstancesResource {
                             @PathParam("id") String id) {
         CurrentRequestVersion.set(Version.toEnum(version));
         List<InstanceInfo> list = registry.getInstancesById(id);
+        CurrentRequestVersion.remove();
         if (list != null && !list.isEmpty()) {
             return Response.ok(list.get(0)).build();
         } else {

--- a/eureka-core/src/main/java/com/netflix/eureka/util/ServoControl.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/util/ServoControl.java
@@ -1,0 +1,21 @@
+package com.netflix.eureka.util;
+
+import com.netflix.servo.monitor.MonitorConfig;
+import com.netflix.servo.monitor.StatsTimer;
+import com.netflix.servo.stats.StatsConfig;
+
+/**
+ * The sole purpose of this class is shutting down the {@code protected} executor of {@link StatsTimer}
+ */
+public class ServoControl extends StatsTimer {
+
+    public ServoControl(MonitorConfig baseConfig, StatsConfig statsConfig) {
+        super(baseConfig, statsConfig);
+        throw new UnsupportedOperationException(getClass().getName() + " is not meant to be instantiated.");
+    }
+
+    public static void shutdown() {
+        DEFAULT_EXECUTOR.shutdown();
+    }
+
+}

--- a/eureka-core/src/main/java/com/netflix/eureka/util/batcher/AcceptorExecutor.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/util/batcher/AcceptorExecutor.java
@@ -47,6 +47,7 @@ class AcceptorExecutor<ID, T> {
 
     private static final Logger logger = LoggerFactory.getLogger(AcceptorExecutor.class);
 
+    private final String id;
     private final int maxBufferSize;
     private final int maxBatchingSize;
     private final long maxBatchingDelay;
@@ -94,6 +95,7 @@ class AcceptorExecutor<ID, T> {
                      long maxBatchingDelay,
                      long congestionRetryDelayMs,
                      long networkFailureRetryMs) {
+        this.id = id;
         this.maxBufferSize = maxBufferSize;
         this.maxBatchingSize = maxBatchingSize;
         this.maxBatchingDelay = maxBatchingDelay;
@@ -148,6 +150,7 @@ class AcceptorExecutor<ID, T> {
 
     void shutdown() {
         if (isShutdown.compareAndSet(false, true)) {
+            Monitors.unregisterObject(id, this);
             acceptorThread.interrupt();
         }
     }


### PR DESCRIPTION
In order to allow a clean shutdown, I canceled various timers and unregistered a number of Servo monitors. The `CurrentRequestVersion` got a `remove` method so that the `ThreadLocal` can be cleared after use.

The (in my opinion) only ugly solution is `ServoControl` which stops the executor of Servo since the library seems to be no longer maintained.