### PR TITLE
Make instance config factory support custom amazon info provider

### DIFF
--- a/eureka-client-archaius2/src/main/java/com/netflix/appinfo/providers/AmazonInfoProviderFactory.java
+++ b/eureka-client-archaius2/src/main/java/com/netflix/appinfo/providers/AmazonInfoProviderFactory.java
@@ -1,0 +1,9 @@
+package com.netflix.appinfo.providers;
+
+import com.netflix.appinfo.AmazonInfo;
+
+import javax.inject.Provider;
+
+public interface AmazonInfoProviderFactory {
+    Provider<AmazonInfo> get();
+}

--- a/eureka-client-archaius2/src/main/java/com/netflix/appinfo/providers/CustomAmazonInfoProviderInstanceConfigFactory.java
+++ b/eureka-client-archaius2/src/main/java/com/netflix/appinfo/providers/CustomAmazonInfoProviderInstanceConfigFactory.java
@@ -1,0 +1,33 @@
+package com.netflix.appinfo.providers;
+
+import com.netflix.appinfo.AmazonInfo;
+import com.netflix.appinfo.Ec2EurekaArchaius2InstanceConfig;
+import com.netflix.appinfo.EurekaInstanceConfig;
+import com.netflix.archaius.api.Config;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+@Singleton
+public class CustomAmazonInfoProviderInstanceConfigFactory implements EurekaInstanceConfigFactory {
+
+    private final Config configInstance;
+    private final Provider<AmazonInfo> amazonInfoProvider;
+    private EurekaInstanceConfig eurekaInstanceConfig;
+
+    @Inject
+    public CustomAmazonInfoProviderInstanceConfigFactory(Config configInstance, AmazonInfoProviderFactory amazonInfoProviderFactory) {
+        this.configInstance = configInstance;
+        this.amazonInfoProvider = amazonInfoProviderFactory.get();
+    }
+
+    @Override
+    public EurekaInstanceConfig get() {
+        if (eurekaInstanceConfig == null) {
+            eurekaInstanceConfig = new Ec2EurekaArchaius2InstanceConfig(configInstance, amazonInfoProvider);
+        }
+
+        return eurekaInstanceConfig;
+    }
+}


### PR DESCRIPTION
This diff adds `CustomAmazonInfoProviderInstanceConfigFactory`. This allow us to inject custom implementation of `<Provider>AmazonInfo`. The intention is to bind this new factory implementation to the `EurekaInstanceConfigFactory` interface, as documented [here](https://github.com/Netflix/eureka/blob/master/eureka-client-archaius2/src/main/java/com/netflix/discovery/guice/EurekaClientModule.java#L22), so that users can control how `AmazonInfo` is provided.
