### PR TITLE
allow null values for healthcheck

### DIFF
--- a/eureka-client/src/main/java/com/netflix/appinfo/InstanceInfo.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/InstanceInfo.java
@@ -669,7 +669,7 @@ public class InstanceInfo {
             if (explicitUrl != null) {
                 result.healthCheckUrl = explicitUrl.replace(
                         hostNameInterpolationExpression, result.hostName);
-            } else if (result.isUnsecurePortEnabled) {
+            } else if (result.isUnsecurePortEnabled && relativeUrl != null) {
                 result.healthCheckUrl = HTTP_PROTOCOL + result.hostName + COLON
                         + result.port + relativeUrl;
             }
@@ -677,7 +677,7 @@ public class InstanceInfo {
             if (secureExplicitUrl != null) {
                 result.secureHealthCheckUrl = secureExplicitUrl.replace(
                         hostNameInterpolationExpression, result.hostName);
-            } else if (result.isSecurePortEnabled) {
+            } else if (result.isSecurePortEnabled && relativeUrl != null) {
                 result.secureHealthCheckUrl = HTTPS_PROTOCOL + result.hostName
                         + COLON + result.securePort + relativeUrl;
             }

--- a/eureka-client/src/test/java/com/netflix/appinfo/InstanceInfoTest.java
+++ b/eureka-client/src/test/java/com/netflix/appinfo/InstanceInfoTest.java
@@ -107,6 +107,26 @@ public class InstanceInfoTest {
     }
 
     @Test
+    public void testNullUrlEntries() throws Exception {
+        Builder builder = newBuilder()
+                .setAppName("test")
+                .setNamespace("eureka.")
+                .setHostName("localhost")
+                .setPort(80)
+                .setSecurePort(443)
+                .setHealthCheckUrls(null, null, null)
+                .setStatusPageUrl(null, null)
+                .setHomePageUrl(null, null)
+                .enablePort(PortType.SECURE, true);
+
+        // No URLs for healthcheck , status , homepage
+        InstanceInfo noHealtcheckInstanceInfo = builder.build();
+        assertThat(noHealtcheckInstanceInfo.getHealthCheckUrls().size(), is(equalTo(0)));
+        assertThat(noHealtcheckInstanceInfo.getStatusPageUrl(), nullValue());
+        assertThat(noHealtcheckInstanceInfo.getHomePageUrl(), nullValue());
+    }
+
+    @Test
     public void testGetIdWithInstanceIdUsed() {
         InstanceInfo baseline = InstanceInfoGenerator.takeOne();
         String dataCenterInfoId = ((UniqueIdentifier) baseline.getDataCenterInfo()).getId();


### PR DESCRIPTION
This change is needed to allow override `getHealthCheckUrl()` in InstanceConfig class, so `healthCheckUrl` won't be added to instance info of eureka registry.

i.e. 
```
    @Override
    public String getHealthCheckUrl() {
        return null;
    }
```