### PR TITLE
fix enableSelfPreservation bug

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
@@ -1034,7 +1034,7 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
             lease = leaseMap.get(id);
         }
         if (lease != null
-                && (!isLeaseExpirationEnabled() || !lease.isExpired())) {
+                && (isLeaseExpirationEnabled() || !lease.isExpired())) {
             return decorateInstanceInfo(lease);
         } else if (includeRemoteRegions) {
             for (RemoteRegionRegistry remoteRegistry : this.regionNameVSRemoteRegistry.values()) {

--- a/eureka-core/src/main/java/com/netflix/eureka/registry/PeerAwareInstanceRegistryImpl.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/PeerAwareInstanceRegistryImpl.java
@@ -473,7 +473,7 @@ public class PeerAwareInstanceRegistryImpl extends AbstractInstanceRegistry impl
     public boolean isLeaseExpirationEnabled() {
         if (!isSelfPreservationModeEnabled()) {
             // The self preservation mode is disabled, hence allowing the instances to expire.
-            return true;
+            return false;
         }
         return numberOfRenewsPerMinThreshold > 0 && getNumOfRenewsInLastMin() > numberOfRenewsPerMinThreshold;
     }


### PR DESCRIPTION
~~### 1、**the enableSelfPreservation  bug**~~

~~the property eureka.server.enableSelfPreservation default is true~~

~~AbstractInstanceRegistry#evict(long additionalLeaseMs)~~
```java
if (!isLeaseExpirationEnabled()) {
   logger.debug("DS: lease expiration is currently disabled.");
   return;
}
```
~~when the property we set  false, then the function isLeaseExpirationEnabled() return boolean is true~~

~~then !isLeaseExpirationEnabled() is false, the code will not go into this if code~~


~~**so  i  changed the function isLeaseExpirationEnabled()   set the true -> false**~~

~~PeerAwareInstanceRegistryImpl#isLeaseExpirationEnabled()~~
```java
@Override
    public boolean isLeaseExpirationEnabled() {
        if (!isSelfPreservationModeEnabled()) {
            // The self preservation mode is disabled, hence allowing the instances to expire.
           //change here true to false
           - return true;
           + return false;
        }
        return numberOfRenewsPerMinThreshold > 0 && getNumOfRenewsInLastMin() > numberOfRenewsPerMinThreshold;
    }
````


---------------------------



~~### **2、 function call isLeaseExpirationEnabled（）,   below  logic is wrong**~~

~~AbstractInstanceRegistry#getInstanceByAppAndId(String appName, String id, boolean includeRemoteRegions)~~
```java
if (lease != null
                && (!isLeaseExpirationEnabled() || !lease.isExpired())) {
            return decorateInstanceInfo(lease);
        }
```
~~**when isLeaseExpirationEnabled return true means  we want to eureka evict the leases,  so i think here  should be ( isLeaseExpirationEnabled()  || lease not expired   ) && lease != null**~~

~~so i changed it~~

```java
if (lease != null
                && (isLeaseExpirationEnabled() || !lease.isExpired())) {
            return decorateInstanceInfo(lease);
        }
```


---------------------------


~~### 3、 the last one function call this isLeaseExpirationEnabled function~~

~~ AbstractInstanceRegistry#getInstancesById(String id, boolean includeRemoteRegions)~~

~~### **here isLeaseExpirationEnabled is ok,  no need to  edit **~~
```java
if (leaseMap != null) {
                Lease<InstanceInfo> lease = leaseMap.get(id);

                if (lease == null || (isLeaseExpirationEnabled() && lease.isExpired())) {
                    continue;
                }

                if (list == Collections.EMPTY_LIST) {
                    list = new ArrayList<InstanceInfo>();
                }
                list.add(decorateInstanceInfo(lease));
            }
```
