### PR TITLE
decrement expectedNumberOfClientsSendingRenews for expired leases

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
@@ -326,11 +326,20 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
                 }
                 invalidateCache(appName, vip, svip);
                 logger.info("Cancelled instance {}/{} (replication={})", appName, id, isReplication);
-                return true;
             }
         } finally {
             read.unlock();
         }
+
+        synchronized (lock) {
+            if (this.expectedNumberOfClientsSendingRenews > 0) {
+                // Since the client wants to cancel it, reduce the number of clients to send renews.
+                this.expectedNumberOfClientsSendingRenews = this.expectedNumberOfClientsSendingRenews - 1;
+                updateRenewsPerMinThreshold();
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/eureka-core/src/main/java/com/netflix/eureka/registry/PeerAwareInstanceRegistryImpl.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/PeerAwareInstanceRegistryImpl.java
@@ -377,13 +377,7 @@ public class PeerAwareInstanceRegistryImpl extends AbstractInstanceRegistry impl
                           final boolean isReplication) {
         if (super.cancel(appName, id, isReplication)) {
             replicateToPeers(Action.Cancel, appName, id, null, null, isReplication);
-            synchronized (lock) {
-                if (this.expectedNumberOfClientsSendingRenews > 0) {
-                    // Since the client wants to cancel it, reduce the number of clients to send renews
-                    this.expectedNumberOfClientsSendingRenews = this.expectedNumberOfClientsSendingRenews - 1;
-                    updateRenewsPerMinThreshold();
-                }
-            }
+
             return true;
         }
         return false;


### PR DESCRIPTION
Moves the logic that decrements the expected number of clients into
`internalCancel` - this should ensure that we're calling it both for
explicit cancels as well as well as when the instance lease expires.

Fixes #1266