### PR TITLE
Update unit tests

### DIFF
--- a/eureka-client/src/test/java/com/netflix/discovery/InstanceInfoReplicatorTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/InstanceInfoReplicatorTest.java
@@ -32,9 +32,6 @@ public class InstanceInfoReplicatorTest {
     @Before
     public void setUp() throws Exception {
         discoveryClient = mock(DiscoveryClient.class);
-        HealthCheckHandler healthCheckHandler = mock(HealthCheckHandler.class);
-        when(discoveryClient.getHealthCheckHandler()).thenReturn(healthCheckHandler);
-        when(healthCheckHandler.getStatus(any(InstanceInfo.InstanceStatus.class))).thenReturn(null);
 
         InstanceInfo.Builder builder = InstanceInfo.Builder.newBuilder()
                 .setIPAddr("10.10.101.00")

--- a/eureka-client/src/test/java/com/netflix/discovery/util/RateLimiterTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/util/RateLimiterTest.java
@@ -44,7 +44,8 @@ public class RateLimiterTest {
     }
 
     private void testEvenLoad(RateLimiter rateLimiter, long start, int burstSize, int averageRate, long step) {
-        for (long currentTime = start; currentTime < 3; currentTime += step) {
+        long end = start + averageRate * step;
+        for (long currentTime = start; currentTime < end; currentTime += step) {
             assertTrue(rateLimiter.acquire(burstSize, averageRate, currentTime));
         }
     }


### PR DESCRIPTION
update ``InstanceInfoReplicatorTest`` and ``RateLimiterTest``
1. remove staled mock code in ``InstanceInfoReplicatorTest.setup()``
2. change the loop condition in ``RateLimiterTest.testEvenLoad()``. Otherwise, the loop body will not be executed.

