### PR TITLE
Remove null condition check

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
@@ -401,8 +401,7 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
     @Override
     public void storeOverriddenStatusIfRequired(String id, InstanceStatus overriddenStatus) {
         InstanceStatus instanceStatus = overriddenInstanceStatusMap.get(id);
-        if ((instanceStatus == null)
-                || (!overriddenStatus.equals(instanceStatus))) {
+        if (!overriddenStatus.equals(instanceStatus)) {
             // We might not have the overridden status if the server got restarted -this will help us maintain
             // the overridden state from the replica
             logger.info(
@@ -431,7 +430,7 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
     @Override
     public void storeOverriddenStatusIfRequired(String appName, String id, InstanceStatus overriddenStatus) {
         InstanceStatus instanceStatus = overriddenInstanceStatusMap.get(id);
-        if ((instanceStatus == null) || (!overriddenStatus.equals(instanceStatus))) {
+        if (!overriddenStatus.equals(instanceStatus)) {
             // We might not have the overridden status if the server got
             // restarted -this will help us maintain the overridden state
             // from the replica

--- a/eureka-core/src/main/java/com/netflix/eureka/registry/RemoteRegionRegistry.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/RemoteRegionRegistry.java
@@ -499,6 +499,6 @@ public class RemoteRegionRegistry implements LookupService<String> {
             return false;
         }
         String enabled = serverConfig.getExperimental("transport.enabled");
-        return enabled != null && "true".equalsIgnoreCase(enabled);
+        return "true".equalsIgnoreCase(enabled);
     }
 }

--- a/eureka-core/src/main/java/com/netflix/eureka/registry/rule/LeaseExistsRule.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/rule/LeaseExistsRule.java
@@ -27,8 +27,7 @@ public class LeaseExistsRule implements InstanceStatusOverrideRule {
                 existingStatus = existingLease.getHolder().getStatus();
             }
             // Allow server to have its way when the status is UP or OUT_OF_SERVICE
-            if ((existingStatus != null)
-                    && (InstanceInfo.InstanceStatus.OUT_OF_SERVICE.equals(existingStatus)
+            if ((InstanceInfo.InstanceStatus.OUT_OF_SERVICE.equals(existingStatus)
                     || InstanceInfo.InstanceStatus.UP.equals(existingStatus))) {
                 logger.debug("There is already an existing lease with status {}  for instance {}",
                         existingLease.getHolder().getStatus().name(),


### PR DESCRIPTION
Unnecessary null inspection conditions were deleted because performing "equals" without the condition of checking null would produce the same result.