### PR TITLE
Expose updateStatus and updateMetadata in DiscoveryClient

### DIFF
--- a/eureka-client-jersey2/src/main/java/com/netflix/discovery/shared/transport/jersey2/AbstractJersey2EurekaHttpClient.java
+++ b/eureka-client-jersey2/src/main/java/com/netflix/discovery/shared/transport/jersey2/AbstractJersey2EurekaHttpClient.java
@@ -211,8 +211,7 @@ public abstract class AbstractJersey2EurekaHttpClient implements EurekaHttpClien
         try {
             Builder requestBuilder = jerseyClient.target(serviceUrl)
                     .path(urlPath)
-                    .queryParam("key", key)
-                    .queryParam("value", value)
+                    .queryParam(key, value)
                     .request();
             addExtraProperties(requestBuilder);
             addExtraHeaders(requestBuilder);

--- a/eureka-client-jersey2/src/main/java/com/netflix/discovery/shared/transport/jersey2/AbstractJersey2EurekaHttpClient.java
+++ b/eureka-client-jersey2/src/main/java/com/netflix/discovery/shared/transport/jersey2/AbstractJersey2EurekaHttpClient.java
@@ -205,6 +205,30 @@ public abstract class AbstractJersey2EurekaHttpClient implements EurekaHttpClien
     }
 
     @Override
+    public EurekaHttpResponse<Void> updateMetadata(String appName, String id, String key, String value) {
+        String urlPath = "apps/" + appName + '/' + id + "/metadata";
+        Response response = null;
+        try {
+            Builder requestBuilder = jerseyClient.target(serviceUrl)
+                    .path(urlPath)
+                    .queryParam("key", key)
+                    .queryParam("value", value)
+                    .request();
+            addExtraProperties(requestBuilder);
+            addExtraHeaders(requestBuilder);
+            response = requestBuilder.put(Entity.entity("{}", MediaType.APPLICATION_JSON_TYPE)); // Jersey2 refuses to handle PUT with no body
+            return anEurekaHttpResponse(response.getStatus()).headers(headersOf(response)).build();
+        } finally {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Jersey2 HTTP PUT {}/{}; statusCode={}", serviceUrl, urlPath, response == null ? "N/A" : response.getStatus());
+            }
+            if (response != null) {
+                response.close();
+            }
+        }
+    }
+
+    @Override
     public EurekaHttpResponse<Applications> getApplications(String... regions) {
         return getApplicationsInternal("apps/", regions);
     }

--- a/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
@@ -1817,4 +1817,40 @@ public class DiscoveryClient implements EurekaClient {
 
     }
 
+    /**
+     * Update status with the eureka service by making the appropriate REST call.
+     */
+    public boolean updateStatus(InstanceStatus newStatus) throws Throwable {
+        logger.info(PREFIX + "{}: update status...", appPathIdentifier);
+        EurekaHttpResponse<Void> httpResponse;
+        try {
+            httpResponse = eurekaTransport.registrationClient.statusUpdate(instanceInfo.getAppName(), instanceInfo.getId(), newStatus, instanceInfo);
+        } catch (Exception e) {
+            logger.warn(PREFIX + "{} - update status {}", appPathIdentifier, e.getMessage(), e);
+            throw e;
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info(PREFIX + "{} - update status: {}", appPathIdentifier, httpResponse.getStatusCode());
+        }
+        return httpResponse.getStatusCode() == Status.NO_CONTENT.getStatusCode();
+    }
+
+    /**
+     * Update metadata with the eureka service by making the appropriate REST call.
+     */
+    public boolean updateMetadata(String key, String value) throws Throwable {
+        logger.info(PREFIX + "{}: update status...", appPathIdentifier);
+        EurekaHttpResponse<Void> httpResponse;
+        try {
+            httpResponse = eurekaTransport.registrationClient.updateMetadata(instanceInfo.getAppName(), instanceInfo.getId(), key, value);
+        } catch (Exception e) {
+            logger.warn(PREFIX + "{} - update status {}", appPathIdentifier, e.getMessage(), e);
+            throw e;
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info(PREFIX + "{} - update status: {}", appPathIdentifier, httpResponse.getStatusCode());
+        }
+        return httpResponse.getStatusCode() == Status.NO_CONTENT.getStatusCode();
+    }
+
 }

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/transport/EurekaHttpClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/transport/EurekaHttpClient.java
@@ -36,5 +36,7 @@ public interface EurekaHttpClient {
 
     EurekaHttpResponse<InstanceInfo> getInstance(String id);
 
+    EurekaHttpResponse<Void> updateMetadata(String appName, String id, String key, String value);
+
     void shutdown();
 }

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/transport/decorator/EurekaHttpClientDecorator.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/transport/decorator/EurekaHttpClientDecorator.java
@@ -40,7 +40,8 @@ public abstract class EurekaHttpClientDecorator implements EurekaHttpClient {
         GetSecureVip,
         GetApplication,
         GetInstance,
-        GetApplicationInstance
+        GetApplicationInstance,
+        UpdateMetadata,
     }
 
     public interface RequestExecutor<R> {
@@ -95,6 +96,21 @@ public abstract class EurekaHttpClientDecorator implements EurekaHttpClient {
             @Override
             public RequestType getRequestType() {
                 return RequestType.SendHeartBeat;
+            }
+        });
+    }
+
+    @Override
+    public EurekaHttpResponse<Void> updateMetadata(final String appName, final String id, final String key, final String value) {
+        return execute(new RequestExecutor<Void>() {
+            @Override
+            public EurekaHttpResponse<Void> execute(EurekaHttpClient delegate) {
+                return delegate.updateMetadata(appName, id, key, value);
+            }
+
+            @Override
+            public RequestType getRequestType() {
+                return RequestType.UpdateMetadata;
             }
         });
     }

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/transport/jersey/AbstractJerseyEurekaHttpClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/transport/jersey/AbstractJerseyEurekaHttpClient.java
@@ -141,6 +141,29 @@ public abstract class AbstractJerseyEurekaHttpClient implements EurekaHttpClient
     }
 
     @Override
+    public EurekaHttpResponse<Void> updateMetadata(String appName, String id, String key, String value) {
+        String urlPath = "apps/" + appName + '/' + id + "/metadata";
+        ClientResponse response = null;
+        try {
+            Builder requestBuilder = jerseyClient.resource(serviceUrl)
+                    .path(urlPath)
+                    .queryParam("key", key)
+                    .queryParam("value", value)
+                    .getRequestBuilder();
+            addExtraHeaders(requestBuilder);
+            response = requestBuilder.put(ClientResponse.class);
+            return anEurekaHttpResponse(response.getStatus()).headers(headersOf(response)).build();
+        } finally {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Jersey HTTP PUT {}{}; statusCode={}", serviceUrl, urlPath, response == null ? "N/A" : response.getStatus());
+            }
+            if (response != null) {
+                response.close();
+            }
+        }
+    }
+
+    @Override
     public EurekaHttpResponse<Void> deleteStatusOverride(String appName, String id, InstanceInfo info) {
         String urlPath = "apps/" + appName + '/' + id + "/status";
         ClientResponse response = null;

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/transport/jersey/AbstractJerseyEurekaHttpClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/transport/jersey/AbstractJerseyEurekaHttpClient.java
@@ -147,8 +147,7 @@ public abstract class AbstractJerseyEurekaHttpClient implements EurekaHttpClient
         try {
             Builder requestBuilder = jerseyClient.resource(serviceUrl)
                     .path(urlPath)
-                    .queryParam("key", key)
-                    .queryParam("value", value)
+                    .queryParam(key, value)
                     .getRequestBuilder();
             addExtraHeaders(requestBuilder);
             response = requestBuilder.put(ClientResponse.class);

--- a/eureka-core/src/test/java/com/netflix/eureka/cluster/TestableHttpReplicationClient.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/cluster/TestableHttpReplicationClient.java
@@ -143,6 +143,11 @@ public class TestableHttpReplicationClient implements HttpReplicationClient {
     }
 
     @Override
+    public EurekaHttpResponse<Void> updateMetadata(String appName, String id, String key, String value) {
+        throw new IllegalStateException("method not supported");
+    }
+
+    @Override
     public EurekaHttpResponse<InstanceInfo> getInstance(String appName, String id) {
         throw new IllegalStateException("method not supported");
     }
@@ -183,7 +188,7 @@ public class TestableHttpReplicationClient implements HttpReplicationClient {
     public void shutdown() {
     }
 
-    public enum RequestType {Heartbeat, Register, Cancel, StatusUpdate, DeleteStatusOverride, AsgStatusUpdate, Batch}
+    public enum RequestType {Heartbeat, Register, Cancel, StatusUpdate, DeleteStatusOverride, AsgStatusUpdate, Batch, UpdateMetadata}
 
     public static class HandledRequest {
         private final RequestType requestType;


### PR DESCRIPTION
Hello 

Some background:
We use an external tool to manage Eureka Status and Metadata of the service via REST API (i.e. service registered as STARTING, and then external tool update status to UP/OUT_OF_SERVICE + manage some data in Metadata). 
Now, we are going to migrate to a new architure where the service itself will manager its State.
I tried to use `ApplicationInfoManager.getInstance().setInstanceStatus()` and `ApplicationInfoManager.getInstance().registerAppMetadata(metadata)`.
But it does not work for us (maybe because of old eureka server version) or reincarnation of bug https://github.com/Netflix/eureka/issues/1174
Anyway, it is not reliable to continue with this path, so we deciced to use REST API and make requests to server from instance itself. 

Proposal:
It would be very useful to re-use functionality of DiscoveryClient (cause it's already covers eureka server url discovery, retries, metrics etc.).

Would you consider to expose such functionality in DiscoveryClient? 