### PR TITLE
Remove uses of 'provided' in the eureka client

### DIFF
--- a/eureka-client/build.gradle
+++ b/eureka-client/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'nebula.test-jar'
-apply plugin: 'nebula.provided-base'
 
 configurations.all {
     // jersey2
@@ -27,9 +26,9 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
 
     // Eureka client uses JSON encoding by default
-    provided "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${jacksonVersion}"
+    compileOnly "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${jacksonVersion}"
     // Prefered jackson Stax serializer. Default Oracle has issues (adds empty namespace) and is slower
-    provided "com.fasterxml.woodstox:woodstox-core:${woodstoxVersion}"
+    compileOnly "com.fasterxml.woodstox:woodstox-core:${woodstoxVersion}"
 
     runtime "org.codehaus.jettison:jettison:${jettisonVersion}"
 

--- a/eureka-core/build.gradle
+++ b/eureka-core/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compile 'com.thoughtworks.xstream:xstream:1.4.11.1'
     compile 'javax.ws.rs:jsr311-api:1.1.1'
 
-    // These dependencies are marked 'provided' in the client, but we need them always on the server
+    // These dependencies are marked 'compileOnly' in the client, but we need them always on the server
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${jacksonVersion}"
     compile "com.fasterxml.woodstox:woodstox-core:${woodstoxVersion}"
 


### PR DESCRIPTION
After updating gradle, we can stop using the deprecated 'provided' configuration.
This fixes an issue where the jackson-dataformat-xml and woodstox-core dependencies are affecting projects consuming eureka-client.