### PR TITLE
Fix some incorrect logging in AbstractInstanceRegistry

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/AbstractInstanceRegistry.java
@@ -375,7 +375,7 @@ public abstract class AbstractInstanceRegistry implements InstanceRegistry {
                     logger.info(
                             "The instance status {} is different from overridden instance status {} for instance {}. "
                                     + "Hence setting the status to overridden status", instanceInfo.getStatus().name(),
-                                    instanceInfo.getOverriddenStatus().name(),
+                                    overriddenInstanceStatus.name(),
                                     instanceInfo.getId());
                     instanceInfo.setStatusWithoutDirty(overriddenInstanceStatus);
 


### PR DESCRIPTION
The status being logged in `AbstractInstanceRegistry.renew()`  is not the correct one. This is resulting in confusing log statements saying that the overridden status was `UNKNOWN`.