### PR TITLE
Update ResolverUtils::randomize

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/shared/resolver/ResolverUtils.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/resolver/ResolverUtils.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -40,8 +41,6 @@ import org.slf4j.LoggerFactory;
 public final class ResolverUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(ResolverUtils.class);
-
-    private static final String LOCAL_IPV4_ADDRESS = SystemUtil.getServerIPv4();
 
     private static final Pattern ZONE_RE = Pattern.compile("(txt\\.)?([^.]+).*");
 
@@ -81,7 +80,7 @@ public final class ResolverUtils {
     }
 
     /**
-     * Randomize server list using local IPv4 address hash as a seed.
+     * Randomize server list.
      *
      * @return a copy of the original list with elements in the random order
      */
@@ -90,14 +89,7 @@ public final class ResolverUtils {
         if (randomList.size() < 2) {
             return randomList;
         }
-        Random random = new Random(LOCAL_IPV4_ADDRESS.hashCode());
-        int last = randomList.size() - 1;
-        for (int i = 0; i < last; i++) {
-            int pos = random.nextInt(randomList.size() - i);
-            if (pos != i) {
-                Collections.swap(randomList, i, pos);
-            }
-        }
+        Collections.shuffle(randomList,ThreadLocalRandom.current());
         return randomList;
     }
 

--- a/eureka-client/src/test/java/com/netflix/discovery/shared/resolver/ResolverUtilsTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/shared/resolver/ResolverUtilsTest.java
@@ -30,6 +30,8 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
@@ -57,7 +59,37 @@ public class ResolverUtilsTest {
         assertThat(ResolverUtils.extractZoneFromHostName("us-east-1c.myservice.net"), is(equalTo("us-east-1c")));
         assertThat(ResolverUtils.extractZoneFromHostName("txt.us-east-1c.myservice.net"), is(equalTo("us-east-1c")));
     }
-
+    
+    @Test
+    public void testRandomizeProperlyRandomizesList() throws Exception {
+        boolean success = false;
+        for (int i = 0; i < 100; i++) {
+            List<AwsEndpoint> firstList = SampleCluster.UsEast1a.builder().withServerPool(100).build();
+        
+            List<AwsEndpoint> secondList = ResolverUtils.randomize(firstList);
+        
+            try {
+                assertThat(firstList, is(not(equalTo(secondList))));
+                success = true;
+                break;
+            }catch(AssertionError e) {
+            }
+        }
+        
+        if(!success) {
+            throw new AssertionError("ResolverUtils::randomize returned the same list 100 times, this is more than likely a bug.");
+        }
+    }
+    
+    @Test
+    public void testRandomizeReturnsACopyOfTheMethodParameter() throws Exception {
+        List<AwsEndpoint> firstList = SampleCluster.UsEast1a.builder().withServerPool(1).build();
+        
+        List<AwsEndpoint> secondList = ResolverUtils.randomize(firstList);
+        
+        assertThat(firstList, is(not(sameInstance(secondList))));
+    }
+    
     @Test
     public void testIdentical() throws Exception {
         List<AwsEndpoint> firstList = SampleCluster.UsEast1a.builder().withServerPool(10).build();


### PR DESCRIPTION
The method will now properly randomize a list with a different result on each invocation. Using a constant seed made the same list of `["a","b","c"]` always "randomized" to the same result on each invocation.

Since `SessionedEurekaHttpClient` is supposed to round robin through the different eureka endpoints at a configurable interval, having a randomize method that always returns the same value render this class useless.

Thanks