### PR TITLE
refactor: JUnit Jupiter migration from JUnit 4.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ allprojects {
 
         // test deps
         jetty_version = '7.2.0.v20101020'
-        junit_version = '4.11'
+        junit_version = '5.7.2'
         mockitoVersion = '1.10.19'
         mockserverVersion = '3.9.2'
     }

--- a/eureka-client-archaius2/src/test/java/com/netflix/appinfo/Ec2EurekaArchaius2InstanceConfigTest.java
+++ b/eureka-client-archaius2/src/test/java/com/netflix/appinfo/Ec2EurekaArchaius2InstanceConfigTest.java
@@ -2,8 +2,8 @@ package com.netflix.appinfo;
 
 import com.netflix.archaius.config.MapConfig;
 import com.netflix.discovery.util.InstanceInfoGenerator;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
@@ -11,7 +11,7 @@ import static com.netflix.appinfo.AmazonInfo.MetaDataKey.ipv6;
 import static com.netflix.appinfo.AmazonInfo.MetaDataKey.localIpv4;
 import static com.netflix.appinfo.AmazonInfo.MetaDataKey.publicHostname;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author David Liu
@@ -21,7 +21,7 @@ public class Ec2EurekaArchaius2InstanceConfigTest {
     private String dummyDefault = "dummyDefault";
     private InstanceInfo instanceInfo;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         instanceInfo = InstanceInfoGenerator.takeOne();
     }

--- a/eureka-client-archaius2/src/test/java/com/netflix/discovery/guice/Ec2EurekaClientModuleTest.java
+++ b/eureka-client-archaius2/src/test/java/com/netflix/discovery/guice/Ec2EurekaClientModuleTest.java
@@ -16,10 +16,10 @@ import com.netflix.discovery.EurekaClient;
 import com.netflix.discovery.EurekaClientConfig;
 import com.netflix.governator.InjectorBuilder;
 import com.netflix.governator.LifecycleInjector;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author David Liu
@@ -28,7 +28,7 @@ public class Ec2EurekaClientModuleTest {
 
     private LifecycleInjector injector;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         injector = InjectorBuilder
                 .fromModules(
@@ -58,7 +58,7 @@ public class Ec2EurekaClientModuleTest {
                 .createInjector();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         if (injector != null) {
             injector.shutdown();
@@ -69,28 +69,28 @@ public class Ec2EurekaClientModuleTest {
     @Test
     public void testDI() {
         InstanceInfo instanceInfo = injector.getInstance(InstanceInfo.class);
-        Assert.assertEquals(ApplicationInfoManager.getInstance().getInfo(), instanceInfo);
+        Assertions.assertEquals(ApplicationInfoManager.getInstance().getInfo(), instanceInfo);
 
         VipAddressResolver vipAddressResolver = injector.getInstance(VipAddressResolver.class);
-        Assert.assertTrue(vipAddressResolver instanceof Archaius2VipAddressResolver);
+        Assertions.assertTrue(vipAddressResolver instanceof Archaius2VipAddressResolver);
 
         EurekaClient eurekaClient = injector.getInstance(EurekaClient.class);
         DiscoveryClient discoveryClient = injector.getInstance(DiscoveryClient.class);
 
-        Assert.assertEquals(DiscoveryManager.getInstance().getEurekaClient(), eurekaClient);
-        Assert.assertEquals(DiscoveryManager.getInstance().getDiscoveryClient(), discoveryClient);
-        Assert.assertEquals(eurekaClient, discoveryClient);
+        Assertions.assertEquals(DiscoveryManager.getInstance().getEurekaClient(), eurekaClient);
+        Assertions.assertEquals(DiscoveryManager.getInstance().getDiscoveryClient(), discoveryClient);
+        Assertions.assertEquals(eurekaClient, discoveryClient);
 
         EurekaClientConfig eurekaClientConfig = injector.getInstance(EurekaClientConfig.class);
-        Assert.assertEquals(DiscoveryManager.getInstance().getEurekaClientConfig(), eurekaClientConfig);
+        Assertions.assertEquals(DiscoveryManager.getInstance().getEurekaClientConfig(), eurekaClientConfig);
 
         EurekaInstanceConfig eurekaInstanceConfig = injector.getInstance(EurekaInstanceConfig.class);
-        Assert.assertEquals(DiscoveryManager.getInstance().getEurekaInstanceConfig(), eurekaInstanceConfig);
-        Assert.assertTrue(eurekaInstanceConfig instanceof Ec2EurekaArchaius2InstanceConfig);
+        Assertions.assertEquals(DiscoveryManager.getInstance().getEurekaInstanceConfig(), eurekaInstanceConfig);
+        Assertions.assertTrue(eurekaInstanceConfig instanceof Ec2EurekaArchaius2InstanceConfig);
 
         ApplicationInfoManager applicationInfoManager = injector.getInstance(ApplicationInfoManager.class);
         InstanceInfo myInfo = applicationInfoManager.getInfo();
-        Assert.assertTrue(myInfo.getDataCenterInfo() instanceof AmazonInfo);
-        Assert.assertEquals(DataCenterInfo.Name.Amazon, myInfo.getDataCenterInfo().getName());
+        Assertions.assertTrue(myInfo.getDataCenterInfo() instanceof AmazonInfo);
+        Assertions.assertEquals(DataCenterInfo.Name.Amazon, myInfo.getDataCenterInfo().getName());
     }
 }

--- a/eureka-client-archaius2/src/test/java/com/netflix/discovery/guice/EurekaClientModuleConfigurationTest.java
+++ b/eureka-client-archaius2/src/test/java/com/netflix/discovery/guice/EurekaClientModuleConfigurationTest.java
@@ -7,8 +7,8 @@ import com.netflix.appinfo.providers.EurekaInstanceConfigFactory;
 import com.netflix.archaius.guice.ArchaiusModule;
 import com.netflix.governator.InjectorBuilder;
 import com.netflix.governator.LifecycleInjector;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 /**
@@ -46,6 +46,6 @@ public class EurekaClientModuleConfigurationTest {
                 .createInjector();
 
         EurekaInstanceConfig config = injector.getInstance(EurekaInstanceConfig.class);
-        Assert.assertEquals(mockConfig, config);
+        Assertions.assertEquals(mockConfig, config);
     }
 }

--- a/eureka-client-archaius2/src/test/java/com/netflix/discovery/guice/NonEc2EurekaClientModuleTest.java
+++ b/eureka-client-archaius2/src/test/java/com/netflix/discovery/guice/NonEc2EurekaClientModuleTest.java
@@ -15,10 +15,10 @@ import com.netflix.discovery.EurekaClient;
 import com.netflix.discovery.EurekaClientConfig;
 import com.netflix.governator.InjectorBuilder;
 import com.netflix.governator.LifecycleInjector;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author David Liu
@@ -27,7 +27,7 @@ public class NonEc2EurekaClientModuleTest {
 
     private LifecycleInjector injector;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         injector = InjectorBuilder
                 .fromModules(
@@ -51,7 +51,7 @@ public class NonEc2EurekaClientModuleTest {
                 .createInjector();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         if (injector != null) {
             injector.shutdown();
@@ -62,27 +62,27 @@ public class NonEc2EurekaClientModuleTest {
     @Test
     public void testDI() {
         InstanceInfo instanceInfo = injector.getInstance(InstanceInfo.class);
-        Assert.assertEquals(ApplicationInfoManager.getInstance().getInfo(), instanceInfo);
+        Assertions.assertEquals(ApplicationInfoManager.getInstance().getInfo(), instanceInfo);
 
         VipAddressResolver vipAddressResolver = injector.getInstance(VipAddressResolver.class);
-        Assert.assertTrue(vipAddressResolver instanceof Archaius2VipAddressResolver);
+        Assertions.assertTrue(vipAddressResolver instanceof Archaius2VipAddressResolver);
 
         EurekaClient eurekaClient = injector.getInstance(EurekaClient.class);
         DiscoveryClient discoveryClient = injector.getInstance(DiscoveryClient.class);
 
-        Assert.assertEquals(DiscoveryManager.getInstance().getEurekaClient(), eurekaClient);
-        Assert.assertEquals(DiscoveryManager.getInstance().getDiscoveryClient(), discoveryClient);
-        Assert.assertEquals(eurekaClient, discoveryClient);
+        Assertions.assertEquals(DiscoveryManager.getInstance().getEurekaClient(), eurekaClient);
+        Assertions.assertEquals(DiscoveryManager.getInstance().getDiscoveryClient(), discoveryClient);
+        Assertions.assertEquals(eurekaClient, discoveryClient);
 
         EurekaClientConfig eurekaClientConfig = injector.getInstance(EurekaClientConfig.class);
-        Assert.assertEquals(DiscoveryManager.getInstance().getEurekaClientConfig(), eurekaClientConfig);
+        Assertions.assertEquals(DiscoveryManager.getInstance().getEurekaClientConfig(), eurekaClientConfig);
 
         EurekaInstanceConfig eurekaInstanceConfig = injector.getInstance(EurekaInstanceConfig.class);
-        Assert.assertEquals(DiscoveryManager.getInstance().getEurekaInstanceConfig(), eurekaInstanceConfig);
-        Assert.assertTrue(eurekaInstanceConfig instanceof EurekaArchaius2InstanceConfig);
+        Assertions.assertEquals(DiscoveryManager.getInstance().getEurekaInstanceConfig(), eurekaInstanceConfig);
+        Assertions.assertTrue(eurekaInstanceConfig instanceof EurekaArchaius2InstanceConfig);
 
         ApplicationInfoManager applicationInfoManager = injector.getInstance(ApplicationInfoManager.class);
         InstanceInfo myInfo = applicationInfoManager.getInfo();
-        Assert.assertEquals(DataCenterInfo.Name.MyOwn, myInfo.getDataCenterInfo().getName());
+        Assertions.assertEquals(DataCenterInfo.Name.MyOwn, myInfo.getDataCenterInfo().getName());
     }
 }

--- a/eureka-client-archaius2/src/test/java/com/netflix/discovery/internal/util/InternalPrefixedConfigTest.java
+++ b/eureka-client-archaius2/src/test/java/com/netflix/discovery/internal/util/InternalPrefixedConfigTest.java
@@ -1,8 +1,8 @@
 package com.netflix.discovery.internal.util;
 
 import com.netflix.archaius.api.Config;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 /**
@@ -15,12 +15,12 @@ public class InternalPrefixedConfigTest {
         Config configInstance = Mockito.mock(Config.class);
 
         InternalPrefixedConfig config = new InternalPrefixedConfig(configInstance);
-        Assert.assertEquals("", config.getNamespace());
+        Assertions.assertEquals("", config.getNamespace());
 
         config = new InternalPrefixedConfig(configInstance, "foo");
-        Assert.assertEquals("foo.", config.getNamespace());
+        Assertions.assertEquals("foo.", config.getNamespace());
 
         config = new InternalPrefixedConfig(configInstance, "foo", "bar");
-        Assert.assertEquals("foo.bar.", config.getNamespace());
+        Assertions.assertEquals("foo.bar.", config.getNamespace());
     }
 }

--- a/eureka-client-jersey2/build.gradle
+++ b/eureka-client-jersey2/build.gradle
@@ -34,8 +34,9 @@ dependencies {
     }
     // bring in jersey2 compatible eureka-core-jersey2 directly
     testCompile project(':eureka-core-jersey2')
-
-    testCompile "junit:junit:${junit_version}"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_version}"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:${junit_version}"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_version}"
     testCompile "org.mockito:mockito-core:${mockitoVersion}"
     testCompile "com.netflix.governator:governator:${governatorVersion}"
 }

--- a/eureka-client-jersey2/src/test/java/com/netflix/discovery/guice/Jersey2EurekaModuleTest.java
+++ b/eureka-client-jersey2/src/test/java/com/netflix/discovery/guice/Jersey2EurekaModuleTest.java
@@ -17,10 +17,10 @@ import com.netflix.discovery.shared.transport.jersey.TransportClientFactories;
 import com.netflix.discovery.shared.transport.jersey2.Jersey2TransportClientFactories;
 import com.netflix.governator.InjectorBuilder;
 import com.netflix.governator.LifecycleInjector;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author David Liu
@@ -29,7 +29,7 @@ public class Jersey2EurekaModuleTest {
 
     private LifecycleInjector injector;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         ConfigurationManager.getConfigInstance().setProperty("eureka.region", "default");
         ConfigurationManager.getConfigInstance().setProperty("eureka.shouldFetchRegistry", "false");
@@ -49,7 +49,7 @@ public class Jersey2EurekaModuleTest {
                 .createInjector();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         if (injector != null) {
             injector.shutdown();
@@ -61,25 +61,25 @@ public class Jersey2EurekaModuleTest {
     @Test
     public void testDI() {
         InstanceInfo instanceInfo = injector.getInstance(InstanceInfo.class);
-        Assert.assertEquals(ApplicationInfoManager.getInstance().getInfo(), instanceInfo);
+        Assertions.assertEquals(ApplicationInfoManager.getInstance().getInfo(), instanceInfo);
 
         EurekaClient eurekaClient = injector.getInstance(EurekaClient.class);
         DiscoveryClient discoveryClient = injector.getInstance(DiscoveryClient.class);
 
-        Assert.assertEquals(DiscoveryManager.getInstance().getEurekaClient(), eurekaClient);
-        Assert.assertEquals(DiscoveryManager.getInstance().getDiscoveryClient(), discoveryClient);
-        Assert.assertEquals(eurekaClient, discoveryClient);
+        Assertions.assertEquals(DiscoveryManager.getInstance().getEurekaClient(), eurekaClient);
+        Assertions.assertEquals(DiscoveryManager.getInstance().getDiscoveryClient(), discoveryClient);
+        Assertions.assertEquals(eurekaClient, discoveryClient);
 
         EurekaClientConfig eurekaClientConfig = injector.getInstance(EurekaClientConfig.class);
-        Assert.assertEquals(DiscoveryManager.getInstance().getEurekaClientConfig(), eurekaClientConfig);
+        Assertions.assertEquals(DiscoveryManager.getInstance().getEurekaClientConfig(), eurekaClientConfig);
 
         EurekaInstanceConfig eurekaInstanceConfig = injector.getInstance(EurekaInstanceConfig.class);
-        Assert.assertEquals(DiscoveryManager.getInstance().getEurekaInstanceConfig(), eurekaInstanceConfig);
+        Assertions.assertEquals(DiscoveryManager.getInstance().getEurekaInstanceConfig(), eurekaInstanceConfig);
 
         Binding<TransportClientFactories> binding = injector.getExistingBinding(Key.get(TransportClientFactories.class));
-        Assert.assertNotNull(binding);  // has a binding for jersey2
+        Assertions.assertNotNull(binding);  // has a binding for jersey2
 
         TransportClientFactories transportClientFactories = injector.getInstance(TransportClientFactories.class);
-        Assert.assertTrue(transportClientFactories instanceof Jersey2TransportClientFactories);
+        Assertions.assertTrue(transportClientFactories instanceof Jersey2TransportClientFactories);
     }
 }

--- a/eureka-client-jersey2/src/test/java/com/netflix/discovery/shared/transport/jersey2/AbstractJersey2EurekaHttpClientTest.java
+++ b/eureka-client-jersey2/src/test/java/com/netflix/discovery/shared/transport/jersey2/AbstractJersey2EurekaHttpClientTest.java
@@ -24,7 +24,7 @@ import com.netflix.discovery.shared.transport.EurekaHttpClientCompatibilityTestS
 import com.netflix.discovery.shared.transport.TransportClientFactory;
 import com.netflix.discovery.shared.transport.jersey2.Jersey2ApplicationClientFactory.Jersey2ApplicationClientFactoryBuilder;
 import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 
 /**
  * @author Tomasz Bak
@@ -34,7 +34,7 @@ public class AbstractJersey2EurekaHttpClientTest extends EurekaHttpClientCompati
     private AbstractJersey2EurekaHttpClient jersey2HttpClient;
 
     @Override
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         if (jersey2HttpClient != null) {
             jersey2HttpClient.shutdown();

--- a/eureka-client/build.gradle
+++ b/eureka-client/build.gradle
@@ -33,7 +33,9 @@ dependencies {
     runtimeOnly "org.codehaus.jettison:jettison:${jettisonVersion}"
 
     testCompile project(':eureka-test-utils')
-    testCompile "junit:junit:${junit_version}"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_version}"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:${junit_version}"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_version}"
     testCompile 'org.mortbay.jetty:jetty:6.1H.22'
     testCompile "org.mockito:mockito-core:${mockitoVersion}"
     testCompile "org.mock-server:mockserver-netty:${mockserverVersion}"

--- a/eureka-client/src/test/java/com/netflix/appinfo/AmazonInfoTest.java
+++ b/eureka-client/src/test/java/com/netflix/appinfo/AmazonInfoTest.java
@@ -1,11 +1,11 @@
 package com.netflix.appinfo;
 
+import org.junit.jupiter.api.Test;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
-import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author David Liu

--- a/eureka-client/src/test/java/com/netflix/appinfo/ApplicationInfoManagerTest.java
+++ b/eureka-client/src/test/java/com/netflix/appinfo/ApplicationInfoManagerTest.java
@@ -2,17 +2,17 @@ package com.netflix.appinfo;
 
 import com.netflix.discovery.CommonConstants;
 import com.netflix.discovery.util.InstanceInfoGenerator;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static com.netflix.appinfo.AmazonInfo.MetaDataKey.localIpv4;
 import static com.netflix.appinfo.AmazonInfo.MetaDataKey.publicHostname;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.anyBoolean;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -26,7 +26,7 @@ public class ApplicationInfoManagerTest {
     private InstanceInfo instanceInfo;
     private ApplicationInfoManager applicationInfoManager;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         AmazonInfo initialAmazonInfo = AmazonInfo.Builder.newBuilder().build();
 

--- a/eureka-client/src/test/java/com/netflix/appinfo/CloudInstanceConfigTest.java
+++ b/eureka-client/src/test/java/com/netflix/appinfo/CloudInstanceConfigTest.java
@@ -1,15 +1,15 @@
 package com.netflix.appinfo;
 
 import com.netflix.discovery.util.InstanceInfoGenerator;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static com.netflix.appinfo.AmazonInfo.MetaDataKey.ipv6;
 import static com.netflix.appinfo.AmazonInfo.MetaDataKey.localIpv4;
 import static com.netflix.appinfo.AmazonInfo.MetaDataKey.publicHostname;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 /**
@@ -21,7 +21,7 @@ public class CloudInstanceConfigTest {
     private String dummyDefault = "dummyDefault";
     private InstanceInfo instanceInfo;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         instanceInfo = InstanceInfoGenerator.takeOne();
     }

--- a/eureka-client/src/test/java/com/netflix/appinfo/InstanceInfoTest.java
+++ b/eureka-client/src/test/java/com/netflix/appinfo/InstanceInfoTest.java
@@ -5,23 +5,23 @@ import com.netflix.appinfo.InstanceInfo.PortType;
 import com.netflix.config.ConcurrentCompositeConfiguration;
 import com.netflix.config.ConfigurationManager;
 import com.netflix.discovery.util.InstanceInfoGenerator;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static com.netflix.appinfo.InstanceInfo.Builder.newBuilder;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * Created by jzarfoss on 2/12/14.
  */
 public class InstanceInfoTest {
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         ((ConcurrentCompositeConfiguration) ConfigurationManager.getConfigInstance()).clearOverrideProperty("NETFLIX_APP_GROUP");
         ((ConcurrentCompositeConfiguration) ConfigurationManager.getConfigInstance()).clearOverrideProperty("eureka.appGroup");
@@ -45,7 +45,7 @@ public class InstanceInfoTest {
         InstanceInfo smallII2 = new InstanceInfo(smallII1);
 
         assertNotSame(smallII1, smallII2);
-        Assert.assertEquals(smallII1, smallII2);
+        Assertions.assertEquals(smallII1, smallII2);
 
 
         InstanceInfo fullII1 = newBuilder().setMetadata(null)
@@ -64,7 +64,7 @@ public class InstanceInfoTest {
         InstanceInfo fullII2 = new InstanceInfo(fullII1);
 
         assertNotSame(fullII1, fullII2);
-        Assert.assertEquals(fullII1, fullII2);
+        Assertions.assertEquals(fullII1, fullII2);
     }
 
     @Test
@@ -73,7 +73,7 @@ public class InstanceInfoTest {
         ((ConcurrentCompositeConfiguration) ConfigurationManager.getConfigInstance()).setOverrideProperty("NETFLIX_APP_GROUP",
                 appGroup);
         MyDataCenterInstanceConfig config = new MyDataCenterInstanceConfig();
-        Assert.assertEquals("Unexpected app group name", appGroup, config.getAppGroupName());
+        Assertions.assertEquals(appGroup, config.getAppGroupName(), "Unexpected app group name");
     }
 
     @Test
@@ -82,7 +82,7 @@ public class InstanceInfoTest {
         ((ConcurrentCompositeConfiguration) ConfigurationManager.getConfigInstance()).setOverrideProperty("eureka.appGroup",
                 appGroup);
         MyDataCenterInstanceConfig config = new MyDataCenterInstanceConfig();
-        Assert.assertEquals("Unexpected app group name", appGroup, config.getAppGroupName());
+        Assertions.assertEquals(appGroup, config.getAppGroupName(), "Unexpected app group name");
     }
 
     @Test

--- a/eureka-client/src/test/java/com/netflix/appinfo/RefreshableAmazonInfoProviderTest.java
+++ b/eureka-client/src/test/java/com/netflix/appinfo/RefreshableAmazonInfoProviderTest.java
@@ -1,15 +1,15 @@
 package com.netflix.appinfo;
 
 import com.netflix.discovery.util.InstanceInfoGenerator;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static com.netflix.appinfo.AmazonInfo.MetaDataKey.amiId;
 import static com.netflix.appinfo.AmazonInfo.MetaDataKey.instanceId;
 import static com.netflix.appinfo.AmazonInfo.MetaDataKey.localIpv4;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author David Liu
@@ -18,7 +18,7 @@ public class RefreshableAmazonInfoProviderTest {
 
     private InstanceInfo instanceInfo;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         instanceInfo = InstanceInfoGenerator.takeOne();
     }

--- a/eureka-client/src/test/java/com/netflix/discovery/AbstractDiscoveryClientTester.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/AbstractDiscoveryClientTester.java
@@ -1,15 +1,15 @@
 package com.netflix.discovery;
 
 import com.netflix.discovery.junit.resource.DiscoveryClientResource;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * @author Nitesh Kant
  */
 public abstract class AbstractDiscoveryClientTester extends BaseDiscoveryClientTester {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
 
         setupProperties();
@@ -20,7 +20,7 @@ public abstract class AbstractDiscoveryClientTester extends BaseDiscoveryClientT
         setupDiscoveryClient();
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         shutdownDiscoveryClient();
         DiscoveryClientResource.clearDiscoveryClientConfig();

--- a/eureka-client/src/test/java/com/netflix/discovery/BackUpRegistryTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/BackUpRegistryTest.java
@@ -14,9 +14,9 @@ import com.netflix.config.ConfigurationManager;
 import com.netflix.discovery.shared.Application;
 import com.netflix.discovery.shared.Applications;
 import com.netflix.discovery.shared.resolver.ResolverUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Nitesh Kant
@@ -78,7 +78,7 @@ public class BackUpRegistryTest {
         );
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         client.shutdown();
         ConfigurationManager.getConfigInstance().clear();
@@ -90,9 +90,9 @@ public class BackUpRegistryTest {
         Applications applications = client.getApplications();
         List<Application> registeredApplications = applications.getRegisteredApplications();
         System.out.println("***" + registeredApplications);
-        Assert.assertNotNull("Local region apps not found.", registeredApplications);
-        Assert.assertEquals("Local apps size not as expected.", 1, registeredApplications.size());
-        Assert.assertEquals("Local region apps not present.", LOCAL_REGION_APP_NAME, registeredApplications.get(0).getName());
+        Assertions.assertNotNull(registeredApplications, "Local region apps not found.");
+        Assertions.assertEquals(1, registeredApplications.size(), "Local apps size not as expected.");
+        Assertions.assertEquals(LOCAL_REGION_APP_NAME, registeredApplications.get(0).getName(), "Local region apps not present.");
     }
 
     @Test
@@ -100,8 +100,8 @@ public class BackUpRegistryTest {
         setUp(true);
         Applications applications = client.getApplications();
         List<Application> registeredApplications = applications.getRegisteredApplications();
-        Assert.assertNotNull("Local region apps not found.", registeredApplications);
-        Assert.assertEquals("Local apps size not as expected.", 2, registeredApplications.size()); // Remote region comes with no instances.
+        Assertions.assertNotNull(registeredApplications, "Local region apps not found.");
+        Assertions.assertEquals(2, registeredApplications.size(), "Local apps size not as expected."); // Remote region comes with no instances.
         Application localRegionApp = null;
         Application remoteRegionApp = null;
         for (Application registeredApplication : registeredApplications) {
@@ -111,8 +111,8 @@ public class BackUpRegistryTest {
                 remoteRegionApp = registeredApplication;
             }
         }
-        Assert.assertNotNull("Local region apps not present.", localRegionApp);
-        Assert.assertTrue("Remote region instances returned for local query.", null == remoteRegionApp || remoteRegionApp.getInstances().isEmpty());
+        Assertions.assertNotNull(localRegionApp, "Local region apps not present.");
+        Assertions.assertTrue(null == remoteRegionApp || remoteRegionApp.getInstances().isEmpty(), "Remote region instances returned for local query.");
     }
 
     @Test
@@ -120,9 +120,9 @@ public class BackUpRegistryTest {
         setUp(true);
         Applications applications = client.getApplicationsForARegion(REMOTE_REGION);
         List<Application> registeredApplications = applications.getRegisteredApplications();
-        Assert.assertNotNull("Remote region apps not found.", registeredApplications);
-        Assert.assertEquals("Remote apps size not as expected.", 1, registeredApplications.size());
-        Assert.assertEquals("Remote region apps not present.", REMOTE_REGION_APP_NAME, registeredApplications.get(0).getName());
+        Assertions.assertNotNull(registeredApplications, "Remote region apps not found.");
+        Assertions.assertEquals(1, registeredApplications.size(), "Remote apps size not as expected.");
+        Assertions.assertEquals(REMOTE_REGION_APP_NAME, registeredApplications.get(0).getName(), "Remote region apps not present.");
     }
 
     @Test
@@ -130,7 +130,7 @@ public class BackUpRegistryTest {
         setUp(true);
         Applications applications = client.getApplications();
 
-        Assert.assertEquals("UP_1_", applications.getAppsHashCode());
+        Assertions.assertEquals("UP_1_", applications.getAppsHashCode());
     }
 
     private void setupBackupMock() {

--- a/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientCloseJerseyThreadTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientCloseJerseyThreadTest.java
@@ -1,10 +1,11 @@
 package com.netflix.discovery;
 
+import org.junit.jupiter.api.Test;
+
 import java.util.Set;
-import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class DiscoveryClientCloseJerseyThreadTest extends AbstractDiscoveryClientTester {
 

--- a/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientDisableRegistryTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientDisableRegistryTest.java
@@ -7,9 +7,9 @@ import com.netflix.appinfo.DataCenterInfo;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.appinfo.MyDataCenterInstanceConfig;
 import com.netflix.config.ConfigurationManager;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Nitesh Kant
@@ -19,7 +19,7 @@ public class DiscoveryClientDisableRegistryTest {
     private EurekaClient client;
     private MockRemoteEurekaServer mockLocalEurekaServer;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         mockLocalEurekaServer = new MockRemoteEurekaServer();
         mockLocalEurekaServer.start();
@@ -47,7 +47,7 @@ public class DiscoveryClientDisableRegistryTest {
 
     @Test
     public void testDisableFetchRegistry() throws Exception {
-        Assert.assertFalse("Registry fetch disabled but eureka server recieved a registry fetch.",
-                mockLocalEurekaServer.isSentRegistry());
+        Assertions.assertFalse(mockLocalEurekaServer.isSentRegistry(),
+                "Registry fetch disabled but eureka server recieved a registry fetch.");
     }
 }

--- a/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientEventBusTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientEventBusTest.java
@@ -16,20 +16,20 @@ import com.netflix.discovery.shared.transport.SimpleEurekaHttpServer;
 import com.netflix.discovery.util.InstanceInfoGenerator;
 import com.netflix.eventbus.spi.EventBus;
 import com.netflix.eventbus.spi.Subscribe;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static com.netflix.discovery.shared.transport.EurekaHttpResponse.anEurekaHttpResponse;
 import static com.netflix.discovery.util.EurekaEntityFunctions.toApplications;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
@@ -52,19 +52,19 @@ public class DiscoveryClientEventBusTest {
     /**
      * Share server stub by all tests.
      */
-    @BeforeClass
+    @BeforeAll
     public static void setUpClass() throws IOException {
         eurekaHttpServer = new SimpleEurekaHttpServer(requestHandler);
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownClass() throws Exception {
         if (eurekaHttpServer != null) {
             eurekaHttpServer.shutdown();
         }
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         reset(requestHandler);
         when(requestHandler.register(any(InstanceInfo.class))).thenReturn(EurekaHttpResponse.status(204));

--- a/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientHealthTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientHealthTest.java
@@ -4,8 +4,8 @@ import com.netflix.appinfo.HealthCheckCallback;
 import com.netflix.appinfo.HealthCheckHandler;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.config.ConfigurationManager;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -41,85 +41,96 @@ public class DiscoveryClientHealthTest extends AbstractDiscoveryClientTester {
     public void testCallback() throws Exception {
         MyHealthCheckCallback myCallback = new MyHealthCheckCallback(true);
 
-        Assert.assertTrue(client instanceof DiscoveryClient);
+        Assertions.assertTrue(client instanceof DiscoveryClient);
         DiscoveryClient clientImpl = (DiscoveryClient) client;
 
         InstanceInfoReplicator instanceInfoReplicator = clientImpl.getInstanceInfoReplicator();
         instanceInfoReplicator.run();
 
-        Assert.assertEquals("Instance info status not as expected.", InstanceInfo.InstanceStatus.STARTING,
-                clientImpl.getInstanceInfo().getStatus());
-        Assert.assertFalse("Healthcheck callback invoked when status is STARTING.", myCallback.isInvoked());
+        Assertions.assertEquals(InstanceInfo.InstanceStatus.STARTING,
+                clientImpl.getInstanceInfo().getStatus(),
+                "Instance info status not as expected.");
+        Assertions.assertFalse(myCallback.isInvoked(), "Healthcheck callback invoked when status is STARTING.");
 
         client.registerHealthCheckCallback(myCallback);
 
         clientImpl.getInstanceInfo().setStatus(InstanceInfo.InstanceStatus.OUT_OF_SERVICE);
-        Assert.assertEquals("Instance info status not as expected.", InstanceInfo.InstanceStatus.OUT_OF_SERVICE,
-                clientImpl.getInstanceInfo().getStatus());
+        Assertions.assertEquals(InstanceInfo.InstanceStatus.OUT_OF_SERVICE,
+                clientImpl.getInstanceInfo().getStatus(),
+                "Instance info status not as expected.");
 
         myCallback.reset();
         instanceInfoReplicator.run();
-        Assert.assertFalse("Healthcheck callback invoked when status is OOS.", myCallback.isInvoked());
+        Assertions.assertFalse(myCallback.isInvoked(), "Healthcheck callback invoked when status is OOS.");
 
         clientImpl.getInstanceInfo().setStatus(InstanceInfo.InstanceStatus.DOWN);
-        Assert.assertEquals("Instance info status not as expected.", InstanceInfo.InstanceStatus.DOWN,
-                clientImpl.getInstanceInfo().getStatus());
+        Assertions.assertEquals(InstanceInfo.InstanceStatus.DOWN,
+                clientImpl.getInstanceInfo().getStatus(),
+                "Instance info status not as expected.");
         myCallback.reset();
         instanceInfoReplicator.run();
 
-        Assert.assertTrue("Healthcheck callback not invoked.", myCallback.isInvoked());
-        Assert.assertEquals("Instance info status not as expected.", InstanceInfo.InstanceStatus.UP,
-                clientImpl.getInstanceInfo().getStatus());
+        Assertions.assertTrue(myCallback.isInvoked(), "Healthcheck callback not invoked.");
+        Assertions.assertEquals(InstanceInfo.InstanceStatus.UP,
+                clientImpl.getInstanceInfo().getStatus(),
+                "Instance info status not as expected.");
     }
 
     @Test
     public void testHandler() throws Exception {
         MyHealthCheckHandler myHealthCheckHandler = new MyHealthCheckHandler(InstanceInfo.InstanceStatus.UP);
 
-        Assert.assertTrue(client instanceof DiscoveryClient);
+        Assertions.assertTrue(client instanceof DiscoveryClient);
         DiscoveryClient clientImpl = (DiscoveryClient) client;
 
         InstanceInfoReplicator instanceInfoReplicator = clientImpl.getInstanceInfoReplicator();
 
-        Assert.assertEquals("Instance info status not as expected.", InstanceInfo.InstanceStatus.STARTING,
-                clientImpl.getInstanceInfo().getStatus());
+        Assertions.assertEquals(InstanceInfo.InstanceStatus.STARTING,
+                clientImpl.getInstanceInfo().getStatus(),
+                "Instance info status not as expected.");
 
         client.registerHealthCheck(myHealthCheckHandler);
 
         instanceInfoReplicator.run();
 
-        Assert.assertTrue("Healthcheck callback not invoked when status is STARTING.", myHealthCheckHandler.isInvoked());
-        Assert.assertEquals("Instance info status not as expected post healthcheck.", InstanceInfo.InstanceStatus.UP,
-                clientImpl.getInstanceInfo().getStatus());
+        Assertions.assertTrue(myHealthCheckHandler.isInvoked(), "Healthcheck callback not invoked when status is STARTING.");
+        Assertions.assertEquals(InstanceInfo.InstanceStatus.UP,
+                clientImpl.getInstanceInfo().getStatus(),
+                "Instance info status not as expected post healthcheck.");
 
         clientImpl.getInstanceInfo().setStatus(InstanceInfo.InstanceStatus.OUT_OF_SERVICE);
-        Assert.assertEquals("Instance info status not as expected.", InstanceInfo.InstanceStatus.OUT_OF_SERVICE,
-                clientImpl.getInstanceInfo().getStatus());
+        Assertions.assertEquals(InstanceInfo.InstanceStatus.OUT_OF_SERVICE,
+                clientImpl.getInstanceInfo().getStatus(),
+                "Instance info status not as expected.");
         myHealthCheckHandler.reset();
         instanceInfoReplicator.run();
 
-        Assert.assertTrue("Healthcheck callback not invoked when status is OUT_OF_SERVICE.", myHealthCheckHandler.isInvoked());
-        Assert.assertEquals("Instance info status not as expected post healthcheck.", InstanceInfo.InstanceStatus.UP,
-                clientImpl.getInstanceInfo().getStatus());
+        Assertions.assertTrue(myHealthCheckHandler.isInvoked(), "Healthcheck callback not invoked when status is OUT_OF_SERVICE.");
+        Assertions.assertEquals(InstanceInfo.InstanceStatus.UP,
+                clientImpl.getInstanceInfo().getStatus(),
+                "Instance info status not as expected post healthcheck.");
 
         clientImpl.getInstanceInfo().setStatus(InstanceInfo.InstanceStatus.DOWN);
-        Assert.assertEquals("Instance info status not as expected.", InstanceInfo.InstanceStatus.DOWN,
-                clientImpl.getInstanceInfo().getStatus());
+        Assertions.assertEquals(InstanceInfo.InstanceStatus.DOWN,
+                clientImpl.getInstanceInfo().getStatus(),
+                "Instance info status not as expected.");
         myHealthCheckHandler.reset();
         instanceInfoReplicator.run();
 
-        Assert.assertTrue("Healthcheck callback not invoked when status is DOWN.", myHealthCheckHandler.isInvoked());
-        Assert.assertEquals("Instance info status not as expected post healthcheck.", InstanceInfo.InstanceStatus.UP,
-                clientImpl.getInstanceInfo().getStatus());
+        Assertions.assertTrue(myHealthCheckHandler.isInvoked(), "Healthcheck callback not invoked when status is DOWN.");
+        Assertions.assertEquals(InstanceInfo.InstanceStatus.UP,
+                clientImpl.getInstanceInfo().getStatus(),
+                "Instance info status not as expected post healthcheck.");
 
         clientImpl.getInstanceInfo().setStatus(InstanceInfo.InstanceStatus.UP);
         myHealthCheckHandler.reset();
         myHealthCheckHandler.shouldException = true;
         instanceInfoReplicator.run();
 
-        Assert.assertTrue("Healthcheck callback not invoked when status is UP.", myHealthCheckHandler.isInvoked());
-        Assert.assertEquals("Instance info status not as expected post healthcheck.", InstanceInfo.InstanceStatus.DOWN,
-                clientImpl.getInstanceInfo().getStatus());
+        Assertions.assertTrue(myHealthCheckHandler.isInvoked(), "Healthcheck callback not invoked when status is UP.");
+        Assertions.assertEquals(InstanceInfo.InstanceStatus.DOWN,
+                clientImpl.getInstanceInfo().getStatus(),
+                "Instance info status not as expected post healthcheck.");
     }
 
     @Test
@@ -147,7 +158,7 @@ public class DiscoveryClientHealthTest extends AbstractDiscoveryClientTester {
        try {
             finishLatch.await();
             discoveryClients.forEach(client ->
-                    Assert.assertSame("Healthcheck handler should be custom.", myHealthCheckHandler, client.getHealthCheckHandler()));
+                    Assertions.assertSame(myHealthCheckHandler, client.getHealthCheckHandler(), "Healthcheck handler should be custom."));
         } finally {
             //cleanup resources
             discoveryClients.forEach(DiscoveryClient::shutdown);

--- a/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientRedirectTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientRedirectTest.java
@@ -15,11 +15,11 @@ import com.netflix.discovery.shared.Application;
 import com.netflix.discovery.shared.Applications;
 import com.netflix.discovery.util.EurekaEntityFunctions;
 import com.netflix.discovery.util.InstanceInfoGenerator;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.mockserver.client.server.MockServerClient;
 import org.mockserver.junit.MockServerRule;
 import org.mockserver.matchers.Times;
@@ -78,12 +78,12 @@ public class DiscoveryClientRedirectTest {
 
     private final InstanceInfoGenerator dataGenerator = InstanceInfoGenerator.newBuilder(2, 1).withMetaData(true).build();
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         targetServerBaseUri = "http://localhost:" + targetServerMockRule.getHttpPort();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         if (redirectServerMockClient != null) {
             redirectServerMockClient.reset();
@@ -148,7 +148,7 @@ public class DiscoveryClientRedirectTest {
     }
 
     // There is an issue with using mock-server for this test case.  For now it is verified manually that it works.
-    @Ignore
+    @Disabled
     @Test
     public void testClientRegistrationFollowsRedirectsAndPinsToTargetServer() throws Exception {
     }

--- a/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientRegisterUpdateTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientRegisterUpdateTest.java
@@ -6,10 +6,10 @@ import com.netflix.appinfo.LeaseInfo;
 import com.netflix.appinfo.MyDataCenterInstanceConfig;
 import com.netflix.config.ConfigurationManager;
 import com.netflix.discovery.util.InstanceInfoGenerator;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.List;
@@ -26,7 +26,7 @@ public class DiscoveryClientRegisterUpdateTest {
     private MockRemoteEurekaServer mockLocalEurekaServer;
     private TestClient client;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         mockLocalEurekaServer = new MockRemoteEurekaServer();
         mockLocalEurekaServer.start();
@@ -66,7 +66,7 @@ public class DiscoveryClientRegisterUpdateTest {
         mockLocalEurekaServer.registerCount.set(0l);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         client.shutdown();
         mockLocalEurekaServer.stop();
@@ -85,7 +85,7 @@ public class DiscoveryClientRegisterUpdateTest {
         // give some execution time
         expectStatus(InstanceInfo.InstanceStatus.DOWN, 5, TimeUnit.SECONDS);
 
-        Assert.assertTrue(mockLocalEurekaServer.registerCount.get() >= 3);  // at least 3
+        Assertions.assertTrue(mockLocalEurekaServer.registerCount.get() >= 3);  // at least 3
     }
 
     /**
@@ -101,14 +101,14 @@ public class DiscoveryClientRegisterUpdateTest {
         applicationInfoManager.setInstanceStatus(InstanceInfo.InstanceStatus.UP);
         expectStatus(InstanceInfo.InstanceStatus.UP, 5, TimeUnit.SECONDS);
 
-        Assert.assertTrue(mockLocalEurekaServer.registerCount.get() >= 2);  // at least 2
+        Assertions.assertTrue(mockLocalEurekaServer.registerCount.get() >= 2);  // at least 2
     }
 
     @Test
     public void registerUpdateShutdownTest() throws Exception {
-        Assert.assertEquals(1, applicationInfoManager.getStatusChangeListeners().size());
+        Assertions.assertEquals(1, applicationInfoManager.getStatusChangeListeners().size());
         client.shutdown();
-        Assert.assertEquals(0, applicationInfoManager.getStatusChangeListeners().size());
+        Assertions.assertEquals(0, applicationInfoManager.getStatusChangeListeners().size());
         Mockito.verify(client, Mockito.times(1)).unregister();
     }
 
@@ -118,12 +118,12 @@ public class DiscoveryClientRegisterUpdateTest {
 
         ConfigurationManager.getConfigInstance().setProperty("eureka.registration.enabled", "false");
         client = new TestClient(applicationInfoManager, new DefaultEurekaClientConfig());
-        Assert.assertEquals(0, applicationInfoManager.getStatusChangeListeners().size());
+        Assertions.assertEquals(0, applicationInfoManager.getStatusChangeListeners().size());
         applicationInfoManager.setInstanceStatus(InstanceInfo.InstanceStatus.DOWN);
         applicationInfoManager.setInstanceStatus(InstanceInfo.InstanceStatus.UP);
         Thread.sleep(400);
         client.shutdown();
-        Assert.assertEquals(0, applicationInfoManager.getStatusChangeListeners().size());
+        Assertions.assertEquals(0, applicationInfoManager.getStatusChangeListeners().size());
     }
 
     @Test
@@ -148,7 +148,7 @@ public class DiscoveryClientRegisterUpdateTest {
 
     private void expectStatus(InstanceInfo.InstanceStatus expected, long timeout, TimeUnit timeUnit) throws InterruptedException {
             String status = mockLocalEurekaServer.registrationStatusesQueue.poll(timeout, timeUnit);
-            Assert.assertEquals(expected.name(), status);
+            Assertions.assertEquals(expected.name(), status);
     }
 
     private static <T> T getLast(List<T> list) {

--- a/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientRegistryTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientRegistryTest.java
@@ -16,11 +16,11 @@ import com.netflix.discovery.shared.transport.EurekaHttpClient;
 import com.netflix.discovery.shared.transport.EurekaHttpResponse;
 import com.netflix.discovery.shared.transport.SimpleEurekaHttpServer;
 import com.netflix.discovery.util.InstanceInfoGenerator;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static com.netflix.discovery.shared.transport.EurekaHttpResponse.anEurekaHttpResponse;
 import static com.netflix.discovery.util.EurekaEntityFunctions.copyApplications;
@@ -31,10 +31,10 @@ import static com.netflix.discovery.util.EurekaEntityFunctions.toApplications;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.timeout;
@@ -64,19 +64,19 @@ public class DiscoveryClientRegistryTest {
     /**
      * Share server stub by all tests.
      */
-    @BeforeClass
+    @BeforeAll
     public static void setUpClass() throws IOException {
         eurekaHttpServer = new SimpleEurekaHttpServer(requestHandler);
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownClass() throws Exception {
         if (eurekaHttpServer != null) {
             eurekaHttpServer.shutdown();
         }
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         reset(requestHandler);
         when(requestHandler.cancel(anyString(), anyString())).thenReturn(EurekaHttpResponse.status(200));

--- a/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientStatsInitFailedTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientStatsInitFailedTest.java
@@ -1,24 +1,24 @@
 package com.netflix.discovery;
 
 import com.netflix.discovery.junit.resource.DiscoveryClientResource;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for DiscoveryClient stats reported when initial registry fetch fails.
  */
 public class DiscoveryClientStatsInitFailedTest extends BaseDiscoveryClientTester {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         setupProperties();
         populateRemoteRegistryAtStartup();
         setupDiscoveryClient();
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         shutdownDiscoveryClient();
         DiscoveryClientResource.clearDiscoveryClientConfig();
@@ -26,16 +26,16 @@ public class DiscoveryClientStatsInitFailedTest extends BaseDiscoveryClientTeste
 
     @Test
     public void testEmptyInitLocalRegistrySize() throws Exception {
-        Assert.assertTrue(client instanceof DiscoveryClient);
+        Assertions.assertTrue(client instanceof DiscoveryClient);
         DiscoveryClient clientImpl = (DiscoveryClient) client;
-        Assert.assertEquals(0, clientImpl.getStats().initLocalRegistrySize());
+        Assertions.assertEquals(0, clientImpl.getStats().initLocalRegistrySize());
     }
 
     @Test
     public void testInitFailed() throws Exception {
-        Assert.assertTrue(client instanceof DiscoveryClient);
+        Assertions.assertTrue(client instanceof DiscoveryClient);
         DiscoveryClient clientImpl = (DiscoveryClient) client;
-        Assert.assertFalse(clientImpl.getStats().initSucceeded());
+        Assertions.assertFalse(clientImpl.getStats().initSucceeded());
     }
 
 }

--- a/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientStatsTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/DiscoveryClientStatsTest.java
@@ -1,7 +1,7 @@
 package com.netflix.discovery;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for DiscoveryClient stats reported when initial registry fetch succeeds.
@@ -10,16 +10,16 @@ public class DiscoveryClientStatsTest extends AbstractDiscoveryClientTester {
 
     @Test
     public void testNonEmptyInitLocalRegistrySize() throws Exception {
-        Assert.assertTrue(client instanceof DiscoveryClient);
+        Assertions.assertTrue(client instanceof DiscoveryClient);
         DiscoveryClient clientImpl = (DiscoveryClient) client;
-        Assert.assertEquals(createLocalApps().size(), clientImpl.getStats().initLocalRegistrySize());
+        Assertions.assertEquals(createLocalApps().size(), clientImpl.getStats().initLocalRegistrySize());
     }
 
     @Test
     public void testInitSucceeded() throws Exception {
-        Assert.assertTrue(client instanceof DiscoveryClient);
+        Assertions.assertTrue(client instanceof DiscoveryClient);
         DiscoveryClient clientImpl = (DiscoveryClient) client;
-        Assert.assertTrue(clientImpl.getStats().initSucceeded());
+        Assertions.assertTrue(clientImpl.getStats().initSucceeded());
     }
 
 }

--- a/eureka-client/src/test/java/com/netflix/discovery/EurekaEventListenerTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/EurekaEventListenerTest.java
@@ -4,10 +4,10 @@ import static com.netflix.discovery.shared.transport.EurekaHttpResponse.anEureka
 import static com.netflix.discovery.util.EurekaEntityFunctions.toApplications;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
@@ -16,12 +16,11 @@ import java.io.IOException;
 
 import javax.ws.rs.core.MediaType;
 
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
-import org.junit.Test;
-
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.discovery.junit.resource.DiscoveryClientResource;
 import com.netflix.discovery.shared.Applications;
@@ -43,19 +42,19 @@ public class EurekaEventListenerTest {
     /**
      * Share server stub by all tests.
      */
-    @BeforeClass
+    @BeforeAll
     public static void setUpClass() throws IOException {
         eurekaHttpServer = new SimpleEurekaHttpServer(requestHandler);
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownClass() throws Exception {
         if (eurekaHttpServer != null) {
             eurekaHttpServer.shutdown();
         }
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         reset(requestHandler);
         when(requestHandler.register(any(InstanceInfo.class))).thenReturn(EurekaHttpResponse.status(204));

--- a/eureka-client/src/test/java/com/netflix/discovery/InstanceInfoReplicatorTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/InstanceInfoReplicatorTest.java
@@ -4,19 +4,17 @@ import com.netflix.appinfo.DataCenterInfo;
 import com.netflix.appinfo.HealthCheckHandler;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.appinfo.LeaseInfo;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * @author David Liu
@@ -29,7 +27,7 @@ public class InstanceInfoReplicatorTest {
     private DiscoveryClient discoveryClient;
     private InstanceInfoReplicator replicator;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         discoveryClient = mock(DiscoveryClient.class);
 
@@ -51,7 +49,7 @@ public class InstanceInfoReplicatorTest {
         this.replicator = new InstanceInfoReplicator(discoveryClient, instanceInfo, refreshRateSeconds, burstSize);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         replicator.stop();
     }

--- a/eureka-client/src/test/java/com/netflix/discovery/InstanceRegionCheckerTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/InstanceRegionCheckerTest.java
@@ -3,8 +3,8 @@ package com.netflix.discovery;
 import com.netflix.appinfo.AmazonInfo;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.config.ConfigurationManager;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Nitesh Kant
@@ -22,7 +22,7 @@ public class InstanceRegionCheckerTest {
         InstanceInfo instanceInfo = InstanceInfo.Builder.newBuilder().setAppName("app").setDataCenterInfo(dcInfo).build();
         String instanceRegion = checker.getInstanceRegion(instanceInfo);
 
-        Assert.assertEquals("Invalid instance region.", "us-east-1", instanceRegion);
+        Assertions.assertEquals("us-east-1", instanceRegion, "Invalid instance region.");
     }
 
     @Test
@@ -37,7 +37,7 @@ public class InstanceRegionCheckerTest {
                 dcInfo).build();
         String instanceRegion = checker.getInstanceRegion(instanceInfo);
 
-        Assert.assertEquals("Invalid instance region.", "us-east-1", instanceRegion);
+        Assertions.assertEquals("us-east-1", instanceRegion, "Invalid instance region.");
     }
 
     @Test
@@ -52,7 +52,7 @@ public class InstanceRegionCheckerTest {
                 dcInfo).build();
         String instanceRegion = checker.getInstanceRegion(instanceInfo);
 
-        Assert.assertNull("Invalid instance region.", instanceRegion);
+        Assertions.assertNull(instanceRegion, "Invalid instance region.");
     }
 
     @Test
@@ -66,7 +66,7 @@ public class InstanceRegionCheckerTest {
         InstanceInfo instanceInfo = InstanceInfo.Builder.newBuilder().setAppName("abc").setDataCenterInfo(dcInfo).build();
         String instanceRegion = checker.getInstanceRegion(instanceInfo);
 
-        Assert.assertEquals("Invalid instance region.", "us-east-1", instanceRegion);
+        Assertions.assertEquals("us-east-1", instanceRegion, "Invalid instance region.");
     }
 
     @Test
@@ -80,6 +80,6 @@ public class InstanceRegionCheckerTest {
         InstanceInfo instanceInfo = InstanceInfo.Builder.newBuilder().setAppName("abc").setDataCenterInfo(dcInfo).build();
         String instanceRegion = checker.getInstanceRegion(instanceInfo);
 
-        Assert.assertNull("Invalid instance region.", instanceRegion);
+        Assertions.assertNull(instanceRegion, "Invalid instance region.");
     }
 }

--- a/eureka-client/src/test/java/com/netflix/discovery/Jersey1DiscoveryClientOptionalArgsTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/Jersey1DiscoveryClientOptionalArgsTest.java
@@ -3,9 +3,8 @@ package com.netflix.discovery;
 import javax.inject.Provider;
 
 import com.netflix.discovery.shared.transport.jersey.Jersey1DiscoveryClientOptionalArgs;
-import org.junit.Before;
-import org.junit.Test;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import com.netflix.appinfo.HealthCheckCallback;
 import com.netflix.appinfo.HealthCheckHandler;
 
@@ -16,7 +15,7 @@ public class Jersey1DiscoveryClientOptionalArgsTest {
     
     private Jersey1DiscoveryClientOptionalArgs args;
     
-    @Before
+    @BeforeEach
     public void before() {
         args = new Jersey1DiscoveryClientOptionalArgs();
     }

--- a/eureka-client/src/test/java/com/netflix/discovery/MockRemoteEurekaServer.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/MockRemoteEurekaServer.java
@@ -21,7 +21,7 @@ import com.netflix.appinfo.InstanceInfo;
 import com.netflix.discovery.converters.XmlXStream;
 import com.netflix.discovery.shared.Application;
 import com.netflix.discovery.shared.Applications;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.rules.ExternalResource;
 import org.mortbay.jetty.Request;
 import org.mortbay.jetty.Server;
@@ -65,7 +65,7 @@ public class MockRemoteEurekaServer extends ExternalResource {
         try {
             stop();
         } catch (Exception e) {
-            Assert.fail(e.getMessage());
+            Assertions.fail(e.getMessage());
         }
     }
 
@@ -141,9 +141,9 @@ public class MockRemoteEurekaServer extends ExternalResource {
             String authVersion = request.getHeader(AbstractEurekaIdentity.AUTH_VERSION_HEADER_KEY);
             String authId = request.getHeader(AbstractEurekaIdentity.AUTH_ID_HEADER_KEY);
 
-            Assert.assertEquals(EurekaClientIdentity.DEFAULT_CLIENT_NAME, authName);
-            Assert.assertNotNull(authVersion);
-            Assert.assertNotNull(authId);
+            Assertions.assertEquals(EurekaClientIdentity.DEFAULT_CLIENT_NAME, authName);
+            Assertions.assertNotNull(authVersion);
+            Assertions.assertNotNull(authId);
 
             String pathInfo = request.getPathInfo();
             System.out.println("Eureka port: " + port + ". " + System.currentTimeMillis() +

--- a/eureka-client/src/test/java/com/netflix/discovery/TimedSupervisorTaskTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/TimedSupervisorTaskTest.java
@@ -10,10 +10,10 @@ import java.util.concurrent.atomic.AtomicLong;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TimedSupervisorTaskTest {
 
@@ -30,7 +30,7 @@ public class TimedSupervisorTaskTest {
     private AtomicLong maxConcurrentTestTasks;
     private AtomicLong testTaskCounter;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         scheduler = Executors.newScheduledThreadPool(4,
                 new ThreadFactoryBuilder()
@@ -55,7 +55,7 @@ public class TimedSupervisorTaskTest {
         testTaskCounter = new AtomicLong(0);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         if (executor != null) {
             executor.shutdownNow();
@@ -78,12 +78,12 @@ public class TimedSupervisorTaskTest {
 
         helperExecutor.submit(supervisorTask).get();
 
-        Assert.assertEquals(1, maxConcurrentTestTasks.get());
-        Assert.assertEquals(0, testTaskCounter.get());
+        Assertions.assertEquals(1, maxConcurrentTestTasks.get());
+        Assertions.assertEquals(0, testTaskCounter.get());
 
-        Assert.assertEquals(1, testTaskStartCounter.get());
-        Assert.assertEquals(1, testTaskSuccessfulCounter.get());
-        Assert.assertEquals(0, testTaskInterruptedCounter.get());
+        Assertions.assertEquals(1, testTaskStartCounter.get());
+        Assertions.assertEquals(1, testTaskSuccessfulCounter.get());
+        Assertions.assertEquals(0, testTaskInterruptedCounter.get());
     }
 
     @Test
@@ -95,12 +95,12 @@ public class TimedSupervisorTaskTest {
         helperExecutor.submit(supervisorTask).get();
         Thread.sleep(500);  // wait a little bit for the subtask interrupt handler
 
-        Assert.assertEquals(1, maxConcurrentTestTasks.get());
-        Assert.assertEquals(1, testTaskCounter.get());
+        Assertions.assertEquals(1, maxConcurrentTestTasks.get());
+        Assertions.assertEquals(1, testTaskCounter.get());
 
-        Assert.assertEquals(1, testTaskStartCounter.get());
-        Assert.assertEquals(0, testTaskSuccessfulCounter.get());
-        Assert.assertEquals(1, testTaskInterruptedCounter.get());
+        Assertions.assertEquals(1, testTaskStartCounter.get());
+        Assertions.assertEquals(0, testTaskSuccessfulCounter.get());
+        Assertions.assertEquals(1, testTaskInterruptedCounter.get());
     }
 
     @Test
@@ -113,12 +113,12 @@ public class TimedSupervisorTaskTest {
 
         Thread.sleep(500);  // wait a little bit for the subtask interrupt handlers
 
-        Assert.assertEquals(3, maxConcurrentTestTasks.get());
-        Assert.assertEquals(3, testTaskCounter.get());
+        Assertions.assertEquals(3, maxConcurrentTestTasks.get());
+        Assertions.assertEquals(3, testTaskCounter.get());
 
-        Assert.assertEquals(3, testTaskStartCounter.get());
-        Assert.assertEquals(0, testTaskSuccessfulCounter.get());
-        Assert.assertEquals(0, testTaskInterruptedCounter.get());
+        Assertions.assertEquals(3, testTaskStartCounter.get());
+        Assertions.assertEquals(0, testTaskSuccessfulCounter.get());
+        Assertions.assertEquals(0, testTaskInterruptedCounter.get());
     }
 
     @Test
@@ -130,10 +130,10 @@ public class TimedSupervisorTaskTest {
         scheduler.schedule(supervisorTask, 0, TimeUnit.SECONDS);
         Thread.sleep(5000);  // let the scheduler run for long enough for some results
 
-        Assert.assertEquals(1, maxConcurrentTestTasks.get());
-        Assert.assertEquals(0, testTaskCounter.get());
+        Assertions.assertEquals(1, maxConcurrentTestTasks.get());
+        Assertions.assertEquals(0, testTaskCounter.get());
 
-        Assert.assertEquals(0, testTaskInterruptedCounter.get());
+        Assertions.assertEquals(0, testTaskInterruptedCounter.get());
     }
 
     @Test
@@ -145,11 +145,11 @@ public class TimedSupervisorTaskTest {
         scheduler.schedule(supervisorTask, 0, TimeUnit.SECONDS);
         Thread.sleep(5000);  // let the scheduler run for long enough for some results
 
-        Assert.assertEquals(1, maxConcurrentTestTasks.get());
-        Assert.assertTrue(0 != testTaskCounter.get());  // tasks are been cancelled
+        Assertions.assertEquals(1, maxConcurrentTestTasks.get());
+        Assertions.assertTrue(0 != testTaskCounter.get());  // tasks are been cancelled
 
 
-        Assert.assertEquals(0, testTaskSuccessfulCounter.get());
+        Assertions.assertEquals(0, testTaskSuccessfulCounter.get());
     }
 
     private class TestTask implements Runnable {

--- a/eureka-client/src/test/java/com/netflix/discovery/converters/EnumLookupTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/converters/EnumLookupTest.java
@@ -1,7 +1,7 @@
 package com.netflix.discovery.converters;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class EnumLookupTest {
     
@@ -18,9 +18,9 @@ public class EnumLookupTest {
     public void testLookup() {
         EnumLookup<TestEnum> lookup = new EnumLookup<>(TestEnum.class, v->v.name.toCharArray());
         char[] buffer = "zeroonetwothreefour".toCharArray();
-        Assert.assertSame(TestEnum.VAL_ONE, lookup.find(buffer, 4, 3));
-        Assert.assertSame(TestEnum.VAL_TWO, lookup.find(buffer, 7, 3));
-        Assert.assertSame(TestEnum.VAL_THREE, lookup.find(buffer, 10, 5));
+        Assertions.assertSame(TestEnum.VAL_ONE, lookup.find(buffer, 4, 3));
+        Assertions.assertSame(TestEnum.VAL_TWO, lookup.find(buffer, 7, 3));
+        Assertions.assertSame(TestEnum.VAL_THREE, lookup.find(buffer, 10, 5));
     }
 
 }

--- a/eureka-client/src/test/java/com/netflix/discovery/converters/EurekaCodecCompatibilityTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/converters/EurekaCodecCompatibilityTest.java
@@ -23,11 +23,11 @@ import com.netflix.eureka.cluster.protocol.ReplicationInstanceResponse;
 import com.netflix.eureka.cluster.protocol.ReplicationList;
 import com.netflix.eureka.cluster.protocol.ReplicationListResponse;
 import com.netflix.eureka.registry.PeerAwareInstanceRegistryImpl.Action;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Tomasz Bak

--- a/eureka-client/src/test/java/com/netflix/discovery/converters/EurekaJacksonCodecIntegrationTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/converters/EurekaJacksonCodecIntegrationTest.java
@@ -12,9 +12,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import org.junit.Test;
-
 import com.netflix.discovery.shared.Applications;
+import org.junit.jupiter.api.Test;
 
 /**
  * this integration test parses the response of a Eureka discovery server,
@@ -23,7 +22,7 @@ import com.netflix.discovery.shared.Applications;
  * tests below are @Ignore'd.
  *
  */
-@org.junit.Ignore
+@org.junit.jupiter.api.Disabled
 public class EurekaJacksonCodecIntegrationTest {
     private static final int UNREASONABLE_TIMEOUT_MS = 500;
     private final EurekaJacksonCodec codec = new EurekaJacksonCodec("", "");

--- a/eureka-client/src/test/java/com/netflix/discovery/converters/EurekaJacksonCodecTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/converters/EurekaJacksonCodecTest.java
@@ -1,6 +1,6 @@
 package com.netflix.discovery.converters;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -10,14 +10,13 @@ import java.util.Iterator;
 
 import javax.ws.rs.core.MediaType;
 
-import org.junit.Test;
-
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.appinfo.InstanceInfo.ActionType;
 import com.netflix.discovery.shared.Application;
 import com.netflix.discovery.shared.Applications;
 import com.netflix.discovery.util.EurekaEntityComparators;
 import com.netflix.discovery.util.InstanceInfoGenerator;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tomasz Bak

--- a/eureka-client/src/test/java/com/netflix/discovery/converters/EurekaJsonAndXmlJacksonCodecTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/converters/EurekaJsonAndXmlJacksonCodecTest.java
@@ -17,12 +17,12 @@ import com.netflix.discovery.shared.Application;
 import com.netflix.discovery.shared.Applications;
 import com.netflix.discovery.util.EurekaEntityComparators;
 import com.netflix.discovery.util.InstanceInfoGenerator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Tomasz Bak

--- a/eureka-client/src/test/java/com/netflix/discovery/converters/JsonXStreamTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/converters/JsonXStreamTest.java
@@ -1,11 +1,12 @@
 package com.netflix.discovery.converters;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.thoughtworks.xstream.security.ForbiddenClassException;
-import org.junit.Test;
-
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import com.netflix.discovery.shared.Applications;
 import com.netflix.discovery.util.EurekaEntityComparators;
 import com.netflix.discovery.util.InstanceInfoGenerator;
@@ -43,10 +44,13 @@ public class JsonXStreamTest {
     /**
      * Tests: http://x-stream.github.io/CVE-2017-7957.html
      */
-    @Test(expected=ForbiddenClassException.class, timeout=5000)
+    @Test
+    @Timeout(5000)
     public void testVoidElementUnmarshalling() throws Exception {
-        XStream xstream = JsonXStream.getInstance();
-        xstream.fromXML("{'void':null}");
+        assertThrows(ForbiddenClassException.class, () -> {
+            XStream xstream = JsonXStream.getInstance();
+            xstream.fromXML("{'void':null}");
+        });
     }
 
 }

--- a/eureka-client/src/test/java/com/netflix/discovery/converters/StringCacheTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/converters/StringCacheTest.java
@@ -1,9 +1,9 @@
 package com.netflix.discovery.converters;
 
 import com.netflix.discovery.util.StringCache;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Tomasz Bak

--- a/eureka-client/src/test/java/com/netflix/discovery/converters/XmlXStreamTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/converters/XmlXStreamTest.java
@@ -1,14 +1,16 @@
 package com.netflix.discovery.converters;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.netflix.discovery.shared.Applications;
 import com.netflix.discovery.util.EurekaEntityComparators;
 import com.netflix.discovery.util.InstanceInfoGenerator;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.security.ForbiddenClassException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * @author Tomasz Bak
@@ -42,18 +44,24 @@ public class XmlXStreamTest {
     /**
      * Tests: http://x-stream.github.io/CVE-2017-7957.html
      */
-    @Test(expected=ForbiddenClassException.class, timeout=5000)
+    @Test
+    @Timeout(5000)
     public void testVoidElementUnmarshalling() throws Exception {
-        XStream xstream = XmlXStream.getInstance();
-        xstream.fromXML("<void/>");
+        assertThrows(ForbiddenClassException.class, () -> {
+            XStream xstream = XmlXStream.getInstance();
+            xstream.fromXML("<void/>");
+        });
     }
 
     /**
      * Tests: http://x-stream.github.io/CVE-2017-7957.html
      */
-    @Test(expected=ForbiddenClassException.class, timeout=5000)
+    @Test
+    @Timeout(5000)
     public void testVoidAttributeUnmarshalling() throws Exception {
-        XStream xstream = XmlXStream.getInstance();
-        xstream.fromXML("<string class='void'>Hello, world!</string>");
+        assertThrows(ForbiddenClassException.class, () -> {
+            XStream xstream = XmlXStream.getInstance();
+            xstream.fromXML("<string class='void'>Hello, world!</string>");
+        });
     }
 }

--- a/eureka-client/src/test/java/com/netflix/discovery/converters/jackson/builder/StringInterningAmazonInfoBuilderTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/converters/jackson/builder/StringInterningAmazonInfoBuilderTest.java
@@ -19,11 +19,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.netflix.appinfo.AmazonInfo;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class StringInterningAmazonInfoBuilderTest {
 
@@ -41,9 +43,11 @@ public class StringInterningAmazonInfoBuilderTest {
         return new AmazonInfo(info.getName().name(), new HashMap<>(info.getMetadata()));
     }
 
-    @Test(expected = InvalidTypeIdException.class)
+    @Test
     public void payloadThatIsEmpty() throws IOException {
-        newMapper().readValue("{}", AmazonInfo.class);
+        assertThrows(InvalidTypeIdException.class, () -> {
+            newMapper().readValue("{}", AmazonInfo.class);
+        });
     }
 
     @Test
@@ -52,7 +56,7 @@ public class StringInterningAmazonInfoBuilderTest {
                 + "\"@class\": \"com.netflix.appinfo.AmazonInfo\""
                 + "}";
         AmazonInfo info = newMapper().readValue(json, AmazonInfo.class);
-        Assert.assertEquals(new AmazonInfo(), info);
+        Assertions.assertEquals(new AmazonInfo(), info);
     }
 
     @Test
@@ -68,7 +72,7 @@ public class StringInterningAmazonInfoBuilderTest {
         AmazonInfo expected = AmazonInfo.Builder.newBuilder()
                 .addMetadata(AmazonInfo.MetaDataKey.instanceId, "i-12345")
                 .build();
-        Assert.assertEquals(expected, nonCompact(info));
+        Assertions.assertEquals(expected, nonCompact(info));
     }
 
     @Test
@@ -84,7 +88,7 @@ public class StringInterningAmazonInfoBuilderTest {
         AmazonInfo expected = AmazonInfo.Builder.newBuilder()
                 .addMetadata(AmazonInfo.MetaDataKey.instanceId, "i-12345")
                 .build();
-        Assert.assertEquals(expected, nonCompact(info));
+        Assertions.assertEquals(expected, nonCompact(info));
     }
 
     @Test
@@ -101,7 +105,7 @@ public class StringInterningAmazonInfoBuilderTest {
         AmazonInfo expected = AmazonInfo.Builder.newBuilder()
                 .addMetadata(AmazonInfo.MetaDataKey.instanceId, "i-12345")
                 .build();
-        Assert.assertEquals(expected, nonCompact(info));
+        Assertions.assertEquals(expected, nonCompact(info));
     }
 
     @Test
@@ -118,7 +122,7 @@ public class StringInterningAmazonInfoBuilderTest {
         AmazonInfo expected = AmazonInfo.Builder.newBuilder()
                 .addMetadata(AmazonInfo.MetaDataKey.instanceId, "i-12345")
                 .build();
-        Assert.assertEquals(expected, nonCompact(info));
+        Assertions.assertEquals(expected, nonCompact(info));
     }
 
     @Test
@@ -137,6 +141,6 @@ public class StringInterningAmazonInfoBuilderTest {
         AmazonInfo expected = AmazonInfo.Builder.newBuilder()
                 .addMetadata(AmazonInfo.MetaDataKey.instanceId, "i-12345")
                 .build();
-        Assert.assertEquals(expected, nonCompact(info));
+        Assertions.assertEquals(expected, nonCompact(info));
     }
 }

--- a/eureka-client/src/test/java/com/netflix/discovery/converters/wrappers/CodecWrappersTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/converters/wrappers/CodecWrappersTest.java
@@ -1,7 +1,7 @@
 package com.netflix.discovery.converters.wrappers;
 
 import junit.framework.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;

--- a/eureka-client/src/test/java/com/netflix/discovery/guice/EurekaModuleTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/guice/EurekaModuleTest.java
@@ -16,10 +16,10 @@ import com.netflix.discovery.EurekaClientConfig;
 import com.netflix.discovery.shared.transport.jersey.TransportClientFactories;
 import com.netflix.governator.InjectorBuilder;
 import com.netflix.governator.LifecycleInjector;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author David Liu
@@ -28,7 +28,7 @@ public class EurekaModuleTest {
 
     private LifecycleInjector injector;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         ConfigurationManager.getConfigInstance().setProperty("eureka.region", "default");
         ConfigurationManager.getConfigInstance().setProperty("eureka.shouldFetchRegistry", "false");
@@ -48,7 +48,7 @@ public class EurekaModuleTest {
                 .createInjector();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         if (injector != null) {
             injector.shutdown();
@@ -60,22 +60,22 @@ public class EurekaModuleTest {
     @Test
     public void testDI() {
         InstanceInfo instanceInfo = injector.getInstance(InstanceInfo.class);
-        Assert.assertEquals(ApplicationInfoManager.getInstance().getInfo(), instanceInfo);
+        Assertions.assertEquals(ApplicationInfoManager.getInstance().getInfo(), instanceInfo);
 
         EurekaClient eurekaClient = injector.getInstance(EurekaClient.class);
         DiscoveryClient discoveryClient = injector.getInstance(DiscoveryClient.class);
 
-        Assert.assertEquals(DiscoveryManager.getInstance().getEurekaClient(), eurekaClient);
-        Assert.assertEquals(DiscoveryManager.getInstance().getDiscoveryClient(), discoveryClient);
-        Assert.assertEquals(eurekaClient, discoveryClient);
+        Assertions.assertEquals(DiscoveryManager.getInstance().getEurekaClient(), eurekaClient);
+        Assertions.assertEquals(DiscoveryManager.getInstance().getDiscoveryClient(), discoveryClient);
+        Assertions.assertEquals(eurekaClient, discoveryClient);
 
         EurekaClientConfig eurekaClientConfig = injector.getInstance(EurekaClientConfig.class);
-        Assert.assertEquals(DiscoveryManager.getInstance().getEurekaClientConfig(), eurekaClientConfig);
+        Assertions.assertEquals(DiscoveryManager.getInstance().getEurekaClientConfig(), eurekaClientConfig);
 
         EurekaInstanceConfig eurekaInstanceConfig = injector.getInstance(EurekaInstanceConfig.class);
-        Assert.assertEquals(DiscoveryManager.getInstance().getEurekaInstanceConfig(), eurekaInstanceConfig);
+        Assertions.assertEquals(DiscoveryManager.getInstance().getEurekaInstanceConfig(), eurekaInstanceConfig);
 
         Binding<TransportClientFactories> binding = injector.getExistingBinding(Key.get(TransportClientFactories.class));
-        Assert.assertNull(binding);  // no bindings so defaulting to default of jersey1
+        Assertions.assertNull(binding);  // no bindings so defaulting to default of jersey1
     }
 }

--- a/eureka-client/src/test/java/com/netflix/discovery/provider/DiscoveryJerseyProviderTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/provider/DiscoveryJerseyProviderTest.java
@@ -26,11 +26,11 @@ import com.netflix.appinfo.InstanceInfo;
 import com.netflix.discovery.converters.wrappers.CodecWrappers;
 import com.netflix.discovery.util.InstanceInfoGenerator;
 import org.apache.commons.io.output.ByteArrayOutputStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  */

--- a/eureka-client/src/test/java/com/netflix/discovery/providers/DefaultEurekaClientConfigProviderTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/providers/DefaultEurekaClientConfigProviderTest.java
@@ -26,11 +26,11 @@ import com.netflix.discovery.EurekaNamespace;
 import com.netflix.governator.guice.BootstrapBinder;
 import com.netflix.governator.guice.BootstrapModule;
 import com.netflix.governator.guice.LifecycleInjector;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Tomasz Bak

--- a/eureka-client/src/test/java/com/netflix/discovery/shared/ApplicationsTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/shared/ApplicationsTest.java
@@ -1,11 +1,6 @@
 package com.netflix.discovery.shared;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
@@ -16,8 +11,8 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.google.common.collect.Iterables;
@@ -205,13 +200,13 @@ public class ApplicationsTest {
         applications.addApplication(application);
 
         List<InstanceInfo> instanceInfos = application.getInstances();
-        Assert.assertEquals(1, instanceInfos.size());
-        Assert.assertTrue(instanceInfos.contains(instanceInfo));
+        Assertions.assertEquals(1, instanceInfos.size());
+        Assertions.assertTrue(instanceInfos.contains(instanceInfo));
 
         List<Application> appsList = applications.getRegisteredApplications();
-        Assert.assertEquals(1, appsList.size());
-        Assert.assertTrue(appsList.contains(application));
-        Assert.assertEquals(application, applications.getRegisteredApplications(application.getName()));
+        Assertions.assertEquals(1, appsList.size());
+        Assertions.assertTrue(appsList.contains(application));
+        Assertions.assertEquals(application, applications.getRegisteredApplications(application.getName()));
     }
 
     @Test
@@ -236,9 +231,9 @@ public class ApplicationsTest {
         applications.addApplication(application);
         
         List<Application> appsList = applications.getRegisteredApplications();
-        Assert.assertEquals(1, appsList.size());
-        Assert.assertTrue(appsList.contains(application));
-        Assert.assertEquals(application, applications.getRegisteredApplications(application.getName()));
+        Assertions.assertEquals(1, appsList.size());
+        Assertions.assertTrue(appsList.contains(application));
+        Assertions.assertEquals(application, applications.getRegisteredApplications(application.getName()));
     }
     
     @Test
@@ -262,9 +257,9 @@ public class ApplicationsTest {
         Applications applications = new Applications("UP_1_", -1L, Arrays.asList(application));
         
         List<Application> appsList = applications.getRegisteredApplications();
-        Assert.assertEquals(1, appsList.size());
-        Assert.assertTrue(appsList.contains(application));
-        Assert.assertEquals(application, applications.getRegisteredApplications(application.getName()));
+        Assertions.assertEquals(1, appsList.size());
+        Assertions.assertTrue(appsList.contains(application));
+        Assertions.assertEquals(application, applications.getRegisteredApplications(application.getName()));
     }
     
     @Test

--- a/eureka-client/src/test/java/com/netflix/discovery/shared/resolver/AsyncResolverTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/shared/resolver/AsyncResolverTest.java
@@ -2,17 +2,17 @@ package com.netflix.discovery.shared.resolver;
 
 import com.netflix.discovery.shared.resolver.aws.SampleCluster;
 import com.netflix.discovery.shared.transport.EurekaTransportConfig;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.anyLong;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -31,7 +31,7 @@ public class AsyncResolverTest {
 
     private AsyncResolver resolver;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         when(transportConfig.getAsyncExecutorThreadPoolSize()).thenReturn(3);
         when(transportConfig.getAsyncResolverRefreshIntervalMs()).thenReturn(200);
@@ -46,7 +46,7 @@ public class AsyncResolverTest {
         ));
     }
 
-    @After
+    @AfterEach
     public void shutDown() {
         resolver.shutdown();
     }

--- a/eureka-client/src/test/java/com/netflix/discovery/shared/resolver/ReloadingClusterResolverTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/shared/resolver/ReloadingClusterResolverTest.java
@@ -22,11 +22,12 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import com.netflix.discovery.shared.resolver.aws.AwsEndpoint;
 import com.netflix.discovery.shared.resolver.aws.SampleCluster;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Tomasz Bak
@@ -37,7 +38,8 @@ public class ReloadingClusterResolverTest {
 
     private ReloadingClusterResolver<AwsEndpoint> resolver;
 
-    @Test(timeout = 30000)
+    @Test
+    @Timeout(30000)
     public void testDataAreReloadedPeriodically() throws Exception {
         List<AwsEndpoint> firstEndpointList = SampleCluster.UsEast1a.build();
         factory.setEndpoints(firstEndpointList);
@@ -53,7 +55,8 @@ public class ReloadingClusterResolverTest {
         assertThat(awaitUpdate(resolver, secondEndpointList), is(true));
     }
 
-    @Test(timeout = 30000)
+    @Test
+    @Timeout(30000)
     public void testIdenticalListsDoNotCauseReload() throws Exception {
         List<AwsEndpoint> firstEndpointList = SampleCluster.UsEast1a.build();
         factory.setEndpoints(firstEndpointList);

--- a/eureka-client/src/test/java/com/netflix/discovery/shared/resolver/ResolverUtilsTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/shared/resolver/ResolverUtilsTest.java
@@ -26,14 +26,14 @@ import com.netflix.discovery.EurekaClientConfig;
 import com.netflix.discovery.shared.resolver.aws.AwsEndpoint;
 import com.netflix.discovery.shared.resolver.aws.SampleCluster;
 import com.netflix.discovery.shared.transport.EurekaTransportConfig;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -115,13 +115,13 @@ public class ResolverUtilsTest {
         InstanceInfo instanceWithAWSInfo = InstanceInfo.Builder.newBuilder().setAppName("appName")
                 .setHostName("hostName").setPort(8080).setDataCenterInfo(amazonInfo).build();
         AwsEndpoint awsEndpoint = ResolverUtils.instanceInfoToEndpoint(clientConfig, transportConfig, instanceWithAWSInfo);
-        assertEquals("zone not equals.", "us-east-1c", awsEndpoint.getZone());
+        assertEquals("us-east-1c", awsEndpoint.getZone(), "zone not equals.");
 
         MyDataCenterInfo myDataCenterInfo = new MyDataCenterInfo(DataCenterInfo.Name.MyOwn);
         InstanceInfo instanceWithMyDataInfo = InstanceInfo.Builder.newBuilder().setAppName("appName")
                 .setHostName("hostName").setPort(8080).setDataCenterInfo(myDataCenterInfo)
                 .add("zone", "us-east-1c").build();
         awsEndpoint = ResolverUtils.instanceInfoToEndpoint(clientConfig, transportConfig, instanceWithMyDataInfo);
-        assertEquals("zone not equals.", "us-east-1c", awsEndpoint.getZone());
+        assertEquals("us-east-1c", awsEndpoint.getZone(), "zone not equals.");
     }
 }

--- a/eureka-client/src/test/java/com/netflix/discovery/shared/resolver/StaticClusterResolverTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/shared/resolver/StaticClusterResolverTest.java
@@ -16,13 +16,13 @@
 
 package com.netflix.discovery.shared.resolver;
 
-import java.net.URL;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import java.net.URL;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Tomasz Bak

--- a/eureka-client/src/test/java/com/netflix/discovery/shared/resolver/aws/ApplicationsResolverTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/shared/resolver/aws/ApplicationsResolverTest.java
@@ -5,17 +5,17 @@ import com.netflix.discovery.shared.Applications;
 import com.netflix.discovery.shared.resolver.aws.ApplicationsResolver.ApplicationsSource;
 import com.netflix.discovery.shared.transport.EurekaTransportConfig;
 import com.netflix.discovery.util.InstanceInfoGenerator;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.eq;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -32,7 +32,7 @@ public class ApplicationsResolverTest {
     private String vipAddress;
     private ApplicationsResolver resolver;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         when(clientConfig.getEurekaServerURLContext()).thenReturn("context");
         when(clientConfig.getRegion()).thenReturn("region");

--- a/eureka-client/src/test/java/com/netflix/discovery/shared/resolver/aws/ConfigClusterResolverTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/shared/resolver/aws/ConfigClusterResolverTest.java
@@ -5,15 +5,15 @@ import com.netflix.appinfo.InstanceInfo;
 import com.netflix.appinfo.MyDataCenterInfo;
 import com.netflix.discovery.EurekaClientConfig;
 import com.netflix.discovery.util.InstanceInfoGenerator;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -37,7 +37,7 @@ public class ConfigClusterResolverTest {
     );
     private ConfigClusterResolver resolver;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         when(clientConfig.shouldUseDnsForFetchingServiceUrls()).thenReturn(false);
         when(clientConfig.getRegion()).thenReturn("us-east-1");

--- a/eureka-client/src/test/java/com/netflix/discovery/shared/resolver/aws/EurekaHttpResolverTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/shared/resolver/aws/EurekaHttpResolverTest.java
@@ -8,15 +8,15 @@ import com.netflix.discovery.shared.transport.EurekaHttpClientFactory;
 import com.netflix.discovery.shared.transport.EurekaHttpResponse;
 import com.netflix.discovery.shared.transport.EurekaTransportConfig;
 import com.netflix.discovery.util.InstanceInfoGenerator;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -36,7 +36,7 @@ public class EurekaHttpResolverTest {
     private String vipAddress;
     private EurekaHttpResolver resolver;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         when(clientConfig.getEurekaServerURLContext()).thenReturn("context");
         when(clientConfig.getRegion()).thenReturn("region");
@@ -50,7 +50,7 @@ public class EurekaHttpResolverTest {
         resolver = new EurekaHttpResolver(clientConfig, transportConfig, clientFactory, vipAddress);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
     }
 

--- a/eureka-client/src/test/java/com/netflix/discovery/shared/resolver/aws/ZoneAffinityClusterResolverTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/shared/resolver/aws/ZoneAffinityClusterResolverTest.java
@@ -20,11 +20,11 @@ import java.util.List;
 
 import com.netflix.discovery.shared.resolver.ResolverUtils;
 import com.netflix.discovery.shared.resolver.StaticClusterResolver;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Tomasz Bak

--- a/eureka-client/src/test/java/com/netflix/discovery/shared/transport/EurekaHttpClientsTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/shared/transport/EurekaHttpClientsTest.java
@@ -48,18 +48,15 @@ import com.sun.jersey.api.client.ClientHandlerException;
 import com.sun.jersey.api.client.ClientRequest;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.filter.ClientFilter;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static com.netflix.discovery.shared.transport.EurekaHttpResponse.anEurekaHttpResponse;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
@@ -93,7 +90,7 @@ public class EurekaHttpClientsTest {
 
     private final InstanceInfoGenerator instanceGen = InstanceInfoGenerator.newBuilder(2, 1).build();
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
         clientConfig = mock(EurekaClientConfig.class);
         transportConfig = mock(EurekaTransportConfig.class);
@@ -120,7 +117,7 @@ public class EurekaHttpClientsTest {
                 ));
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         if (writeServer != null) {
             writeServer.shutdown();

--- a/eureka-client/src/test/java/com/netflix/discovery/shared/transport/decorator/RedirectingEurekaHttpClientTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/shared/transport/decorator/RedirectingEurekaHttpClientTest.java
@@ -25,11 +25,11 @@ import com.netflix.discovery.shared.resolver.EurekaEndpoint;
 import com.netflix.discovery.shared.transport.EurekaHttpClient;
 import com.netflix.discovery.shared.transport.TransportClientFactory;
 import com.netflix.discovery.shared.transport.TransportException;
-import org.junit.Test;
-import org.mockito.Matchers;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
 
 import static com.netflix.discovery.shared.transport.EurekaHttpResponse.anEurekaHttpResponse;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
@@ -50,7 +50,7 @@ public class RedirectingEurekaHttpClientTest {
     private final DnsService dnsService = mock(DnsService.class);
 
     public void setupRedirect() {
-        when(factory.newClient(Matchers.<EurekaEndpoint>anyVararg())).thenReturn(sourceClient, redirectedClient);
+        when(factory.newClient(ArgumentMatchers.<EurekaEndpoint>any())).thenReturn(sourceClient, redirectedClient);
         when(sourceClient.getApplications()).thenReturn(
                 anEurekaHttpResponse(302, Applications.class)
                         .headers(HttpHeaders.LOCATION, "http://another.discovery.test/eureka/v2/apps")
@@ -64,7 +64,7 @@ public class RedirectingEurekaHttpClientTest {
 
     @Test
     public void testNonRedirectedRequestsAreServedByFirstClient() throws Exception {
-        when(factory.newClient(Matchers.<EurekaEndpoint>anyVararg())).thenReturn(sourceClient);
+        when(factory.newClient(ArgumentMatchers.<EurekaEndpoint>any())).thenReturn(sourceClient);
         when(sourceClient.getApplications()).thenReturn(
                 anEurekaHttpResponse(200, new Applications()).type(MediaType.APPLICATION_JSON_TYPE).build()
         );
@@ -72,7 +72,7 @@ public class RedirectingEurekaHttpClientTest {
         RedirectingEurekaHttpClient httpClient = new RedirectingEurekaHttpClient(SERVICE_URL, factory, dnsService);
         httpClient.getApplications();
 
-        verify(factory, times(1)).newClient(Matchers.<EurekaEndpoint>anyVararg());
+        verify(factory, times(1)).newClient(ArgumentMatchers.<EurekaEndpoint>any());
         verify(sourceClient, times(1)).getApplications();
     }
 
@@ -85,7 +85,7 @@ public class RedirectingEurekaHttpClientTest {
         // First call pins client to resolved IP
         httpClient.getApplications();
 
-        verify(factory, times(2)).newClient(Matchers.<EurekaEndpoint>anyVararg());
+        verify(factory, times(2)).newClient(ArgumentMatchers.<EurekaEndpoint>any());
         verify(sourceClient, times(1)).getApplications();
         verify(dnsService, times(1)).resolveIp("another.discovery.test");
         verify(redirectedClient, times(1)).getApplications();
@@ -93,7 +93,7 @@ public class RedirectingEurekaHttpClientTest {
         // Second call goes straight to the same address
         httpClient.getApplications();
 
-        verify(factory, times(2)).newClient(Matchers.<EurekaEndpoint>anyVararg());
+        verify(factory, times(2)).newClient(ArgumentMatchers.<EurekaEndpoint>any());
         verify(sourceClient, times(1)).getApplications();
         verify(dnsService, times(1)).resolveIp("another.discovery.test");
         verify(redirectedClient, times(2)).getApplications();
@@ -123,7 +123,7 @@ public class RedirectingEurekaHttpClientTest {
 
         httpClient.getApplications();
 
-        verify(factory, times(2)).newClient(Matchers.<EurekaEndpoint>anyVararg());
+        verify(factory, times(2)).newClient(ArgumentMatchers.<EurekaEndpoint>any());
         verify(sourceClient, times(1)).getApplications();
         verify(dnsService, times(1)).resolveIp("another.discovery.test");
         verify(redirectedClient, times(1)).getApplications();

--- a/eureka-client/src/test/java/com/netflix/discovery/shared/transport/decorator/SessionedEurekaHttpClientTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/shared/transport/decorator/SessionedEurekaHttpClientTest.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import com.netflix.discovery.shared.transport.EurekaHttpClient;
 import com.netflix.discovery.shared.transport.EurekaHttpClientFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 

--- a/eureka-client/src/test/java/com/netflix/discovery/shared/transport/jersey/JerseyApplicationClientTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/shared/transport/jersey/JerseyApplicationClientTest.java
@@ -23,14 +23,14 @@ import com.netflix.discovery.shared.resolver.DefaultEndpoint;
 import com.netflix.discovery.shared.transport.EurekaHttpClient;
 import com.netflix.discovery.shared.transport.EurekaHttpClientCompatibilityTestSuite;
 import com.netflix.discovery.shared.transport.TransportClientFactory;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 
 public class JerseyApplicationClientTest extends EurekaHttpClientCompatibilityTestSuite {
 
     private JerseyApplicationClient jerseyHttpClient;
 
     @Override
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         if (jerseyHttpClient != null) {
             jerseyHttpClient.shutdown();

--- a/eureka-client/src/test/java/com/netflix/discovery/shared/transport/jersey/UnexpectedContentTypeTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/shared/transport/jersey/UnexpectedContentTypeTest.java
@@ -5,10 +5,10 @@ import com.netflix.appinfo.InstanceInfo;
 import com.netflix.discovery.shared.resolver.DefaultEndpoint;
 import com.netflix.discovery.shared.transport.EurekaHttpResponse;
 import com.netflix.discovery.shared.transport.TransportClientFactory;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
@@ -35,7 +35,7 @@ public class UnexpectedContentTypeTest {
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort().dynamicHttpsPort()); // No-args constructor defaults to port 8080
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         TransportClientFactory clientFactory = JerseyEurekaHttpClientFactory.newBuilder()
                 .withClientName(CLIENT_APP_NAME)
@@ -74,7 +74,7 @@ public class UnexpectedContentTypeTest {
         assertThat(response.getEntity()).as("instance info").isNull();
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         if (jerseyHttpClient != null) {
             jerseyHttpClient.shutdown();

--- a/eureka-client/src/test/java/com/netflix/discovery/util/DeserializerStringCacheTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/util/DeserializerStringCacheTest.java
@@ -6,10 +6,10 @@ import java.util.Arrays;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.netflix.discovery.util.DeserializerStringCache.CacheScope;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/eureka-client/src/test/java/com/netflix/discovery/util/DiscoveryBuildInfoTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/util/DiscoveryBuildInfoTest.java
@@ -1,10 +1,10 @@
 package com.netflix.discovery.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Tomasz Bak

--- a/eureka-client/src/test/java/com/netflix/discovery/util/EurekaEntityFunctionsTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/util/EurekaEntityFunctionsTest.java
@@ -19,8 +19,8 @@ package com.netflix.discovery.util;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.discovery.shared.Application;
 import com.netflix.discovery.shared.Applications;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
@@ -56,7 +56,7 @@ public class EurekaEntityFunctionsTest {
 
         HashSet<String> strings =
                 new HashSet<>(Arrays.asList("baz", "bar", "foo"));
-        Assert.assertEquals(strings,
+        Assertions.assertEquals(strings,
                 EurekaEntityFunctions.selectApplicationNames(applications));
     }
 
@@ -66,7 +66,7 @@ public class EurekaEntityFunctionsTest {
                 InstanceInfo.ActionType.ADDED);
         HashMap<String, InstanceInfo> hashMap = new HashMap<>();
         hashMap.put("foo", application.getByInstanceId("foo"));
-        Assert.assertEquals(hashMap,
+        Assertions.assertEquals(hashMap,
                 EurekaEntityFunctions.selectInstancesMappedById(application));
     }
 
@@ -76,14 +76,14 @@ public class EurekaEntityFunctionsTest {
                 InstanceInfo.ActionType.ADDED);
         Applications applications = createApplications(application);
 
-        Assert.assertNull(EurekaEntityFunctions
+        Assertions.assertNull(EurekaEntityFunctions
                 .selectInstance(new Applications(), "foo"));
-        Assert.assertNull(EurekaEntityFunctions
+        Assertions.assertNull(EurekaEntityFunctions
                 .selectInstance(new Applications(), "foo", "foo"));
 
-        Assert.assertEquals(application.getByInstanceId("foo"),
+        Assertions.assertEquals(application.getByInstanceId("foo"),
                 EurekaEntityFunctions.selectInstance(applications, "foo"));
-        Assert.assertEquals(application.getByInstanceId("foo"),
+        Assertions.assertEquals(application.getByInstanceId("foo"),
                 EurekaEntityFunctions.selectInstance(applications, "foo", "foo"));
     }
 
@@ -94,8 +94,8 @@ public class EurekaEntityFunctionsTest {
         Applications applications = createApplications(application);
         applications.addApplication(application);
 
-        Assert.assertNull(EurekaEntityFunctions.takeFirst(new Applications()));
-        Assert.assertEquals(application.getByInstanceId("foo"),
+        Assertions.assertNull(EurekaEntityFunctions.takeFirst(new Applications()));
+        Assertions.assertEquals(application.getByInstanceId("foo"),
                 EurekaEntityFunctions.takeFirst(applications));
     }
 
@@ -105,7 +105,7 @@ public class EurekaEntityFunctionsTest {
                 InstanceInfo.ActionType.ADDED);
         Applications applications = createApplications(application);
         applications.addApplication(application);
-        Assert.assertEquals(new ArrayList<>(Arrays.asList(
+        Assertions.assertEquals(new ArrayList<>(Arrays.asList(
                 application.getByInstanceId("foo"),
                 application.getByInstanceId("foo"))),
                 EurekaEntityFunctions.selectAll(applications));
@@ -115,7 +115,7 @@ public class EurekaEntityFunctionsTest {
     public void testToApplicationMapIfNotNullReturnMapOfApplication() {
         Application application = createSingleInstanceApp("foo", "foo",
                 InstanceInfo.ActionType.ADDED);
-        Assert.assertEquals(1, EurekaEntityFunctions.toApplicationMap(
+        Assertions.assertEquals(1, EurekaEntityFunctions.toApplicationMap(
                 new ArrayList<>(Arrays.asList(
                         application.getByInstanceId("foo")))).size());
     }
@@ -131,7 +131,7 @@ public class EurekaEntityFunctionsTest {
         Applications applications = createApplications(new Application("foo"),
                 new Application("bar"), new Application("baz"));
 
-        Assert.assertEquals(applications.size(),
+        Assertions.assertEquals(applications.size(),
                 EurekaEntityFunctions.toApplications(hashMap).size());
     }
 
@@ -143,7 +143,7 @@ public class EurekaEntityFunctionsTest {
                 InstanceInfo.ActionType.ADDED).getByInstanceId("bar");
         InstanceInfo instanceInfo3 = createSingleInstanceApp("baz", "baz",
                 InstanceInfo.ActionType.ADDED).getByInstanceId("baz");
-        Assert.assertEquals(3, EurekaEntityFunctions.toApplications(
+        Assertions.assertEquals(3, EurekaEntityFunctions.toApplications(
                 instanceInfo1, instanceInfo2, instanceInfo3).size());
     }
 
@@ -156,7 +156,7 @@ public class EurekaEntityFunctionsTest {
         Applications applications = createApplications();
         applications.addApplication(application1);
         applications.addApplication(application2);
-        Assert.assertEquals(2,
+        Assertions.assertEquals(2,
                 EurekaEntityFunctions.copyApplications(applications).size());
     }
 
@@ -164,7 +164,7 @@ public class EurekaEntityFunctionsTest {
     public void testCopyApplicationIfNotNullReturnApplication() {
         Application application = createSingleInstanceApp("foo", "foo",
                 InstanceInfo.ActionType.ADDED);
-        Assert.assertEquals(1,
+        Assertions.assertEquals(1,
                 EurekaEntityFunctions.copyApplication(application).size());
     }
 
@@ -172,7 +172,7 @@ public class EurekaEntityFunctionsTest {
     public void testCopyInstancesIfNotNullReturnCollectionOfInstanceInfo() {
         Application application = createSingleInstanceApp("foo", "foo",
                 InstanceInfo.ActionType.ADDED);
-        Assert.assertEquals(1,
+        Assertions.assertEquals(1,
                 EurekaEntityFunctions.copyInstances(
                         new ArrayList<>(Arrays.asList(
                                 application.getByInstanceId("foo"))),
@@ -185,7 +185,7 @@ public class EurekaEntityFunctionsTest {
         Application application = createSingleInstanceApp("foo", "foo",
                 InstanceInfo.ActionType.ADDED);
         Applications applications = createApplications(application);
-        Assert.assertEquals(1, EurekaEntityFunctions.mergeApplications(
+        Assertions.assertEquals(1, EurekaEntityFunctions.mergeApplications(
                 applications, applications).size());
     }
 
@@ -200,7 +200,7 @@ public class EurekaEntityFunctionsTest {
                 InstanceInfo.ActionType.ADDED);
         Applications applications2 = createApplications(application2);
 
-        Assert.assertEquals(2, EurekaEntityFunctions.mergeApplications(
+        Assertions.assertEquals(2, EurekaEntityFunctions.mergeApplications(
                 applications1, applications2).size());
     }
 
@@ -208,7 +208,7 @@ public class EurekaEntityFunctionsTest {
     public void testMergeApplicationIfActionTypeAddedReturnApplication() {
         Application application = createSingleInstanceApp("foo", "foo",
                 InstanceInfo.ActionType.ADDED);
-        Assert.assertEquals(application.getInstances(),
+        Assertions.assertEquals(application.getInstances(),
                 EurekaEntityFunctions.mergeApplication(
                         application, application).getInstances());
     }
@@ -217,7 +217,7 @@ public class EurekaEntityFunctionsTest {
     public void testMergeApplicationIfActionTypeModifiedReturnApplication() {
         Application application = createSingleInstanceApp("foo", "foo",
                 InstanceInfo.ActionType.MODIFIED);
-        Assert.assertEquals(application.getInstances(),
+        Assertions.assertEquals(application.getInstances(),
                 EurekaEntityFunctions.mergeApplication(
                         application, application).getInstances());
     }
@@ -227,7 +227,7 @@ public class EurekaEntityFunctionsTest {
         Application application = createSingleInstanceApp("foo", "foo",
                 InstanceInfo.ActionType.DELETED);
 
-        Assert.assertNotEquals(application.getInstances(),
+        Assertions.assertNotEquals(application.getInstances(),
                 EurekaEntityFunctions.mergeApplication(
                         application, application).getInstances());
     }
@@ -237,7 +237,7 @@ public class EurekaEntityFunctionsTest {
         Application application = createSingleInstanceApp("foo", "foo",
                 InstanceInfo.ActionType.ADDED);
         Applications applications = createApplications(application);
-        Assert.assertEquals(1l,
+        Assertions.assertEquals(1l,
                 (long) EurekaEntityFunctions.updateMeta(applications)
                         .getVersion());
     }
@@ -247,7 +247,7 @@ public class EurekaEntityFunctionsTest {
         Application application = createSingleInstanceApp("foo", "foo",
                 InstanceInfo.ActionType.ADDED);
         Applications applications = createApplications(application);
-        Assert.assertEquals(1,
+        Assertions.assertEquals(1,
                 EurekaEntityFunctions.countInstances(applications));
     }
 
@@ -260,15 +260,15 @@ public class EurekaEntityFunctionsTest {
         InstanceInfo instanceInfo4 = createSingleInstanceApp("bar", "bar",
                 InstanceInfo.ActionType.ADDED).getByInstanceId("bar");
 
-        Assert.assertTrue(EurekaEntityFunctions.comparatorByAppNameAndId()
+        Assertions.assertTrue(EurekaEntityFunctions.comparatorByAppNameAndId()
                 .compare(instanceInfo1, instanceInfo2) > 0);
-        Assert.assertTrue(EurekaEntityFunctions.comparatorByAppNameAndId()
+        Assertions.assertTrue(EurekaEntityFunctions.comparatorByAppNameAndId()
                 .compare(instanceInfo3, instanceInfo2) > 0);
-        Assert.assertTrue(EurekaEntityFunctions.comparatorByAppNameAndId()
+        Assertions.assertTrue(EurekaEntityFunctions.comparatorByAppNameAndId()
                 .compare(instanceInfo1, instanceInfo3) < 0);
-        Assert.assertTrue(EurekaEntityFunctions.comparatorByAppNameAndId()
+        Assertions.assertTrue(EurekaEntityFunctions.comparatorByAppNameAndId()
                 .compare(instanceInfo3, instanceInfo4) > 0);
-        Assert.assertTrue(EurekaEntityFunctions.comparatorByAppNameAndId()
+        Assertions.assertTrue(EurekaEntityFunctions.comparatorByAppNameAndId()
                 .compare(instanceInfo3, instanceInfo3) == 0);
     }
 }

--- a/eureka-client/src/test/java/com/netflix/discovery/util/EurekaUtilsTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/util/EurekaUtilsTest.java
@@ -3,8 +3,8 @@ package com.netflix.discovery.util;
 import com.netflix.appinfo.AmazonInfo;
 import com.netflix.appinfo.DataCenterInfo;
 import com.netflix.appinfo.InstanceInfo;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author David Liu
@@ -21,10 +21,10 @@ public class EurekaUtilsTest {
                 })
                 .build();
 
-        Assert.assertFalse(EurekaUtils.isInEc2(instanceInfo1));
+        Assertions.assertFalse(EurekaUtils.isInEc2(instanceInfo1));
 
         InstanceInfo instanceInfo2 = InstanceInfoGenerator.takeOne();
-        Assert.assertTrue(EurekaUtils.isInEc2(instanceInfo2));
+        Assertions.assertTrue(EurekaUtils.isInEc2(instanceInfo2));
     }
 
     @Test
@@ -38,15 +38,15 @@ public class EurekaUtilsTest {
                 })
                 .build();
 
-        Assert.assertFalse(EurekaUtils.isInVpc(instanceInfo1));
+        Assertions.assertFalse(EurekaUtils.isInVpc(instanceInfo1));
 
         InstanceInfo instanceInfo2 = InstanceInfoGenerator.takeOne();
-        Assert.assertFalse(EurekaUtils.isInVpc(instanceInfo2));
+        Assertions.assertFalse(EurekaUtils.isInVpc(instanceInfo2));
 
         InstanceInfo instanceInfo3 = InstanceInfoGenerator.takeOne();
         ((AmazonInfo) instanceInfo3.getDataCenterInfo()).getMetadata()
                 .put(AmazonInfo.MetaDataKey.vpcId.getName(), "vpc-123456");
 
-        Assert.assertTrue(EurekaUtils.isInVpc(instanceInfo3));
+        Assertions.assertTrue(EurekaUtils.isInVpc(instanceInfo3));
     }
 }

--- a/eureka-client/src/test/java/com/netflix/discovery/util/RateLimiterTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/util/RateLimiterTest.java
@@ -16,12 +16,12 @@
 
 package com.netflix.discovery.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Tomasz Bak

--- a/eureka-core-jersey2/build.gradle
+++ b/eureka-core-jersey2/build.gradle
@@ -16,8 +16,9 @@ dependencies {
     }
     // bring in jersey2 compatible eureka-core-jersey2 directly
     testCompile project(':eureka-core-jersey2')
-
-    testCompile "junit:junit:${junit_version}"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_version}"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:${junit_version}"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_version}"
     testCompile "org.mock-server:mockserver-netty:${mockserverVersion}"
     testCompile "org.mockito:mockito-core:${mockitoVersion}"
     testRuntime 'org.slf4j:slf4j-simple:1.7.10'

--- a/eureka-core-jersey2/src/test/java/com/netflix/eureka/transport/Jersey2ReplicationClientTest.java
+++ b/eureka-core-jersey2/src/test/java/com/netflix/eureka/transport/Jersey2ReplicationClientTest.java
@@ -17,18 +17,18 @@ import com.netflix.eureka.cluster.PeerEurekaNode;
 import com.netflix.eureka.resources.ASGResource.ASGStatus;
 import com.netflix.eureka.resources.DefaultServerCodecs;
 import com.netflix.eureka.resources.ServerCodecs;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockserver.client.server.MockServerClient;
 import org.mockserver.junit.MockServerRule;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 import static org.mockserver.model.Header.header;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
@@ -52,14 +52,14 @@ public class Jersey2ReplicationClientTest {
     private final ServerCodecs serverCodecs = new DefaultServerCodecs(config);
     private final InstanceInfo instanceInfo = ClusterSampleData.newInstanceInfo(1);
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         replicationClient = Jersey2ReplicationClient.createReplicationClient(
                 config, serverCodecs, "http://localhost:" + serverMockRule.getHttpPort() + "/eureka/v2"
         );
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         if (serverMockClient != null) {
             serverMockClient.reset();

--- a/eureka-core/build.gradle
+++ b/eureka-core/build.gradle
@@ -15,7 +15,9 @@ dependencies {
     compile "com.fasterxml.woodstox:woodstox-core:${woodstoxVersion}"
 
     testCompile project(':eureka-test-utils')
-    testCompile "junit:junit:${junit_version}"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_version}"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:${junit_version}"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_version}"
     testCompile 'org.mortbay.jetty:jetty:6.1H.22'
     testCompile "org.mock-server:mockserver-netty:${mockserverVersion}"
     testCompile "com.jcraft:jzlib:1.1.3" // netty dependency

--- a/eureka-core/src/test/java/com/netflix/eureka/AbstractTester.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/AbstractTester.java
@@ -27,8 +27,8 @@ import com.netflix.eureka.registry.PeerAwareInstanceRegistryImpl;
 import com.netflix.eureka.resources.DefaultServerCodecs;
 import com.netflix.eureka.resources.ServerCodecs;
 import com.netflix.eureka.test.async.executor.SingleEvent;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -61,7 +61,7 @@ public class AbstractTester {
     protected EurekaClient client;
     protected PeerAwareInstanceRegistryImpl registry;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         ConfigurationManager.getConfigInstance().clearProperty("eureka.remoteRegion.global.appWhiteList");
         ConfigurationManager.getConfigInstance().setProperty("eureka.responseCacheAutoExpirationInSeconds", "10");
@@ -130,7 +130,7 @@ public class AbstractTester {
         return new MockRemoteEurekaServer(0 /* use ephemeral */, remoteRegionApps, remoteRegionAppsDelta);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         for (Pair<String, String> registeredApp : registeredApps) {
             System.out.println("Canceling application: " + registeredApp.first() + " from local registry.");

--- a/eureka-core/src/test/java/com/netflix/eureka/DefaultEurekaServerConfigTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/DefaultEurekaServerConfigTest.java
@@ -4,8 +4,8 @@ import java.util.Map;
 import java.util.Set;
 
 import com.netflix.config.ConfigurationManager;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Nitesh Kant
@@ -25,11 +25,11 @@ public class DefaultEurekaServerConfigTest {
         DefaultEurekaServerConfig config = new DefaultEurekaServerConfig();
         Map<String, String> remoteRegionUrlsWithName = config.getRemoteRegionUrlsWithName();
 
-        Assert.assertEquals("Unexpected remote region url count.", 2, remoteRegionUrlsWithName.size());
-        Assert.assertTrue("Remote region 1 not found.", remoteRegionUrlsWithName.containsKey(region1));
-        Assert.assertTrue("Remote region 2 not found.", remoteRegionUrlsWithName.containsKey(region2));
-        Assert.assertEquals("Unexpected remote region 1 url.", region1url, remoteRegionUrlsWithName.get(region1));
-        Assert.assertEquals("Unexpected remote region 2 url.", region2url, remoteRegionUrlsWithName.get(region2));
+        Assertions.assertEquals(2, remoteRegionUrlsWithName.size(), "Unexpected remote region url count.");
+        Assertions.assertTrue(remoteRegionUrlsWithName.containsKey(region1), "Remote region 1 not found.");
+        Assertions.assertTrue(remoteRegionUrlsWithName.containsKey(region2), "Remote region 2 not found.");
+        Assertions.assertEquals(region1url, remoteRegionUrlsWithName.get(region1), "Unexpected remote region 1 url.");
+        Assertions.assertEquals(region2url, remoteRegionUrlsWithName.get(region2), "Unexpected remote region 2 url.");
 
     }
 
@@ -42,9 +42,9 @@ public class DefaultEurekaServerConfigTest {
         DefaultEurekaServerConfig config = new DefaultEurekaServerConfig();
         Map<String, String> remoteRegionUrlsWithName = config.getRemoteRegionUrlsWithName();
 
-        Assert.assertEquals("Unexpected remote region url count.", 1, remoteRegionUrlsWithName.size());
-        Assert.assertTrue("Remote region 1 not found.", remoteRegionUrlsWithName.containsKey(region1));
-        Assert.assertEquals("Unexpected remote region 1 url.", region1url, remoteRegionUrlsWithName.get(region1));
+        Assertions.assertEquals(1, remoteRegionUrlsWithName.size(), "Unexpected remote region url count.");
+        Assertions.assertTrue(remoteRegionUrlsWithName.containsKey(region1), "Remote region 1 not found.");
+        Assertions.assertEquals(region1url, remoteRegionUrlsWithName.get(region1), "Unexpected remote region 1 url.");
 
     }
 
@@ -54,9 +54,9 @@ public class DefaultEurekaServerConfigTest {
         ConfigurationManager.getConfigInstance().setProperty("eureka.remoteRegion.global.appWhiteList", whitelistApp);
         DefaultEurekaServerConfig config = new DefaultEurekaServerConfig();
         Set<String> globalList = config.getRemoteRegionAppWhitelist(null);
-        Assert.assertNotNull("Global whitelist is null.", globalList);
-        Assert.assertEquals("Global whitelist not as expected.", 1, globalList.size());
-        Assert.assertEquals("Global whitelist not as expected.", whitelistApp, globalList.iterator().next());
+        Assertions.assertNotNull(globalList, "Global whitelist is null.");
+        Assertions.assertEquals(1, globalList.size(), "Global whitelist not as expected.");
+        Assertions.assertEquals(whitelistApp, globalList.iterator().next(), "Global whitelist not as expected.");
     }
 
     @Test
@@ -67,8 +67,8 @@ public class DefaultEurekaServerConfigTest {
         ConfigurationManager.getConfigInstance().setProperty("eureka.remoteRegion.region1.appWhiteList", regionWhiteListApp);
         DefaultEurekaServerConfig config = new DefaultEurekaServerConfig();
         Set<String> regionList = config.getRemoteRegionAppWhitelist(null);
-        Assert.assertNotNull("Region whitelist is null.", regionList);
-        Assert.assertEquals("Region whitelist not as expected.", 1, regionList.size());
-        Assert.assertEquals("Region whitelist not as expected.", regionWhiteListApp, regionList.iterator().next());
+        Assertions.assertNotNull(regionList, "Region whitelist is null.");
+        Assertions.assertEquals(1, regionList.size(), "Region whitelist not as expected.");
+        Assertions.assertEquals(regionWhiteListApp, regionList.iterator().next(), "Region whitelist not as expected.");
     }
 }

--- a/eureka-core/src/test/java/com/netflix/eureka/GzipEncodingEnforcingFilterTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/GzipEncodingEnforcingFilterTest.java
@@ -16,11 +16,11 @@
 
 package com.netflix.eureka;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -32,13 +32,13 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Enumeration;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
 /**
  * @author Kebe Liu
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class GzipEncodingEnforcingFilterTest {
 
     private static final String ACCEPT_ENCODING_HEADER = "Accept-Encoding";
@@ -55,7 +55,7 @@ public class GzipEncodingEnforcingFilterTest {
 
     private GzipEncodingEnforcingFilter filter;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         filter = new GzipEncodingEnforcingFilter();
         filterChain = new FilterChain() {
@@ -71,7 +71,7 @@ public class GzipEncodingEnforcingFilterTest {
         gzipRequest();
         filter.doFilter(request, response, filterChain);
         Enumeration values = filteredRequest.getHeaders(ACCEPT_ENCODING_HEADER);
-        assertEquals("Expected Accept-Encoding null", null, values);
+        assertEquals(null, values, "Expected Accept-Encoding null");
     }
 
     @Test
@@ -83,7 +83,7 @@ public class GzipEncodingEnforcingFilterTest {
         while (values.hasMoreElements()) {
             res = res + values.nextElement() + "\n";
         }
-        assertEquals("Expected Accept-Encoding gzip", "gzip\n", res);
+        assertEquals("gzip\n", res, "Expected Accept-Encoding gzip");
     }
 
     @Test
@@ -110,7 +110,7 @@ public class GzipEncodingEnforcingFilterTest {
         while (values.hasMoreElements()) {
             res = res + values.nextElement() + "\n";
         }
-        assertEquals("Expected Test ok", "ok\n", res);
+        assertEquals("ok\n", res, "Expected Test ok");
     }
 
     private void gzipRequest() {

--- a/eureka-core/src/test/java/com/netflix/eureka/RateLimitingFilterTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/RateLimitingFilterTest.java
@@ -26,13 +26,13 @@ import com.netflix.appinfo.EurekaClientIdentity;
 import com.netflix.appinfo.MyDataCenterInstanceConfig;
 import com.netflix.config.ConfigurationManager;
 import com.netflix.eureka.util.EurekaMonitors;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -42,7 +42,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Tomasz Bak
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class RateLimitingFilterTest {
 
     private static final String FULL_FETCH = "base/apps";
@@ -63,7 +63,7 @@ public class RateLimitingFilterTest {
 
     private RateLimitingFilter filter;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         RateLimitingFilter.reset();
 
@@ -112,7 +112,7 @@ public class RateLimitingFilterTest {
         long rateLimiterCounter = EurekaMonitors.RATE_LIMITED.getCount();
         filter.doFilter(request, response, filterChain);
 
-        assertEquals("Expected rate limiter counter increase", rateLimiterCounter + 1, EurekaMonitors.RATE_LIMITED.getCount());
+        assertEquals(rateLimiterCounter + 1, EurekaMonitors.RATE_LIMITED.getCount(), "Expected rate limiter counter increase");
         verify(response, times(1)).setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
     }
 
@@ -129,7 +129,7 @@ public class RateLimitingFilterTest {
         long rateLimiterCounter = EurekaMonitors.RATE_LIMITED.getCount();
         filter.doFilter(request, response, filterChain);
 
-        assertEquals("Expected rate limiter counter increase", rateLimiterCounter + 1, EurekaMonitors.RATE_LIMITED.getCount());
+        assertEquals(rateLimiterCounter + 1, EurekaMonitors.RATE_LIMITED.getCount(), "Expected rate limiter counter increase");
         verify(response, times(1)).setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
     }
 
@@ -149,7 +149,7 @@ public class RateLimitingFilterTest {
         long rateLimiterCounter = EurekaMonitors.RATE_LIMITED_CANDIDATES.getCount();
         filter.doFilter(request, response, filterChain);
 
-        assertEquals("Expected rate limiter counter increase", rateLimiterCounter + 1, EurekaMonitors.RATE_LIMITED_CANDIDATES.getCount());
+        assertEquals(rateLimiterCounter + 1, EurekaMonitors.RATE_LIMITED_CANDIDATES.getCount(), "Expected rate limiter counter increase");
         // We just test the counter
         verify(response, times(0)).setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
     }

--- a/eureka-core/src/test/java/com/netflix/eureka/RemoteRegionSoftDependencyTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/RemoteRegionSoftDependencyTest.java
@@ -1,9 +1,9 @@
 package com.netflix.eureka;
 
 import com.netflix.eureka.mock.MockRemoteEurekaServer;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.doReturn;
 
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.doReturn;
 public class RemoteRegionSoftDependencyTest extends AbstractTester {
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         doReturn(10).when(serverConfig).getWaitTimeInMsWhenSyncEmpty();
@@ -24,8 +24,8 @@ public class RemoteRegionSoftDependencyTest extends AbstractTester {
 
     @Test
     public void testSoftDepRemoteDown() throws Exception {
-        Assert.assertTrue("Registry access disallowed when remote region is down.", registry.shouldAllowAccess(false));
-        Assert.assertFalse("Registry access allowed when remote region is down.", registry.shouldAllowAccess(true));
+        Assertions.assertTrue(registry.shouldAllowAccess(false), "Registry access disallowed when remote region is down.");
+        Assertions.assertFalse(registry.shouldAllowAccess(true), "Registry access allowed when remote region is down.");
     }
 
     @Override

--- a/eureka-core/src/test/java/com/netflix/eureka/aws/EIPManagerTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/aws/EIPManagerTest.java
@@ -18,15 +18,14 @@ package com.netflix.eureka.aws;
 
 import com.google.common.collect.Lists;
 import com.netflix.discovery.EurekaClientConfig;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -37,7 +36,7 @@ public class EIPManagerTest {
     private EurekaClientConfig config = mock(EurekaClientConfig.class);
     private EIPManager eipManager;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         when(config.shouldUseDnsForFetchingServiceUrls()).thenReturn(Boolean.FALSE);
         eipManager = new EIPManager(null, config, null, null);
@@ -69,12 +68,14 @@ public class EIPManagerTest {
         assertTrue(returnValue.contains("101.202.33.44"));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void shouldThrowExceptionWhenNoElasticNames() {
-        when(config.getRegion()).thenReturn("eu-west-1");
-        List<String> hosts = Lists.newArrayList("example.com", "5.6.7.8");
-        when(config.getEurekaServerServiceUrls(any(String.class))).thenReturn(hosts);
+        assertThrows(RuntimeException.class, () -> {
+            when(config.getRegion()).thenReturn("eu-west-1");
+            List<String> hosts = Lists.newArrayList("example.com", "5.6.7.8");
+            when(config.getEurekaServerServiceUrls(any(String.class))).thenReturn(hosts);
 
-        eipManager.getCandidateEIPs("i-123", "eu-west-1a");
+            eipManager.getCandidateEIPs("i-123", "eu-west-1a");
+        });
     }
 }

--- a/eureka-core/src/test/java/com/netflix/eureka/cluster/JerseyReplicationClientTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/cluster/JerseyReplicationClientTest.java
@@ -17,18 +17,18 @@ import com.netflix.eureka.resources.ASGResource.ASGStatus;
 import com.netflix.eureka.resources.DefaultServerCodecs;
 import com.netflix.eureka.resources.ServerCodecs;
 import com.netflix.eureka.transport.JerseyReplicationClient;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockserver.client.server.MockServerClient;
 import org.mockserver.junit.MockServerRule;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 import static org.mockserver.model.Header.header;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
@@ -52,14 +52,14 @@ public class JerseyReplicationClientTest {
     private final ServerCodecs serverCodecs = new DefaultServerCodecs(config);
     private final InstanceInfo instanceInfo = ClusterSampleData.newInstanceInfo(1);
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         replicationClient = JerseyReplicationClient.createReplicationClient(
                 config, serverCodecs, "http://localhost:" + serverMockRule.getHttpPort() + "/eureka/v2"
         );
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         if (serverMockClient != null) {
             serverMockClient.reset();

--- a/eureka-core/src/test/java/com/netflix/eureka/cluster/PeerEurekaNodeTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/cluster/PeerEurekaNodeTest.java
@@ -14,15 +14,15 @@ import com.netflix.eureka.cluster.TestableHttpReplicationClient.RequestType;
 import com.netflix.eureka.cluster.protocol.ReplicationInstance;
 import com.netflix.eureka.cluster.protocol.ReplicationList;
 import com.netflix.eureka.resources.ASGResource.ASGStatus;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
@@ -42,13 +42,13 @@ public class PeerEurekaNodeTest {
     private final InstanceInfo instanceInfo = ClusterSampleData.newInstanceInfo(1);
     private PeerEurekaNode peerEurekaNode;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         httpReplicationClient.withNetworkStatusCode(200);
         httpReplicationClient.withBatchReply(200);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         if (peerEurekaNode != null) {
             peerEurekaNode.shutDown();

--- a/eureka-core/src/test/java/com/netflix/eureka/cluster/PeerEurekaNodesTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/cluster/PeerEurekaNodesTest.java
@@ -14,13 +14,13 @@ import com.netflix.discovery.shared.transport.ClusterSampleData;
 import com.netflix.eureka.EurekaServerConfig;
 import com.netflix.eureka.registry.PeerAwareInstanceRegistry;
 import com.netflix.eureka.resources.DefaultServerCodecs;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/eureka-core/src/test/java/com/netflix/eureka/cluster/ReplicationTaskProcessorTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/cluster/ReplicationTaskProcessorTest.java
@@ -7,12 +7,12 @@ import com.netflix.discovery.util.InstanceInfoGenerator;
 import com.netflix.eureka.cluster.TestableInstanceReplicationTask.ProcessingState;
 import com.netflix.eureka.registry.PeerAwareInstanceRegistryImpl.Action;
 import com.netflix.eureka.util.batcher.TaskProcessor.ProcessingResult;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static com.netflix.eureka.cluster.TestableInstanceReplicationTask.aReplicationTask;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Tomasz Bak
@@ -23,7 +23,7 @@ public class ReplicationTaskProcessorTest {
 
     private ReplicationTaskProcessor replicationTaskProcessor;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         replicationTaskProcessor = new ReplicationTaskProcessor("peerId#test", replicationClient);
     }

--- a/eureka-core/src/test/java/com/netflix/eureka/cluster/protocol/JacksonEncodingTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/cluster/protocol/JacksonEncodingTest.java
@@ -2,12 +2,11 @@ package com.netflix.eureka.cluster.protocol;
 
 import com.netflix.discovery.converters.EurekaJacksonCodec;
 import com.netflix.discovery.shared.transport.ClusterSampleData;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Tomasz Bak

--- a/eureka-core/src/test/java/com/netflix/eureka/mock/MockRemoteEurekaServer.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/mock/MockRemoteEurekaServer.java
@@ -15,7 +15,7 @@ import com.netflix.discovery.converters.jackson.EurekaJsonJacksonCodec;
 import com.netflix.discovery.shared.Application;
 import com.netflix.discovery.shared.Applications;
 import com.netflix.eureka.*;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.rules.ExternalResource;
 import org.mortbay.jetty.Request;
 import org.mortbay.jetty.Server;
@@ -67,7 +67,7 @@ public class MockRemoteEurekaServer extends ExternalResource {
         try {
             stop();
         } catch (Exception e) {
-            Assert.fail(e.getMessage());
+            Assertions.fail(e.getMessage());
         }
     }
 
@@ -116,13 +116,13 @@ public class MockRemoteEurekaServer extends ExternalResource {
             String authVersion = request.getHeader(AbstractEurekaIdentity.AUTH_VERSION_HEADER_KEY);
             String authId = request.getHeader(AbstractEurekaIdentity.AUTH_ID_HEADER_KEY);
 
-            Assert.assertNotNull(authName);
-            Assert.assertNotNull(authVersion);
-            Assert.assertNotNull(authId);
+            Assertions.assertNotNull(authName);
+            Assertions.assertNotNull(authVersion);
+            Assertions.assertNotNull(authId);
 
-            Assert.assertTrue(!authName.equals(ServerRequestAuthFilter.UNKNOWN));
-            Assert.assertTrue(!authVersion.equals(ServerRequestAuthFilter.UNKNOWN));
-            Assert.assertTrue(!authId.equals(ServerRequestAuthFilter.UNKNOWN));
+            Assertions.assertTrue(!authName.equals(ServerRequestAuthFilter.UNKNOWN));
+            Assertions.assertTrue(!authVersion.equals(ServerRequestAuthFilter.UNKNOWN));
+            Assertions.assertTrue(!authId.equals(ServerRequestAuthFilter.UNKNOWN));
 
             for (FilterHolder filterHolder : this.getFilters()) {
                 filterHolder.getFilter().doFilter(request, response, new FilterChain() {

--- a/eureka-core/src/test/java/com/netflix/eureka/registry/AwsInstanceRegistryTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/registry/AwsInstanceRegistryTest.java
@@ -9,7 +9,7 @@ import com.netflix.discovery.EurekaClient;
 import com.netflix.discovery.EurekaClientConfig;
 import com.netflix.eureka.EurekaServerConfig;
 import com.netflix.eureka.resources.ServerCodecs;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 /**

--- a/eureka-core/src/test/java/com/netflix/eureka/registry/InstanceRegistryTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/registry/InstanceRegistryTest.java
@@ -12,11 +12,11 @@ import com.netflix.discovery.shared.Applications;
 import com.netflix.eureka.AbstractTester;
 import com.netflix.eureka.registry.AbstractInstanceRegistry.CircularQueue;
 import com.netflix.eureka.registry.AbstractInstanceRegistry.EvictionTask;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -27,18 +27,18 @@ public class InstanceRegistryTest extends AbstractTester {
 
     @Test
     public void testSoftDepRemoteUp() throws Exception {
-        Assert.assertTrue("Registry access disallowed when remote region is UP.", registry.shouldAllowAccess(false));
-        Assert.assertTrue("Registry access disallowed when remote region is UP.", registry.shouldAllowAccess(true));
+        Assertions.assertTrue(registry.shouldAllowAccess(false), "Registry access disallowed when remote region is UP.");
+        Assertions.assertTrue(registry.shouldAllowAccess(true), "Registry access disallowed when remote region is UP.");
     }
 
     @Test
     public void testGetAppsFromAllRemoteRegions() throws Exception {
         Applications apps = registry.getApplicationsFromAllRemoteRegions();
         List<Application> registeredApplications = apps.getRegisteredApplications();
-        Assert.assertEquals("Apps size from remote regions do not match", 1, registeredApplications.size());
+        Assertions.assertEquals(1, registeredApplications.size(), "Apps size from remote regions do not match");
         Application app = registeredApplications.iterator().next();
-        Assert.assertEquals("Added app did not return from remote registry", REMOTE_REGION_APP_NAME, app.getName());
-        Assert.assertEquals("Returned app did not have the instance", 1, app.getInstances().size());
+        Assertions.assertEquals(REMOTE_REGION_APP_NAME, app.getName(), "Added app did not return from remote registry");
+        Assertions.assertEquals(1, app.getInstances().size(), "Returned app did not have the instance");
     }
 
     @Test
@@ -47,7 +47,7 @@ public class InstanceRegistryTest extends AbstractTester {
         waitForDeltaToBeRetrieved();
         Applications appDelta = registry.getApplicationDeltasFromMultipleRegions(null);
         List<Application> registeredApplications = appDelta.getRegisteredApplications();
-        Assert.assertEquals("Apps size from remote regions do not match", 2, registeredApplications.size());
+        Assertions.assertEquals(2, registeredApplications.size(), "Apps size from remote regions do not match");
         Application localApplication = null;
         Application remApplication = null;
         for (Application registeredApplication : registeredApplications) {
@@ -58,22 +58,24 @@ public class InstanceRegistryTest extends AbstractTester {
                 remApplication = registeredApplication;
             }
         }
-        Assert.assertNotNull("Did not find local registry app in delta.", localApplication);
-        Assert.assertEquals("Local registry app instance count in delta not as expected.", 1,
-                localApplication.getInstances().size());
-        Assert.assertNotNull("Did not find remote registry app in delta", remApplication);
-        Assert.assertEquals("Remote registry app instance count  in delta not as expected.", 1,
-                remApplication.getInstances().size());
+        Assertions.assertNotNull(localApplication, "Did not find local registry app in delta.");
+        Assertions.assertEquals(1,
+                localApplication.getInstances().size(),
+                "Local registry app instance count in delta not as expected.");
+        Assertions.assertNotNull(remApplication, "Did not find remote registry app in delta");
+        Assertions.assertEquals(1,
+                remApplication.getInstances().size(),
+                "Remote registry app instance count  in delta not as expected.");
     }
 
     @Test
     public void testAppsHashCodeAfterRefresh() throws InterruptedException {
-        Assert.assertEquals("UP_1_", registry.getApplicationsFromAllRemoteRegions().getAppsHashCode());
+        Assertions.assertEquals("UP_1_", registry.getApplicationsFromAllRemoteRegions().getAppsHashCode());
 
         registerInstanceLocally(createLocalInstance(LOCAL_REGION_INSTANCE_2_HOSTNAME));
         waitForDeltaToBeRetrieved();
 
-        Assert.assertEquals("UP_2_", registry.getApplicationsFromAllRemoteRegions().getAppsHashCode());
+        Assertions.assertEquals("UP_2_", registry.getApplicationsFromAllRemoteRegions().getAppsHashCode());
     }
 
     private void waitForDeltaToBeRetrieved() throws InterruptedException {
@@ -95,10 +97,10 @@ public class InstanceRegistryTest extends AbstractTester {
 
         Applications apps = registry.getApplicationsFromLocalRegionOnly();
         List<Application> registeredApplications = apps.getRegisteredApplications();
-        Assert.assertEquals("Apps size from local region do not match", 1, registeredApplications.size());
+        Assertions.assertEquals(1, registeredApplications.size(), "Apps size from local region do not match");
         Application app = registeredApplications.iterator().next();
-        Assert.assertEquals("Added app did not return from local registry", LOCAL_REGION_APP_NAME, app.getName());
-        Assert.assertEquals("Returned app did not have the instance", 1, app.getInstances().size());
+        Assertions.assertEquals(LOCAL_REGION_APP_NAME, app.getName(), "Added app did not return from local registry");
+        Assertions.assertEquals(1, app.getInstances().size(), "Returned app did not have the instance");
     }
 
     @Test
@@ -108,7 +110,7 @@ public class InstanceRegistryTest extends AbstractTester {
 
         Applications apps = registry.getApplicationsFromAllRemoteRegions();
         List<Application> registeredApplications = apps.getRegisteredApplications();
-        Assert.assertEquals("Apps size from both regions do not match", 2, registeredApplications.size());
+        Assertions.assertEquals(2, registeredApplications.size(), "Apps size from both regions do not match");
         Application locaApplication = null;
         Application remApplication = null;
         for (Application registeredApplication : registeredApplications) {
@@ -119,12 +121,14 @@ public class InstanceRegistryTest extends AbstractTester {
                 remApplication = registeredApplication;
             }
         }
-        Assert.assertNotNull("Did not find local registry app", locaApplication);
-        Assert.assertEquals("Local registry app instance count not as expected.", 1,
-                locaApplication.getInstances().size());
-        Assert.assertNotNull("Did not find remote registry app", remApplication);
-        Assert.assertEquals("Remote registry app instance count not as expected.", 2,
-                remApplication.getInstances().size());
+        Assertions.assertNotNull(locaApplication, "Did not find local registry app");
+        Assertions.assertEquals(1,
+                locaApplication.getInstances().size(),
+                "Local registry app instance count not as expected.");
+        Assertions.assertNotNull(remApplication, "Did not find remote registry app");
+        Assertions.assertEquals(2,
+                remApplication.getInstances().size(),
+                "Remote registry app instance count not as expected.");
 
     }
 
@@ -278,42 +282,42 @@ public class InstanceRegistryTest extends AbstractTester {
     public void testCircularQueue() throws Exception {
         CircularQueue<Integer> queue = new CircularQueue<>(5);
 
-        Assert.assertEquals(0, queue.size());
-        Assert.assertNull(queue.peek());
-        Assert.assertEquals(Collections.emptyList(), new ArrayList<>(queue));
+        Assertions.assertEquals(0, queue.size());
+        Assertions.assertNull(queue.peek());
+        Assertions.assertEquals(Collections.emptyList(), new ArrayList<>(queue));
 
         queue.add(1);
         queue.add(2);
         queue.add(3);
         queue.add(4);
 
-        Assert.assertEquals(4, queue.size());
-        Assert.assertEquals(Arrays.asList(1, 2, 3, 4), new ArrayList<>(queue));
+        Assertions.assertEquals(4, queue.size());
+        Assertions.assertEquals(Arrays.asList(1, 2, 3, 4), new ArrayList<>(queue));
 
         queue.offer(5);
 
-        Assert.assertEquals(5, queue.size());
-        Assert.assertEquals(Arrays.asList(1, 2, 3, 4, 5), new ArrayList<>(queue));
+        Assertions.assertEquals(5, queue.size());
+        Assertions.assertEquals(Arrays.asList(1, 2, 3, 4, 5), new ArrayList<>(queue));
 
         queue.offer(6);
 
-        Assert.assertEquals(5, queue.size());
-        Assert.assertEquals(Arrays.asList(2, 3, 4, 5, 6), new ArrayList<>(queue));
+        Assertions.assertEquals(5, queue.size());
+        Assertions.assertEquals(Arrays.asList(2, 3, 4, 5, 6), new ArrayList<>(queue));
 
         Integer poll = queue.poll();
 
-        Assert.assertEquals(4, queue.size());
-        Assert.assertEquals((Object) 2, poll);
-        Assert.assertEquals(Arrays.asList(3, 4, 5, 6), new ArrayList<>(queue));
+        Assertions.assertEquals(4, queue.size());
+        Assertions.assertEquals((Object) 2, poll);
+        Assertions.assertEquals(Arrays.asList(3, 4, 5, 6), new ArrayList<>(queue));
 
         queue.add(7);
 
-        Assert.assertEquals(5, queue.size());
-        Assert.assertEquals(Arrays.asList(3, 4, 5, 6, 7), new ArrayList<>(queue));
+        Assertions.assertEquals(5, queue.size());
+        Assertions.assertEquals(Arrays.asList(3, 4, 5, 6, 7), new ArrayList<>(queue));
 
         queue.clear();
 
-        Assert.assertEquals(0, queue.size());
-        Assert.assertEquals(Collections.emptyList(), new ArrayList<>(queue));
+        Assertions.assertEquals(0, queue.size());
+        Assertions.assertEquals(Collections.emptyList(), new ArrayList<>(queue));
     }
 }

--- a/eureka-core/src/test/java/com/netflix/eureka/registry/ResponseCacheTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/registry/ResponseCacheTest.java
@@ -7,9 +7,9 @@ import com.netflix.eureka.DefaultEurekaServerConfig;
 import com.netflix.eureka.EurekaServerConfig;
 import com.netflix.eureka.Version;
 import com.netflix.eureka.resources.DefaultServerCodecs;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
@@ -24,7 +24,7 @@ public class ResponseCacheTest extends AbstractTester {
     private PeerAwareInstanceRegistry testRegistry;
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         // create a new registry that is sync'ed up with the default registry in the AbstractTester,
@@ -48,10 +48,10 @@ public class ResponseCacheTest extends AbstractTester {
         Key key = new Key(Key.EntityType.Application, REMOTE_REGION_APP_NAME,
                 Key.KeyType.JSON, Version.V1, EurekaAccept.full);
         String response = cache.get(key, false);
-        Assert.assertNotNull("Cache get returned null.", response);
+        Assertions.assertNotNull(response, "Cache get returned null.");
 
         testRegistry.cancel(REMOTE_REGION_APP_NAME, REMOTE_REGION_INSTANCE_1_HOSTNAME, true);
-        Assert.assertNull("Cache after invalidate did not return null for write view.", cache.get(key, true));
+        Assertions.assertNull(cache.get(key, true), "Cache after invalidate did not return null for write view.");
     }
 
     @Test
@@ -63,10 +63,10 @@ public class ResponseCacheTest extends AbstractTester {
                 Key.KeyType.JSON, Version.V1, EurekaAccept.full, new String[]{REMOTE_REGION}
         );
 
-        Assert.assertNotNull("Cache get returned null.", cache.get(key, false));
+        Assertions.assertNotNull(cache.get(key, false), "Cache get returned null.");
 
         testRegistry.cancel(REMOTE_REGION_APP_NAME, REMOTE_REGION_INSTANCE_1_HOSTNAME, true);
-        Assert.assertNull("Cache after invalidate did not return null.", cache.get(key));
+        Assertions.assertNull(cache.get(key), "Cache after invalidate did not return null.");
     }
 
     @Test
@@ -83,12 +83,12 @@ public class ResponseCacheTest extends AbstractTester {
                 Key.KeyType.JSON, Version.V1, EurekaAccept.full, new String[]{REMOTE_REGION}
         );
 
-        Assert.assertNotNull("Cache get returned null.", cache.get(key1, false));
-        Assert.assertNotNull("Cache get returned null.", cache.get(key2, false));
+        Assertions.assertNotNull(cache.get(key1, false), "Cache get returned null.");
+        Assertions.assertNotNull(cache.get(key2, false), "Cache get returned null.");
 
         testRegistry.cancel(REMOTE_REGION_APP_NAME, REMOTE_REGION_INSTANCE_1_HOSTNAME, true);
 
-        Assert.assertNull("Cache after invalidate did not return null.", cache.get(key1, true));
-        Assert.assertNull("Cache after invalidate did not return null.", cache.get(key2, true));
+        Assertions.assertNull(cache.get(key1, true), "Cache after invalidate did not return null.");
+        Assertions.assertNull(cache.get(key2, true), "Cache after invalidate did not return null.");
     }
 }

--- a/eureka-core/src/test/java/com/netflix/eureka/registry/TimeConsumingInstanceRegistryTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/registry/TimeConsumingInstanceRegistryTest.java
@@ -9,8 +9,8 @@ import com.netflix.eureka.test.async.executor.AsyncResult;
 import com.netflix.eureka.test.async.executor.AsyncSequentialExecutor;
 import com.netflix.eureka.test.async.executor.SequentialEvents;
 import com.netflix.eureka.test.async.executor.SingleEvent;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Time consuming test case for {@link InstanceRegistry}.
@@ -157,10 +157,10 @@ public class TimeConsumingInstanceRegistryTest extends AbstractTester {
         AsyncResult<AsyncSequentialExecutor.ResultStatus> remoteRegionAddMoreInstancesResult = executor.run(remoteRegionAddMoreInstancesEvents);
         AsyncResult<AsyncSequentialExecutor.ResultStatus> checkResult = executor.run(checkEvents);
 
-        Assert.assertEquals("Register application and instances failed", AsyncSequentialExecutor.ResultStatus.DONE, registerMyLocalAppAndInstancesResult.getResult());
-        Assert.assertEquals("Show registry status failed", AsyncSequentialExecutor.ResultStatus.DONE, showRegistryStatusEventResult.getResult());
-        Assert.assertEquals("Renew lease did not succeed", AsyncSequentialExecutor.ResultStatus.DONE, renewResult.getResult());
-        Assert.assertEquals("More instances are registered to remote region did not succeed", AsyncSequentialExecutor.ResultStatus.DONE, remoteRegionAddMoreInstancesResult.getResult());
-        Assert.assertEquals("Check failed", AsyncSequentialExecutor.ResultStatus.DONE, checkResult.getResult());
+        Assertions.assertEquals(AsyncSequentialExecutor.ResultStatus.DONE, registerMyLocalAppAndInstancesResult.getResult(), "Register application and instances failed");
+        Assertions.assertEquals(AsyncSequentialExecutor.ResultStatus.DONE, showRegistryStatusEventResult.getResult(), "Show registry status failed");
+        Assertions.assertEquals(AsyncSequentialExecutor.ResultStatus.DONE, renewResult.getResult(), "Renew lease did not succeed");
+        Assertions.assertEquals(AsyncSequentialExecutor.ResultStatus.DONE, remoteRegionAddMoreInstancesResult.getResult(), "More instances are registered to remote region did not succeed");
+        Assertions.assertEquals(AsyncSequentialExecutor.ResultStatus.DONE, checkResult.getResult(), "Check failed");
     }
 }

--- a/eureka-core/src/test/java/com/netflix/eureka/resources/AbstractVIPResourceTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/resources/AbstractVIPResourceTest.java
@@ -11,8 +11,8 @@ import com.netflix.discovery.util.InstanceInfoGenerator;
 import com.netflix.eureka.AbstractTester;
 import com.netflix.eureka.Version;
 import com.netflix.eureka.registry.Key;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -29,7 +29,7 @@ public class AbstractVIPResourceTest extends AbstractTester {
     private Application testApplication;
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         InstanceInfoGenerator instanceInfos = InstanceInfoGenerator.newBuilder(6, 1).build();

--- a/eureka-core/src/test/java/com/netflix/eureka/resources/ApplicationResourceTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/resources/ApplicationResourceTest.java
@@ -13,8 +13,8 @@ import com.netflix.discovery.util.EurekaEntityComparators;
 import com.netflix.discovery.util.InstanceInfoGenerator;
 import com.netflix.eureka.AbstractTester;
 import com.netflix.eureka.Version;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -33,7 +33,7 @@ public class ApplicationResourceTest extends AbstractTester {
     private Application testApplication;
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         InstanceInfoGenerator instanceInfos = InstanceInfoGenerator.newBuilder(6, 1).build();

--- a/eureka-core/src/test/java/com/netflix/eureka/resources/ApplicationsResourceTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/resources/ApplicationsResourceTest.java
@@ -10,8 +10,8 @@ import com.netflix.discovery.shared.Applications;
 import com.netflix.discovery.util.InstanceInfoGenerator;
 import com.netflix.eureka.AbstractTester;
 import com.netflix.eureka.Version;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -27,7 +27,7 @@ public class ApplicationsResourceTest extends AbstractTester {
     private Applications testApplications;
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         InstanceInfoGenerator instanceInfos = InstanceInfoGenerator.newBuilder(20, 6).build();

--- a/eureka-core/src/test/java/com/netflix/eureka/resources/InstanceResourceTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/resources/InstanceResourceTest.java
@@ -6,12 +6,12 @@ import javax.ws.rs.core.Response.Status;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.appinfo.InstanceInfo.InstanceStatus;
 import com.netflix.eureka.AbstractTester;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class InstanceResourceTest extends AbstractTester {
 
@@ -20,7 +20,7 @@ public class InstanceResourceTest extends AbstractTester {
     private InstanceResource instanceResource;
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         applicationResource = new ApplicationResource(testInstanceInfo.getAppName(), serverContext.getServerConfig(), serverContext.getRegistry());

--- a/eureka-core/src/test/java/com/netflix/eureka/resources/PeerReplicationResourceTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/resources/PeerReplicationResourceTest.java
@@ -12,15 +12,15 @@ import com.netflix.eureka.cluster.protocol.ReplicationInstance;
 import com.netflix.eureka.cluster.protocol.ReplicationInstanceResponse;
 import com.netflix.eureka.cluster.protocol.ReplicationList;
 import com.netflix.eureka.cluster.protocol.ReplicationListResponse;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static com.netflix.discovery.shared.transport.ClusterSampleData.newReplicationInstanceOf;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.anyString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -39,7 +39,7 @@ public class PeerReplicationResourceTest {
 
     private final InstanceInfo instanceInfo = ClusterSampleData.newInstanceInfo(0);
 
-    @Before
+    @BeforeEach
     public void setUp() {
         serverContext = mock(EurekaServerContext.class);
         when(serverContext.getServerConfig()).thenReturn(mock(EurekaServerConfig.class));

--- a/eureka-core/src/test/java/com/netflix/eureka/resources/ReplicationConcurrencyTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/resources/ReplicationConcurrencyTest.java
@@ -12,8 +12,8 @@ import com.netflix.eureka.cluster.PeerEurekaNode;
 import com.netflix.eureka.cluster.PeerEurekaNodes;
 import com.netflix.eureka.registry.PeerAwareInstanceRegistry;
 import com.netflix.eureka.registry.PeerAwareInstanceRegistryImpl;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import java.util.Collections;
 
@@ -42,7 +42,7 @@ public class ReplicationConcurrencyTest {
     private InstanceInfo server1Sees;
     private InstanceInfo server2Sees;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         InstanceInfo seed = InstanceInfoGenerator.takeOne();
         id = seed.getId();

--- a/eureka-core/src/test/java/com/netflix/eureka/util/AwsAsgUtilTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/util/AwsAsgUtilTest.java
@@ -12,10 +12,10 @@ import com.netflix.eureka.DefaultEurekaServerConfig;
 import com.netflix.eureka.EurekaServerConfig;
 import com.netflix.eureka.registry.PeerAwareInstanceRegistry;
 import com.netflix.eureka.aws.AwsAsgUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
@@ -33,7 +33,7 @@ public class AwsAsgUtilTest {
     private AwsAsgUtil awsAsgUtil;
     private InstanceInfo instanceInfo;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         ConfigurationManager.getConfigInstance().setProperty("eureka.awsAccessId", "fakeId");
         ConfigurationManager.getConfigInstance().setProperty("eureka.awsSecretKey", "fakeKey");
@@ -58,14 +58,14 @@ public class AwsAsgUtilTest {
         awsAsgUtil = spy(new AwsAsgUtil(serverConfig, clientConfig, registry));
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         ConfigurationManager.getConfigInstance().clear();
     }
 
     @Test
     public void testDefaultAsgStatus() {
-        Assert.assertEquals(true, awsAsgUtil.isASGEnabled(instanceInfo));
+        Assertions.assertEquals(true, awsAsgUtil.isASGEnabled(instanceInfo));
     }
 
     @Test

--- a/eureka-core/src/test/java/com/netflix/eureka/util/StatusUtilTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/util/StatusUtilTest.java
@@ -1,16 +1,12 @@
 package com.netflix.eureka.util;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import org.junit.Test;
 
 import com.netflix.appinfo.ApplicationInfoManager;
 import com.netflix.appinfo.InstanceInfo;
@@ -22,6 +18,7 @@ import com.netflix.eureka.EurekaServerContext;
 import com.netflix.eureka.cluster.PeerEurekaNode;
 import com.netflix.eureka.cluster.PeerEurekaNodes;
 import com.netflix.eureka.registry.PeerAwareInstanceRegistry;
+import org.junit.jupiter.api.Test;
 
 public class StatusUtilTest {
     

--- a/eureka-core/src/test/java/com/netflix/eureka/util/batcher/AcceptorExecutorTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/util/batcher/AcceptorExecutorTest.java
@@ -21,14 +21,14 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import com.netflix.eureka.util.batcher.TaskProcessor.ProcessingResult;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Tomasz Bak
@@ -44,7 +44,7 @@ public class AcceptorExecutorTest {
 
     private AcceptorExecutor<Integer, String> acceptorExecutor;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         acceptorExecutor = new AcceptorExecutor<>(
                 "TEST", MAX_BUFFER_SIZE, WORK_LOAD_SIZE, MAX_BATCHING_DELAY_MS,
@@ -52,7 +52,7 @@ public class AcceptorExecutorTest {
         );
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         acceptorExecutor.shutdown();
     }

--- a/eureka-core/src/test/java/com/netflix/eureka/util/batcher/RecordingProcessor.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/util/batcher/RecordingProcessor.java
@@ -25,7 +25,7 @@ import com.netflix.eureka.util.batcher.TaskProcessor.ProcessingResult;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Tomasz Bak

--- a/eureka-core/src/test/java/com/netflix/eureka/util/batcher/TaskDispatchersTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/util/batcher/TaskDispatchersTest.java
@@ -24,13 +24,13 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
 import com.netflix.eureka.util.batcher.TaskProcessor.ProcessingResult;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Tomasz Bak
@@ -48,7 +48,7 @@ public class TaskDispatchersTest {
 
     private TaskDispatcher<Integer, ProcessingResult> dispatcher;
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         if (dispatcher != null) {
             dispatcher.shutdown();

--- a/eureka-core/src/test/java/com/netflix/eureka/util/batcher/TaskExecutorsTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/util/batcher/TaskExecutorsTest.java
@@ -21,9 +21,9 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 
 import com.netflix.eureka.util.batcher.TaskProcessor.ProcessingResult;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static com.netflix.eureka.util.batcher.RecordingProcessor.permanentErrorTaskHolder;
 import static com.netflix.eureka.util.batcher.RecordingProcessor.successfulTaskHolder;
@@ -49,13 +49,13 @@ public class TaskExecutorsTest {
 
     private TaskExecutors<Integer, ProcessingResult> taskExecutors;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         when(acceptorExecutor.requestWorkItem()).thenReturn(taskQueue);
         when(acceptorExecutor.requestWorkItems()).thenReturn(taskBatchQueue);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         taskExecutors.shutdown();
     }

--- a/eureka-server/src/test/java/com/netflix/eureka/resources/EurekaClientServerRestIntegrationTest.java
+++ b/eureka-server/src/test/java/com/netflix/eureka/resources/EurekaClientServerRestIntegrationTest.java
@@ -26,15 +26,15 @@ import com.netflix.eureka.registry.PeerAwareInstanceRegistryImpl.Action;
 import com.netflix.eureka.transport.JerseyReplicationClient;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.webapp.WebAppContext;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -67,7 +67,7 @@ public class EurekaClientServerRestIntegrationTest {
 
     private static String eurekaServiceUrl;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         injectEurekaConfiguration();
         startServer();
@@ -92,7 +92,7 @@ public class EurekaClientServerRestIntegrationTest {
         );
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() throws Exception {
         removeEurekaConfiguration();
         if (jerseyReplicationClient != null) {

--- a/eureka-test-utils/build.gradle
+++ b/eureka-test-utils/build.gradle
@@ -1,5 +1,8 @@
 dependencies {
     compile project(':eureka-core')
-    compile "junit:junit:${junit_version}"
+    implementation "org.junit.jupiter:junit-jupiter-api:${junit_version}"
+    implementation "org.junit.jupiter:junit-jupiter-params:${junit_version}"
+    implementation "org.hamcrest:hamcrest:2.2"
+    runtimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_version}"
     compile "org.mockito:mockito-core:${mockitoVersion}"
 }

--- a/eureka-test-utils/src/main/java/com/netflix/discovery/shared/transport/EurekaHttpClientCompatibilityTestSuite.java
+++ b/eureka-test-utils/src/main/java/com/netflix/discovery/shared/transport/EurekaHttpClientCompatibilityTestSuite.java
@@ -27,15 +27,15 @@ import com.netflix.appinfo.InstanceInfo.InstanceStatus;
 import com.netflix.discovery.shared.Applications;
 import com.netflix.discovery.util.EurekaEntityComparators;
 import com.netflix.discovery.util.InstanceInfoGenerator;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static com.netflix.discovery.shared.transport.EurekaHttpResponse.anEurekaHttpResponse;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -61,12 +61,12 @@ public abstract class EurekaHttpClientCompatibilityTestSuite {
     protected EurekaHttpClientCompatibilityTestSuite() {
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         httpServer = new SimpleEurekaHttpServer(requestHandler, transportEventListener);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         httpServer.shutdown();
     }

--- a/eureka-test-utils/src/test/java/com/netflix/discovery/shared/transport/SimpleEurekaHttpServerTest.java
+++ b/eureka-test-utils/src/test/java/com/netflix/discovery/shared/transport/SimpleEurekaHttpServerTest.java
@@ -23,7 +23,7 @@ import com.netflix.appinfo.EurekaAccept;
 import com.netflix.discovery.converters.wrappers.CodecWrappers.JacksonJson;
 import com.netflix.discovery.shared.resolver.DefaultEndpoint;
 import com.netflix.discovery.shared.transport.jersey.JerseyEurekaHttpClientFactory;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 
 /**
  * @author Tomasz Bak
@@ -34,7 +34,7 @@ public class SimpleEurekaHttpServerTest extends EurekaHttpClientCompatibilityTes
     private EurekaHttpClient eurekaHttpClient;
 
     @Override
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         httpClientFactory.shutdown();
         super.tearDown();

--- a/eureka-test-utils/src/test/java/com/netflix/discovery/util/InstanceInfoGeneratorTest.java
+++ b/eureka-test-utils/src/test/java/com/netflix/discovery/util/InstanceInfoGeneratorTest.java
@@ -19,11 +19,11 @@ package com.netflix.discovery.util;
 import java.util.Iterator;
 
 import com.netflix.appinfo.InstanceInfo;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Tomasz Bak


### PR DESCRIPTION
👋 This PR will get you most of the way there to JUnit 5 from JUnit 4. We'd just need to migrate `DiscoveryClientResource` and `SimpleEurekaHttpServerResource` which don't have direct analogs in JUnit 5. Shouldn't be very difficult to complete from here, but hopefully this takes away most of the grueling work.

Co-authored-by: Moderne <team@moderne.io>