### PR TITLE
Call size method on Application to avoid copying instance info

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
@@ -1171,7 +1171,7 @@ public class DiscoveryClient implements EurekaClient {
         if (logger.isDebugEnabled()) {
             int totInstances = 0;
             for (Application application : getApplications().getRegisteredApplications()) {
-                totInstances += application.getInstancesAsIsFromEureka().size();
+                totInstances += application.size();
             }
             logger.debug("The total number of all instances in the client now is {}", totInstances);
         }
@@ -1275,7 +1275,7 @@ public class DiscoveryClient implements EurekaClient {
                          * We find all instance list from application(The status of instance status is not only the status is UP but also other status)
                          * if instance list is empty, we remove the application.
                          */
-                        if (existingApp.getInstancesAsIsFromEureka().isEmpty()) {
+                        if (existingApp.size() == 0) {
                             applications.removeApplication(existingApp);
                         }
                     }

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/Application.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/Application.java
@@ -187,7 +187,9 @@ public class Application {
      * @return the number of instances in this application
      */
     public int size() {
-        return instances.size();
+        synchronized (instances) {
+            return instances.size();
+        }
     }
 
     /**
@@ -251,6 +253,7 @@ public class Application {
         Collections.shuffle(instanceInfoList, shuffleRandom);
         this.shuffledInstances.set(instanceInfoList);
     }
+
 
     private void removeInstance(InstanceInfo i, boolean markAsDirty) {
         instancesMap.remove(i.getId());


### PR DESCRIPTION
DiscoveryClient called getInstancesAsIsFromEureka in a couple locations to get the number of instances for an application, when Application already has a method for this purpose that doesn't also incur the overhead of defensively copying.

Additionally, fix a concurrency bug in Application.size, as it was accessing the underlying instances field without synchronization.