### PR TITLE
Resolve spinlock issue in AcceptorExecutor thread

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/util/batcher/AcceptorExecutor.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/util/batcher/AcceptorExecutor.java
@@ -222,13 +222,14 @@ class AcceptorExecutor<ID, T> {
                 drainReprocessQueue();
                 drainAcceptorQueue();
 
-                if (!isShutdown.get()) {
-                    // If all queues are empty, block for a while on the acceptor queue
-                    if (reprocessQueue.isEmpty() && acceptorQueue.isEmpty() && pendingTasks.isEmpty()) {
-                        TaskHolder<ID, T> taskHolder = acceptorQueue.poll(10, TimeUnit.MILLISECONDS);
-                        if (taskHolder != null) {
-                            appendTaskHolder(taskHolder);
-                        }
+                if (isShutdown.get()) {
+                    break;
+                }
+                // If all queues are empty, block for a while on the acceptor queue
+                if (reprocessQueue.isEmpty() && acceptorQueue.isEmpty() && pendingTasks.isEmpty()) {
+                    TaskHolder<ID, T> taskHolder = acceptorQueue.poll(10, TimeUnit.MILLISECONDS);
+                    if (taskHolder != null) {
+                        appendTaskHolder(taskHolder);
                     }
                 }
             } while (!reprocessQueue.isEmpty() || !acceptorQueue.isEmpty() || pendingTasks.isEmpty());


### PR DESCRIPTION
I ran into an issue where an AcceptorExecutor thread would not shutdown and was using 100% cpu.

You can see in the heap dump below that shutdown was properly called and received by the thread. Also, you will notice that all 3 queues (reprocessQueue, acceptorQueue and  pendingTasks) are empty, causing the drainInputQueues while loop to get stuck.

![heapdump](https://user-images.githubusercontent.com/2784286/84155158-04943880-aa36-11ea-8287-c928caee3664.jpg)

If you were to be unlucky, when shutdown was called, you could fall into a condition where nothing was added to the pendingTasks queue and both reprocess and acceptor queue would stay empty since the executor was shutdown.

I did a quick and dirty unit test locally to reproduce the issue, but since this is a timing issue, the test would sometime pass without the fix in position. Of course, when the fix was there I was not able to make the test fail. Because of that, I decided not to add the unit test since it was not very robust. Let me know if you have an idea on how to elegantly test this! Thanks!