### PR TITLE
remove null check code

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
@@ -401,8 +401,7 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
     @Override
     public void storeOverriddenStatusIfRequired(String id, InstanceStatus overriddenStatus) {
         InstanceStatus instanceStatus = overriddenInstanceStatusMap.get(id);
-        if ((instanceStatus == null)
-                || (!overriddenStatus.equals(instanceStatus))) {
+        if (!overriddenStatus.equals(instanceStatus)) {
             // We might not have the overridden status if the server got restarted -this will help us maintain
             // the overridden state from the replica
             logger.info(
@@ -431,7 +430,7 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
     @Override
     public void storeOverriddenStatusIfRequired(String appName, String id, InstanceStatus overriddenStatus) {
         InstanceStatus instanceStatus = overriddenInstanceStatusMap.get(id);
-        if ((instanceStatus == null) || (!overriddenStatus.equals(instanceStatus))) {
+        if (!overriddenStatus.equals(instanceStatus)) {
             // We might not have the overridden status if the server got
             // restarted -this will help us maintain the overridden state
             // from the replica


### PR DESCRIPTION
I think it is unnecessary to check the null of `instanceStatus`.
Because it doesn't matter if `instanceStatus` is null when calling `overrideStatus.equals`