### PR TITLE
Register RemoteRegionRegistry with the servo monitors

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/registry/RemoteRegionRegistry.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/RemoteRegionRegistry.java
@@ -207,6 +207,12 @@ public class RemoteRegionRegistry implements LookupService<String> {
                         remoteRegionFetchTask
                 ),
                 serverConfig.getRemoteRegionRegistryFetchInterval(), TimeUnit.SECONDS);
+
+        try {
+            Monitors.registerObject(this);
+        } catch (Throwable e) {
+            logger.warn("Cannot register the JMX monitor for the RemoteRegionRegistry :", e);
+        }
     }
 
     /**


### PR DESCRIPTION
Without this, it won't collect the metrics.  The annotation alone isn't enough