### PR TITLE
update to latest gradle wrapper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ allprojects {
         jerseyVersion = '1.19.1'
         jettisonVersion = '1.3.7'
         apacheHttpClientVersion = '4.5.3'
+        commonsConfigurationVersion = '1.10'
+        jsr305Version = '3.0.2'
         guiceVersion = '4.1.0'
         servoVersion = '0.12.21'
         governatorVersion = '1.17.5'

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,8 @@ buildscript {
 }
 
 plugins {
-    id 'nebula.netflixoss' version '3.6.0'
+    id 'nebula.netflixoss' version '8.8.1'
+    id 'org.gretty' version '2.1.0'
 }
 
 idea {

--- a/eureka-client-archaius2/build.gradle
+++ b/eureka-client-archaius2/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 
     // archaius2
     compile "com.netflix.archaius:archaius2-core:${archaius2Version}"
+    compile "com.netflix.archaius:archaius2-api:${archaius2Version}"
 
     testCompile project(':eureka-test-utils')
 

--- a/eureka-client/build.gradle
+++ b/eureka-client/build.gradle
@@ -16,6 +16,8 @@ dependencies {
     compile "com.sun.jersey:jersey-client:${jerseyVersion}"
     compile "com.sun.jersey.contribs:jersey-apache-client4:${jerseyVersion}"
     compile "org.apache.httpcomponents:httpclient:${apacheHttpClientVersion}"
+    compile "com.google.code.findbugs:jsr305:${jsr305Version}"
+    compile "commons-configuration:commons-configuration:${commonsConfigurationVersion}"
     compile "com.google.inject:guice:${guiceVersion}"
 
     compile "com.github.vlsi.compactmap:compactmap:1.2.1"

--- a/eureka-server-governator/build.gradle
+++ b/eureka-server-governator/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'war'
-apply plugin: 'jetty'
+apply plugin: 'org.gretty'
 
 dependencies {
     compile project(':eureka-core')
@@ -28,6 +28,6 @@ war {
     from (project(':eureka-resources').file('build/resources/main'))
 }
 
-jettyRun.doFirst {
+gretty {
     contextPath 'eureka'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue May 10 21:33:23 PDT 2016
+#Thu Apr 30 10:13:13 PDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip


### PR DESCRIPTION
Updates the gradle wrapper to 6.3, the neubla plugin to latest version
and replaces the jetty module with org.gretty as the jetty module has
been removed.

Move to org.gretty is motivated by https://stackoverflow.com/questions/50119925/error-while-replacing-jetty-plugin-to-gretty-plugin-gradle

Fixes #1276