### PR TITLE
Small improvements of the class RetrayableEurekaHttpClient

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/shared/transport/decorator/RetryableEurekaHttpClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/transport/decorator/RetryableEurekaHttpClient.java
@@ -62,7 +62,7 @@ public class RetryableEurekaHttpClient extends EurekaHttpClientDecorator {
 
     private final String name;
     private final EurekaTransportConfig transportConfig;
-    private final ClusterResolver clusterResolver;
+    private final ClusterResolver<EurekaEndpoint> clusterResolver;
     private final TransportClientFactory clientFactory;
     private final ServerStatusEvaluator serverStatusEvaluator;
     private final int numberOfRetries;
@@ -73,7 +73,7 @@ public class RetryableEurekaHttpClient extends EurekaHttpClientDecorator {
 
     public RetryableEurekaHttpClient(String name,
                                      EurekaTransportConfig transportConfig,
-                                     ClusterResolver clusterResolver,
+                                     ClusterResolver<EurekaEndpoint> clusterResolver,
                                      TransportClientFactory clientFactory,
                                      ServerStatusEvaluator serverStatusEvaluator,
                                      int numberOfRetries) {
@@ -168,18 +168,16 @@ public class RetryableEurekaHttpClient extends EurekaHttpClientDecorator {
         if (threshold > candidateHosts.size()) {
             threshold = candidateHosts.size();
         }
-        if (quarantineSet.isEmpty()) {
-            // no-op
-        } else if (quarantineSet.size() >= threshold) {
+
+        if (quarantineSet.size() >= threshold) {
             logger.debug("Clearing quarantined list of size {}", quarantineSet.size());
             quarantineSet.clear();
         } else {
             List<EurekaEndpoint> remainingHosts = new ArrayList<>(candidateHosts.size());
-            for (EurekaEndpoint endpoint : candidateHosts) {
-                if (!quarantineSet.contains(endpoint)) {
-                    remainingHosts.add(endpoint);
-                }
-            }
+            candidateHosts.forEach(e -> {
+                 if (!quarantineSet.contains(e))
+                     remainingHosts.add(e);
+            });
             candidateHosts = remainingHosts;
         }
 


### PR DESCRIPTION
Just some minor changes on the RetrayableEurekaHttpClient:

1 - added type of the paramater "EurekaEndpoint" for the attribute ClusterResolver of the class; the IDE doesn't display anymore a raw use of that class;
2 - removed an empty if statement in the getHostCandidates() method;
3 - substitution, in the same method as above, of a For loop with forEach, saving 1 one line of code.
