### PR TITLE
Upgrade xstream-1.4.15 to 1.4.16 for CVE-2021-213{41-51}.

### DIFF
--- a/eureka-client/build.gradle
+++ b/eureka-client/build.gradle
@@ -7,7 +7,7 @@ configurations.all {
 
 dependencies {
     compile "com.netflix.netflix-commons:netflix-eventbus:0.3.0"
-    compile 'com.thoughtworks.xstream:xstream:1.4.15'
+    compile 'com.thoughtworks.xstream:xstream:1.4.16'
     compile "com.netflix.archaius:archaius-core:${archaiusVersion}"
     compile 'javax.ws.rs:jsr311-api:1.1.1'
     compile "com.netflix.servo:servo-core:${servoVersion}"

--- a/eureka-core/build.gradle
+++ b/eureka-core/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compile "com.amazonaws:aws-java-sdk-sts:${awsVersion}"
     compile "com.amazonaws:aws-java-sdk-route53:${awsVersion}"
     compile "javax.servlet:servlet-api:${servletVersion}"
-    compile 'com.thoughtworks.xstream:xstream:1.4.15'
+    compile 'com.thoughtworks.xstream:xstream:1.4.16'
     compile 'javax.ws.rs:jsr311-api:1.1.1'
 
     // These dependencies are marked 'compileOnly' in the client, but we need them always on the server


### PR DESCRIPTION
Upgrade xstream-1.4.15 to 1.4.16 for CVE-2021-213{41-51}.

issue https://github.com/Netflix/eureka/issues/1385