### PR TITLE
Upgrade xstream-1.4.19 to 1.4.20 for CVE-2022-40151 and CVE-2022-41966.

### DIFF
--- a/eureka-client/build.gradle
+++ b/eureka-client/build.gradle
@@ -7,7 +7,7 @@ configurations.all {
 
 dependencies {
     compile "com.netflix.netflix-commons:netflix-eventbus:0.3.0"
-    compile 'com.thoughtworks.xstream:xstream:1.4.19'
+    compile 'com.thoughtworks.xstream:xstream:1.4.20'
     compile "com.netflix.archaius:archaius-core:${archaiusVersion}"
     compile 'javax.ws.rs:jsr311-api:1.1.1'
     compile "com.netflix.servo:servo-core:${servoVersion}"

--- a/eureka-core/build.gradle
+++ b/eureka-core/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compile "com.amazonaws:aws-java-sdk-sts:${awsVersion}"
     compile "com.amazonaws:aws-java-sdk-route53:${awsVersion}"
     compile "javax.servlet:servlet-api:${servletVersion}"
-    compile 'com.thoughtworks.xstream:xstream:1.4.19'
+    compile 'com.thoughtworks.xstream:xstream:1.4.20'
     compile 'javax.ws.rs:jsr311-api:1.1.1'
 
     // These dependencies are marked 'compileOnly' in the client, but we need them always on the server


### PR DESCRIPTION
https://x-stream.github.io/news.html

December 24, 2022 XStream 1.4.20 released

This maintenance release addresses the security vulnerabilities [CVE-2022-40151](https://x-stream.github.io/CVE-2022-40151.html) and [CVE-2022-41966](https://x-stream.github.io/CVE-2022-41966.html), causing a Denial of Service by raising a stack overflow. It also provides new converters for Optional and Atomic types.