### PR TITLE
Make eureka instance config namespace configurable

### DIFF
--- a/eureka-client-archaius2/src/main/java/com/netflix/appinfo/Ec2EurekaArchaius2InstanceConfig.java
+++ b/eureka-client-archaius2/src/main/java/com/netflix/appinfo/Ec2EurekaArchaius2InstanceConfig.java
@@ -47,6 +47,12 @@ public class Ec2EurekaArchaius2InstanceConfig extends EurekaArchaius2InstanceCon
         this.amazonInfoHolder = amazonInfoProvider;
     }
 
+    public Ec2EurekaArchaius2InstanceConfig(Config configInstance, Provider<AmazonInfo> amazonInfoProvider, String namespace) {
+        super(configInstance, namespace);
+        this.amazonInfoConfig = null;
+        this.amazonInfoHolder = amazonInfoProvider;
+    }
+
     public Ec2EurekaArchaius2InstanceConfig(Config configInstance, AmazonInfoConfig amazonInfoConfig, String namespace) {
         this(configInstance, amazonInfoConfig, namespace, null, true);
     }

--- a/eureka-client-archaius2/src/main/java/com/netflix/appinfo/providers/CustomAmazonInfoProviderInstanceConfigFactory.java
+++ b/eureka-client-archaius2/src/main/java/com/netflix/appinfo/providers/CustomAmazonInfoProviderInstanceConfigFactory.java
@@ -4,9 +4,11 @@ import com.netflix.appinfo.AmazonInfo;
 import com.netflix.appinfo.Ec2EurekaArchaius2InstanceConfig;
 import com.netflix.appinfo.EurekaInstanceConfig;
 import com.netflix.archaius.api.Config;
+import com.netflix.discovery.CommonConstants;
 import com.netflix.discovery.DiscoveryManager;
 
-import javax.inject.Inject;
+import com.google.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
@@ -17,6 +19,14 @@ public class CustomAmazonInfoProviderInstanceConfigFactory implements EurekaInst
     private final Provider<AmazonInfo> amazonInfoProvider;
     private EurekaInstanceConfig eurekaInstanceConfig;
 
+    @Inject(optional = true)
+    @Named(CommonConstants.INSTANCE_CONFIG_NAMESPACE_KEY)
+    String instanceConfigNamespace;
+
+    String getInstanceConfigNamespace() {
+        return instanceConfigNamespace == null ? "eureka" : instanceConfigNamespace;
+    }
+
     @Inject
     public CustomAmazonInfoProviderInstanceConfigFactory(Config configInstance, AmazonInfoProviderFactory amazonInfoProviderFactory) {
         this.configInstance = configInstance;
@@ -26,7 +36,7 @@ public class CustomAmazonInfoProviderInstanceConfigFactory implements EurekaInst
     @Override
     public EurekaInstanceConfig get() {
         if (eurekaInstanceConfig == null) {
-            eurekaInstanceConfig = new Ec2EurekaArchaius2InstanceConfig(configInstance, amazonInfoProvider);
+            eurekaInstanceConfig = new Ec2EurekaArchaius2InstanceConfig(configInstance, amazonInfoProvider, getInstanceConfigNamespace());
 
             // Copied from CompositeInstanceConfigFactory.get
             DiscoveryManager.getInstance().setEurekaInstanceConfig(eurekaInstanceConfig);

--- a/eureka-client-archaius2/src/main/java/com/netflix/discovery/guice/EurekaClientModule.java
+++ b/eureka-client-archaius2/src/main/java/com/netflix/discovery/guice/EurekaClientModule.java
@@ -4,6 +4,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.binder.LinkedBindingBuilder;
 import com.google.inject.name.Names;
 import com.netflix.appinfo.providers.EurekaInstanceConfigFactory;
+import com.netflix.discovery.CommonConstants;
 
 /**
  * How to use:
@@ -39,11 +40,11 @@ import com.netflix.appinfo.providers.EurekaInstanceConfigFactory;
 public class EurekaClientModule extends AbstractModule {
 
     protected LinkedBindingBuilder<String> bindEurekaInstanceConfigNamespace() {
-        return bind(String.class).annotatedWith(Names.named(InternalEurekaClientModule.INSTANCE_CONFIG_NAMESPACE_KEY));
+        return bind(String.class).annotatedWith(Names.named(CommonConstants.INSTANCE_CONFIG_NAMESPACE_KEY));
     }
 
     protected LinkedBindingBuilder<String> bindEurekaClientConfigNamespace() {
-        return bind(String.class).annotatedWith(Names.named(InternalEurekaClientModule.CLIENT_CONFIG_NAMESPACE_KEY));
+        return bind(String.class).annotatedWith(Names.named(CommonConstants.CLIENT_CONFIG_NAMESPACE_KEY));
     }
 
     protected LinkedBindingBuilder<EurekaInstanceConfigFactory> bindEurekaInstanceConfigFactory() {

--- a/eureka-client-archaius2/src/main/java/com/netflix/discovery/guice/InternalEurekaClientModule.java
+++ b/eureka-client-archaius2/src/main/java/com/netflix/discovery/guice/InternalEurekaClientModule.java
@@ -31,20 +31,17 @@ import javax.inject.Singleton;
 
 final class InternalEurekaClientModule extends AbstractModule {
 
-    static final String INSTANCE_CONFIG_NAMESPACE_KEY = "eureka.instance.config.namespace";
-    static final String CLIENT_CONFIG_NAMESPACE_KEY = "eureka.client.config.namespace";
-
     @Singleton
     static class ModuleConfig {
         @Inject
         Config config;
 
         @Inject(optional = true)
-        @Named(InternalEurekaClientModule.INSTANCE_CONFIG_NAMESPACE_KEY)
+        @Named(CommonConstants.INSTANCE_CONFIG_NAMESPACE_KEY)
         String instanceConfigNamespace;
 
         @Inject(optional = true)
-        @Named(InternalEurekaClientModule.CLIENT_CONFIG_NAMESPACE_KEY)
+        @Named(CommonConstants.CLIENT_CONFIG_NAMESPACE_KEY)
         String clientConfigNamespace;
 
         @Inject(optional = true)

--- a/eureka-client/src/main/java/com/netflix/discovery/CommonConstants.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/CommonConstants.java
@@ -6,5 +6,6 @@ package com.netflix.discovery;
 public final class CommonConstants {
     public static final String CONFIG_FILE_NAME = "eureka-client";
     public static final String DEFAULT_CONFIG_NAMESPACE = "eureka";
-
+    public static final String INSTANCE_CONFIG_NAMESPACE_KEY = "eureka.instance.config.namespace";
+    public static final String CLIENT_CONFIG_NAMESPACE_KEY = "eureka.client.config.namespace";
 }


### PR DESCRIPTION
Make eureka instance config namespace configurable. This allow us to use `CustomAmazonInfoProviderInstanceConfigFactory` the same way as `CompositeInstanceConfigFactory`.

Specifically, when we use `CompositeInstanceConfigFactory`, we can override the config namespace for which `InstaceConfig` reads its data from, using DI. Within Netflix this is overridden from `eureka` to `netflix.appinfo`. In `CustomAmazonInfoProviderInstanceConfigFactory`, however, this config namespace was previously hardcoded, causing test failures.