### PR TITLE
Replace valueOf to parseLong

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/converters/Converters.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/converters/Converters.java
@@ -615,7 +615,7 @@ public final class Converters {
 
                 long longValue = 0;
                 try {
-                    longValue = Long.valueOf(nodeValue).longValue();
+                    longValue = Long.parseLong(nodeValue);
                 } catch (NumberFormatException ne) {
                     continue;
                 }

--- a/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
@@ -493,7 +493,7 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
                     long replicaDirtyTimestamp = 0;
                     info.setStatusWithoutDirty(newStatus);
                     if (lastDirtyTimestamp != null) {
-                        replicaDirtyTimestamp = Long.valueOf(lastDirtyTimestamp);
+                        replicaDirtyTimestamp = Long.parseLong(lastDirtyTimestamp);
                     }
                     // If the replication's dirty timestamp is more than the existing one, just update
                     // it to the replica's.
@@ -554,7 +554,7 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
                     info.setStatusWithoutDirty(newStatus);
                     long replicaDirtyTimestamp = 0;
                     if (lastDirtyTimestamp != null) {
-                        replicaDirtyTimestamp = Long.valueOf(lastDirtyTimestamp);
+                        replicaDirtyTimestamp = Long.parseLong(lastDirtyTimestamp);
                     }
                     // If the replication's dirty timestamp is more than the existing one, just update
                     // it to the replica's.


### PR DESCRIPTION
Because the declared variable is primitive type, it is better to use `parseLong`.
I think creating a Long instance using `valueOf` and unwrapping again it is an unnecessary process.