### PR TITLE
Broadcast public ipv4 addresses on override

### DIFF
--- a/eureka-client/src/main/java/com/netflix/appinfo/AbstractInstanceConfig.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/AbstractInstanceConfig.java
@@ -211,6 +211,8 @@ public abstract class AbstractInstanceConfig implements EurekaInstanceConfig {
         return hostInfo.first();
     }
 
+    public boolean shouldBroadcastPublicIpv4Addr () { return false; }
+
     private static Pair<String, String> getHostInfo() {
         Pair<String, String> pair;
         try {

--- a/eureka-client/src/main/java/com/netflix/appinfo/CloudInstanceConfig.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/CloudInstanceConfig.java
@@ -128,8 +128,17 @@ public class CloudInstanceConfig extends PropertiesInstanceConfig implements Ref
 
     @Override
     public String getIpAddress() {
-        String ipAddr = amazonInfoHolder.get().get(MetaDataKey.localIpv4);
-        return ipAddr == null ? super.getIpAddress() : ipAddr;
+        String publicIpv4Addr = amazonInfoHolder.get().get(MetaDataKey.publicIpv4);
+        return this.shouldBroadcastPublicIpv4Addr() ?  getPublicIpv4Addr() : getPrivateIpv4Addr();
+    }
+
+    private String getPrivateIpv4Addr() {
+        String privateIpv4Addr = amazonInfoHolder.get().get(MetaDataKey.localIpv4);
+        return privateIpv4Addr == null ? super.getIpAddress() : privateIpv4Addr;
+    }
+    private String getPublicIpv4Addr() {
+        String publicIpv4Addr = amazonInfoHolder.get().get(MetaDataKey.publicIpv4);
+        return publicIpv4Addr == null ? super.getIpAddress() : publicIpv4Addr;
     }
 
     @Override

--- a/eureka-client/src/main/java/com/netflix/appinfo/CloudInstanceConfig.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/CloudInstanceConfig.java
@@ -128,7 +128,6 @@ public class CloudInstanceConfig extends PropertiesInstanceConfig implements Ref
 
     @Override
     public String getIpAddress() {
-        String publicIpv4Addr = amazonInfoHolder.get().get(MetaDataKey.publicIpv4);
         return this.shouldBroadcastPublicIpv4Addr() ?  getPublicIpv4Addr() : getPrivateIpv4Addr();
     }
 

--- a/eureka-client/src/main/java/com/netflix/appinfo/EurekaInstanceConfig.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/EurekaInstanceConfig.java
@@ -221,13 +221,6 @@ public interface EurekaInstanceConfig {
      */
     String getIpAddress();
 
-
-    /**
-     * Indicates if the public ipv4 address of the instance should be advertised.
-     * @return true if the public ipv4 address of the instance should be advertised, false otherwise .
-     */
-    boolean shouldBroadcastPublicIpv4Addr();
-
     /**
      * Gets the relative status page {@link java.net.URL} <em>Path</em> for this
      * instance. The status page URL is then constructed out of the

--- a/eureka-client/src/main/java/com/netflix/appinfo/EurekaInstanceConfig.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/EurekaInstanceConfig.java
@@ -221,6 +221,13 @@ public interface EurekaInstanceConfig {
      */
     String getIpAddress();
 
+
+    /**
+     * Indicates if the public ipv4 address of the instance should be advertised.
+     * @return true if the public ipv4 address of the instance should be advertised, false otherwise .
+     */
+    boolean shouldBroadcastPublicIpv4Addr();
+
     /**
      * Gets the relative status page {@link java.net.URL} <em>Path</em> for this
      * instance. The status page URL is then constructed out of the

--- a/eureka-client/src/main/java/com/netflix/appinfo/PropertiesInstanceConfig.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/PropertiesInstanceConfig.java
@@ -295,6 +295,11 @@ public abstract class PropertiesInstanceConfig extends AbstractInstanceConfig im
     }
 
     @Override
+    public boolean shouldBroadcastPublicIpv4Addr() {
+        return configInstance.getBooleanProperty(namespace + ADVERTISE_PUBLIC_IPV4_ADDR, super.shouldBroadcastPublicIpv4Addr()).get();
+    }
+
+    @Override
     public String getNamespace() {
         return this.namespace;
     }

--- a/eureka-client/src/main/java/com/netflix/appinfo/PropertiesInstanceConfig.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/PropertiesInstanceConfig.java
@@ -299,7 +299,7 @@ public abstract class PropertiesInstanceConfig extends AbstractInstanceConfig im
      * @return true if the public ipv4 address of the instance should be advertised, false otherwise .
      */
     public boolean shouldBroadcastPublicIpv4Addr() {
-        return configInstance.getBooleanProperty(namespace + ADVERTISE_PUBLIC_IPV4_ADDR, super.shouldBroadcastPublicIpv4Addr()).get();
+        return configInstance.getBooleanProperty(namespace + BROADCAST_PUBLIC_IPV4_ADDR_KEY, super.shouldBroadcastPublicIpv4Addr()).get();
     }
 
     @Override

--- a/eureka-client/src/main/java/com/netflix/appinfo/PropertiesInstanceConfig.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/PropertiesInstanceConfig.java
@@ -294,7 +294,10 @@ public abstract class PropertiesInstanceConfig extends AbstractInstanceConfig im
         return result == null ? new String[0] : result.split(",");
     }
 
-    @Override
+    /**
+     * Indicates if the public ipv4 address of the instance should be advertised.
+     * @return true if the public ipv4 address of the instance should be advertised, false otherwise .
+     */
     public boolean shouldBroadcastPublicIpv4Addr() {
         return configInstance.getBooleanProperty(namespace + ADVERTISE_PUBLIC_IPV4_ADDR, super.shouldBroadcastPublicIpv4Addr()).get();
     }

--- a/eureka-client/src/main/java/com/netflix/appinfo/PropertyBasedInstanceConfigConstants.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/PropertyBasedInstanceConfigConstants.java
@@ -36,7 +36,7 @@ final class PropertyBasedInstanceConfigConstants {
     static final String INSTANCE_METADATA_PREFIX = "metadata";
 
     static final String DEFAULT_ADDRESS_RESOLUTION_ORDER_KEY = "defaultAddressResolutionOrder";
-    static final String ADVERTISE_PUBLIC_IPV4_ADDR = "broadcastPublicIpv4";
+    static final String BROADCAST_PUBLIC_IPV4_ADDR_KEY = "broadcastPublicIpv4";
     static final String TRAFFIC_ENABLED_ON_INIT_KEY = "traffic.enabled";
 
 

--- a/eureka-client/src/main/java/com/netflix/appinfo/PropertyBasedInstanceConfigConstants.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/PropertyBasedInstanceConfigConstants.java
@@ -36,6 +36,7 @@ final class PropertyBasedInstanceConfigConstants {
     static final String INSTANCE_METADATA_PREFIX = "metadata";
 
     static final String DEFAULT_ADDRESS_RESOLUTION_ORDER_KEY = "defaultAddressResolutionOrder";
+    static final String ADVERTISE_PUBLIC_IPV4_ADDR = "broadcastPublicIpv4";
     static final String TRAFFIC_ENABLED_ON_INIT_KEY = "traffic.enabled";
 
 

--- a/eureka-client/src/test/java/com/netflix/appinfo/CloudInstanceConfigTest.java
+++ b/eureka-client/src/test/java/com/netflix/appinfo/CloudInstanceConfigTest.java
@@ -8,6 +8,8 @@ import static com.netflix.appinfo.AmazonInfo.MetaDataKey.localIpv4;
 import static com.netflix.appinfo.AmazonInfo.MetaDataKey.publicHostname;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
+
 
 /**
  * @author David Liu
@@ -38,6 +40,16 @@ public class CloudInstanceConfigTest {
         assertThat(config.resolveDefaultAddress(false), is(dummyDefault));
     }
 
+    @Test
+    public void testBroadcastPublicIpv4Address() {
+        AmazonInfo info = (AmazonInfo) instanceInfo.getDataCenterInfo();
+
+        config = createConfig(info);
+
+        // this should work because the test utils class sets the ipAddr to the public IP of the instance
+        assertEquals(instanceInfo.getIPAddr(), config.getIpAddress());
+    }
+
     private CloudInstanceConfig createConfig(AmazonInfo info) {
 
         return new CloudInstanceConfig(info) {
@@ -53,6 +65,9 @@ public class CloudInstanceConfigTest {
             public String getHostName(boolean refresh) {
                 return dummyDefault;
             }
+
+            @Override
+            public boolean shouldBroadcastPublicIpv4Addr() { return true; }
         };
     }
 }


### PR DESCRIPTION
This is a quick and dirty PR to get Eureka to return public ipv4 addresses when overriden by a new config flag `broadcastPublicIpv4`.

However, it doesn't fundamentally alter the behavior of `resolveDefaultAddress` as part of this change. 

/cc @drobertduke 