### PR TITLE
Add IPv6 address to the datacenter metadata keys

### DIFF
--- a/eureka-client-archaius2/src/test/java/com/netflix/appinfo/Ec2EurekaArchaius2InstanceConfigTest.java
+++ b/eureka-client-archaius2/src/test/java/com/netflix/appinfo/Ec2EurekaArchaius2InstanceConfigTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 
 import java.util.Collections;
 
+import static com.netflix.appinfo.AmazonInfo.MetaDataKey.ipv6;
 import static com.netflix.appinfo.AmazonInfo.MetaDataKey.localIpv4;
 import static com.netflix.appinfo.AmazonInfo.MetaDataKey.publicHostname;
 import static org.hamcrest.CoreMatchers.is;
@@ -37,6 +38,10 @@ public class Ec2EurekaArchaius2InstanceConfigTest {
 
         info.getMetadata().remove(localIpv4.getName());
         config = createConfig(info);
+        assertThat(config.resolveDefaultAddress(false), is(info.get(ipv6)));
+
+        info.getMetadata().remove(ipv6.getName());
+        config = createConfig(info);
         assertThat(config.resolveDefaultAddress(false), is(dummyDefault));
     }
 
@@ -47,7 +52,8 @@ public class Ec2EurekaArchaius2InstanceConfigTest {
             public String[] getDefaultAddressResolutionOrder() {
                 return new String[] {
                         publicHostname.name(),
-                        localIpv4.name()
+                        localIpv4.name(),
+                        ipv6.name()
                 };
             }
 

--- a/eureka-client/src/main/java/com/netflix/appinfo/AmazonInfo.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/AmazonInfo.java
@@ -63,6 +63,7 @@ public class AmazonInfo implements DataCenterInfo, UniqueIdentifier {
         availabilityZone("availability-zone", "placement/"),
         publicHostname("public-hostname"),
         publicIpv4("public-ipv4"),
+        ipv6("ipv6"),
         spotTerminationTime("termination-time", "spot/"),
         spotInstanceAction("instance-action", "spot/"),
         mac("mac"),  // mac is declared above vpcId so will be found before vpcId (where it is needed)

--- a/eureka-client/src/test/java/com/netflix/appinfo/CloudInstanceConfigTest.java
+++ b/eureka-client/src/test/java/com/netflix/appinfo/CloudInstanceConfigTest.java
@@ -4,6 +4,7 @@ import com.netflix.discovery.util.InstanceInfoGenerator;
 import org.junit.Before;
 import org.junit.Test;
 
+import static com.netflix.appinfo.AmazonInfo.MetaDataKey.ipv6;
 import static com.netflix.appinfo.AmazonInfo.MetaDataKey.localIpv4;
 import static com.netflix.appinfo.AmazonInfo.MetaDataKey.publicHostname;
 import static org.hamcrest.CoreMatchers.is;
@@ -37,6 +38,10 @@ public class CloudInstanceConfigTest {
 
         info.getMetadata().remove(localIpv4.getName());
         config = createConfig(info);
+        assertThat(config.resolveDefaultAddress(false), is(info.get(ipv6)));
+
+        info.getMetadata().remove(ipv6.getName());
+        config = createConfig(info);
         assertThat(config.resolveDefaultAddress(false), is(dummyDefault));
     }
 
@@ -57,7 +62,8 @@ public class CloudInstanceConfigTest {
             public String[] getDefaultAddressResolutionOrder() {
                 return new String[] {
                         publicHostname.name(),
-                        localIpv4.name()
+                        localIpv4.name(),
+                        ipv6.name()
                 };
             }
 

--- a/eureka-test-utils/src/main/java/com/netflix/discovery/util/InstanceInfoGenerator.java
+++ b/eureka-test-utils/src/main/java/com/netflix/discovery/util/InstanceInfoGenerator.java
@@ -174,6 +174,7 @@ public class InstanceInfoGenerator {
         String privateHostname = "ip-10.0" + appIndex + "." + appInstanceId + ".compute.internal";
         String publicIp = "20.0." + appIndex + '.' + appInstanceId;
         String privateIp = "192.168." + appIndex + '.' + appInstanceId;
+        String ipv6 = "::FFFF:" + publicIp;
 
         String instanceId = String.format("i-%04d%04d", appIndex, appInstanceId);
         if (taggedId) {
@@ -190,6 +191,7 @@ public class InstanceInfoGenerator {
                 .addMetadata(MetaDataKey.localIpv4, privateIp)
                 .addMetadata(MetaDataKey.publicHostname, hostName)
                 .addMetadata(MetaDataKey.publicIpv4, publicIp)
+                .addMetadata(MetaDataKey.ipv6, ipv6)
                 .build();
 
         String unsecureURL = "http://" + hostName + ":8080";


### PR DESCRIPTION
* introduce a new datacenter metadata key for the primary IPv6 address
* update existing tests to make sure the new key can be used while specifying default address resolution order