### PR TITLE
Add stats for DiscoveryClient

### DIFF
--- a/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientStatsInitFailedTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientStatsInitFailedTest.java
@@ -1,0 +1,41 @@
+package com.netflix.discovery;
+
+import com.netflix.discovery.junit.resource.DiscoveryClientResource;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for DiscoveryClient stats reported when initial registry fetch fails.
+ */
+public class DiscoveryClientStatsInitFailedTest extends BaseDiscoveryClientTester {
+
+    @Before
+    public void setUp() throws Exception {
+        setupProperties();
+        populateRemoteRegistryAtStartup();
+        setupDiscoveryClient();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        shutdownDiscoveryClient();
+        DiscoveryClientResource.clearDiscoveryClientConfig();
+    }
+
+    @Test
+    public void testEmptyInitLocalRegistrySize() throws Exception {
+        Assert.assertTrue(client instanceof DiscoveryClient);
+        DiscoveryClient clientImpl = (DiscoveryClient) client;
+        Assert.assertEquals(0, clientImpl.getStats().initLocalRegistrySize());
+    }
+
+    @Test
+    public void testInitFailed() throws Exception {
+        Assert.assertTrue(client instanceof DiscoveryClient);
+        DiscoveryClient clientImpl = (DiscoveryClient) client;
+        Assert.assertFalse(clientImpl.getStats().initSucceeded());
+    }
+
+}

--- a/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientStatsTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientStatsTest.java
@@ -1,0 +1,25 @@
+package com.netflix.discovery;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for DiscoveryClient stats reported when initial registry fetch succeeds.
+ */
+public class DiscoveryClientStatsTest extends AbstractDiscoveryClientTester {
+
+    @Test
+    public void testNonEmptyInitLocalRegistrySize() throws Exception {
+        Assert.assertTrue(client instanceof DiscoveryClient);
+        DiscoveryClient clientImpl = (DiscoveryClient) client;
+        Assert.assertEquals(createLocalApps().size(), clientImpl.getStats().initLocalRegistrySize());
+    }
+
+    @Test
+    public void testInitSucceeded() throws Exception {
+        Assert.assertTrue(client instanceof DiscoveryClient);
+        DiscoveryClient clientImpl = (DiscoveryClient) client;
+        Assert.assertTrue(clientImpl.getStats().initSucceeded());
+    }
+
+}


### PR DESCRIPTION
We introduce a nested class for `DiscoveryClient` to make it easier for users to read helpful attributes that can assist in log analysis and debugging. Most of these attributes are captured by existing metrics:

* `initTimestampMs`: timestamp when the client was initialized
* `localRegistrySize`: number of instances for all applications
* `lastSuccessfulRegistryFetchTimestampMs`: timestamp for last successful fetch
* `lastSuccessfulHeartbeatTimestampMs`: timestamp for last successful heartbeat

We add a new attribute called `initLocalRegistrySize`, which is the number of instances for all applications read when the client was initialized. We include a helper method that uses this attribute so that users can determine whether the client's initial fetch of registry information succeeded or failed. Note that other accessors are suffixed with `Ms` (for milliseconds) to denote the time unit.

Additionally, we update the existing `registrySize` with the value from `initLocalRegistrySize` during initialization instead of waiting until the first local registry refresh.