### PR TITLE
Disable jersey2 jsonp/moxy auto discovery

### DIFF
--- a/eureka-client-jersey2/src/main/java/com/netflix/discovery/shared/transport/jersey2/EurekaJersey2ClientImpl.java
+++ b/eureka-client-jersey2/src/main/java/com/netflix/discovery/shared/transport/jersey2/EurekaJersey2ClientImpl.java
@@ -85,6 +85,9 @@ public class EurekaJersey2ClientImpl implements EurekaJersey2Client {
         try {
             jerseyClientConfig = clientConfig;
             jerseyClientConfig.register(DiscoveryJerseyProvider.class);
+            // Disable json autodiscovery, since json (de)serialization is provided by DiscoveryJerseyProvider
+            jerseyClientConfig.property(ClientProperties.JSON_PROCESSING_FEATURE_DISABLE, Boolean.TRUE);
+            jerseyClientConfig.property(ClientProperties.MOXY_JSON_FEATURE_DISABLE, Boolean.TRUE);
             jerseyClientConfig.connectorProvider(new ApacheConnectorProvider());
             jerseyClientConfig.property(ClientProperties.CONNECT_TIMEOUT, connectionTimeout);
             jerseyClientConfig.property(ClientProperties.READ_TIMEOUT, readTimeout);

--- a/eureka-client-jersey2/src/main/java/com/netflix/discovery/shared/transport/jersey2/Jersey2ApplicationClientFactory.java
+++ b/eureka-client-jersey2/src/main/java/com/netflix/discovery/shared/transport/jersey2/Jersey2ApplicationClientFactory.java
@@ -228,6 +228,10 @@ public class Jersey2ApplicationClientFactory implements TransportClientFactory {
         private void addProviders(ClientConfig clientConfig) {
             DiscoveryJerseyProvider discoveryJerseyProvider = new DiscoveryJerseyProvider(encoderWrapper, decoderWrapper);
             clientConfig.register(discoveryJerseyProvider);
+
+            // Disable json autodiscovery, since json (de)serialization is provided by DiscoveryJerseyProvider
+            clientConfig.property(ClientProperties.JSON_PROCESSING_FEATURE_DISABLE, Boolean.TRUE);
+            clientConfig.property(ClientProperties.MOXY_JSON_FEATURE_DISABLE, Boolean.TRUE);
         }
     }
 }


### PR DESCRIPTION
Disable moxy/jsonp autodiscovery as the eureka client usage leverages an explicitly registered message body reader/writer.

When moxy or another json processor(jsonp) are on the classpath, they will be autodiscovered and registered into the transport/application clients which causes errors as those other providers take precedence over the DiscoveryJerseyProvider.

Example stack trace of moxy attempting to handle the request
```
	at org.eclipse.persistence.jaxb.rs.MOXyJsonProvider.readFrom(MOXyJsonProvider.java:695)
	at org.glassfish.jersey.message.internal.ReaderInterceptorExecutor$TerminalReaderInterceptor.invokeReadFrom(ReaderInterceptorExecutor.java:256)
	at org.glassfish.jersey.message.internal.ReaderInterceptorExecutor$TerminalReaderInterceptor.aroundReadFrom(ReaderInterceptorExecutor.java:235)
	at org.glassfish.jersey.message.internal.ReaderInterceptorExecutor.proceed(ReaderInterceptorExecutor.java:155)
	at org.glassfish.jersey.spi.ContentEncoder.aroundReadFrom(ContentEncoder.java:127)
	at org.glassfish.jersey.message.internal.ReaderInterceptorExecutor.proceed(ReaderInterceptorExecutor.java:155)
	at org.glassfish.jersey.message.internal.MessageBodyFactory.readFrom(MessageBodyFactory.java:1085)
	at org.glassfish.jersey.message.internal.InboundMessageContext.readEntity(InboundMessageContext.java:874)
	at org.glassfish.jersey.message.internal.InboundMessageContext.readEntity(InboundMessageContext.java:808)
	at org.glassfish.jersey.client.ClientResponse.readEntity(ClientResponse.java:326)
	at org.glassfish.jersey.client.InboundJaxrsResponse$1.call(InboundJaxrsResponse.java:115)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:315)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:297)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:228)
	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:419)
	at org.glassfish.jersey.client.InboundJaxrsResponse.runInScopeIfPossible(InboundJaxrsResponse.java:267)
	at org.glassfish.jersey.client.InboundJaxrsResponse.readEntity(InboundJaxrsResponse.java:112)
	at com.netflix.discovery.shared.transport.jersey2.AbstractJersey2EurekaHttpClient.getApplicationsInternal(AbstractJersey2EurekaHttpClient.java:266)
```