### PR TITLE
Add ability to gate InstanceStatus updates

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/EurekaInstanceStatusChangeGate.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/EurekaInstanceStatusChangeGate.java
@@ -1,0 +1,17 @@
+package com.netflix.discovery;
+
+import com.netflix.appinfo.InstanceInfo;
+
+/**
+ * A gate can be used to limit InstanceStatus changes.
+ */
+public interface EurekaInstanceStatusChangeGate {
+
+    /**
+     * Return `true` if the transition from the current status to `newStatus` is allowed.
+     * @param newStatus The instance's new desired status
+     * @return `true` if transition is allowed
+     */
+    boolean isAllowed(InstanceInfo.InstanceStatus newStatus);
+
+}

--- a/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientInstanceStatusChangeGateTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientInstanceStatusChangeGateTest.java
@@ -1,0 +1,103 @@
+package com.netflix.discovery;
+
+import com.netflix.appinfo.HealthCheckHandler;
+import com.netflix.appinfo.InstanceInfo;
+import com.netflix.config.ConfigurationManager;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DiscoveryClientInstanceStatusChangeGateTest extends AbstractDiscoveryClientTester {
+
+    @Override
+    protected void setupProperties() {
+        super.setupProperties();
+        ConfigurationManager.getConfigInstance().setProperty("eureka.registration.enabled", "true");
+        // as the tests in this class triggers the instanceInfoReplicator explicitly, set the below config
+        // so that it does not run as a background task
+        ConfigurationManager.getConfigInstance().setProperty("eureka.appinfo.initial.replicate.time", Integer.MAX_VALUE);
+        ConfigurationManager.getConfigInstance().setProperty("eureka.appinfo.replicate.interval", Integer.MAX_VALUE);
+    }
+
+    @Override
+    protected InstanceInfo.Builder newInstanceInfoBuilder(int renewalIntervalInSecs) {
+        InstanceInfo.Builder builder = super.newInstanceInfoBuilder(renewalIntervalInSecs);
+        builder.setStatus(InstanceInfo.InstanceStatus.STARTING);
+        return builder;
+    }
+
+    @Test
+    public void testAddGateSuccess() throws Exception {
+        Assert.assertTrue(client instanceof DiscoveryClient);
+        DiscoveryClient clientImpl = (DiscoveryClient) client;
+        Assert.assertTrue(clientImpl.addGate(InstanceInfo.InstanceStatus.UP, newStatus -> true));
+    }
+
+    @Test
+    public void testAddGateFailure() throws Exception {
+        Assert.assertTrue(client instanceof DiscoveryClient);
+        DiscoveryClient clientImpl = (DiscoveryClient) client;
+        EurekaInstanceStatusChangeGate gate = newStatus -> true;
+        Assert.assertTrue(clientImpl.addGate(InstanceInfo.InstanceStatus.UP, gate));
+        Assert.assertFalse(clientImpl.addGate(InstanceInfo.InstanceStatus.UP, gate));
+    }
+
+    @Test
+    public void testIsNotAllowedSetsStatusToDown() throws Exception {
+        ExampleHealthCheckHandler healthCheckHandler = new ExampleHealthCheckHandler(InstanceInfo.InstanceStatus.UP);
+        Assert.assertTrue(client instanceof DiscoveryClient);
+        DiscoveryClient clientImpl = (DiscoveryClient) client;
+        clientImpl.addGate(InstanceInfo.InstanceStatus.UP, newStatus -> false);
+
+        InstanceInfoReplicator replicator = clientImpl.getInstanceInfoReplicator();
+        Assert.assertEquals("InstanceInfo status not expected", InstanceInfo.InstanceStatus.STARTING, clientImpl.getInstanceInfo().getStatus());
+        client.registerHealthCheck(healthCheckHandler);
+        replicator.run();
+        Assert.assertTrue("HealthCheck callback not invoked", healthCheckHandler.isInvoked());
+        Assert.assertEquals("InstanceInfo status not expected", InstanceInfo.InstanceStatus.DOWN, clientImpl.getInstanceInfo().getStatus());
+    }
+
+    @Test
+    public void testIsAllowedSetsStatusGiven() throws Exception {
+        ExampleHealthCheckHandler healthCheckHandler = new ExampleHealthCheckHandler(InstanceInfo.InstanceStatus.UP);
+        Assert.assertTrue(client instanceof DiscoveryClient);
+        DiscoveryClient clientImpl = (DiscoveryClient) client;
+        clientImpl.addGate(InstanceInfo.InstanceStatus.UP, newStatus -> true);
+
+        InstanceInfoReplicator replicator = clientImpl.getInstanceInfoReplicator();
+        Assert.assertEquals("InstanceInfo status not expected", InstanceInfo.InstanceStatus.STARTING, clientImpl.getInstanceInfo().getStatus());
+        client.registerHealthCheck(healthCheckHandler);
+        replicator.run();
+        Assert.assertTrue("HealthCheck callback not invoked", healthCheckHandler.isInvoked());
+        Assert.assertEquals("InstanceInfo status not expected", InstanceInfo.InstanceStatus.UP, clientImpl.getInstanceInfo().getStatus());
+    }
+
+    private static class ExampleHealthCheckHandler implements HealthCheckHandler {
+
+        private final InstanceInfo.InstanceStatus health;
+        private volatile boolean invoked;
+        volatile boolean shouldException;
+
+        private ExampleHealthCheckHandler(InstanceInfo.InstanceStatus health) {
+            this.health = health;
+        }
+
+        public boolean isInvoked() {
+            return invoked;
+        }
+
+        public void reset() {
+            shouldException = false;
+            invoked = false;
+        }
+
+        @Override
+        public InstanceInfo.InstanceStatus getStatus(InstanceInfo.InstanceStatus currentStatus) {
+            invoked = true;
+            if (shouldException) {
+                throw new RuntimeException("test induced exception");
+            }
+            return health;
+        }
+    }
+
+}


### PR DESCRIPTION
We add a way for users to define gates when updating their InstanceStatus that is irrespective of the healthcheck handler response. For example, if the healthcheck handler returns an InstanceStatus of `UP` but a gate disallows that status then the healthcheck status will be overridden and the new status will be set to `DOWN`.

If there are no gates defined, the default behavior of the discovery client is unchanged.