### PR TITLE
Update Compactmap library to 2.0

### DIFF
--- a/eureka-client/build.gradle
+++ b/eureka-client/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     compile "commons-configuration:commons-configuration:${commonsConfigurationVersion}"
     compile "com.google.inject:guice:${guiceVersion}"
 
-    compile "com.github.vlsi.compactmap:compactmap:1.2.1"
+    compile "com.github.vlsi.compactmap:compactmap:2.0"
 
     compile "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
     compile "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"


### PR DESCRIPTION
Compactmap 2.0 has been relicensed under the Apache 2.0 license.
See: https://github.com/vlsi/compactmap/issues/6

Previous versions use LGPL.
This caught multiple projects by surprise. See for example
https://github.com/spring-cloud/spring-cloud-netflix/issues/3636
or https://github.com/hazelcast/hazelcast-eureka/issues/52