### PR TITLE
Log status transitions to DOWN at error level, instead of warn

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
@@ -1349,10 +1349,8 @@ public class DiscoveryClient implements EurekaClient {
 
                 @Override
                 public void notify(StatusChangeEvent statusChangeEvent) {
-                    if (InstanceStatus.DOWN == statusChangeEvent.getStatus() ||
-                            InstanceStatus.DOWN == statusChangeEvent.getPreviousStatus()) {
-                        // log at warn level if DOWN was involved
-                        logger.warn("Saw local status change event {}", statusChangeEvent);
+                    if (statusChangeEvent.getStatus() == InstanceStatus.DOWN) {
+                        logger.error("Saw local status change event {}", statusChangeEvent);
                     } else {
                         logger.info("Saw local status change event {}", statusChangeEvent);
                     }


### PR DESCRIPTION
I also dropped the transitions out of down to info, rather than warn, since
there isn't really anything to be concerned about on such a transition