### PR TITLE
fix "NullPointerException throw by maybeReadTimeOut() that can cause Eureka cluster registration inconsistency"

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/cluster/ReplicationTaskProcessor.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/cluster/ReplicationTaskProcessor.java
@@ -192,14 +192,20 @@ class ReplicationTaskProcessor implements TaskProcessor<ReplicationTask> {
      */
     private static boolean maybeReadTimeOut(Throwable e) {
         do {
-            if (IOException.class.isInstance(e)) {
-            	String message = e.getMessage().toLowerCase();
-            	Matcher matcher = READ_TIME_OUT_PATTERN.matcher(message);
-            	if(matcher.find()) {
-            		return true;
-            	}
+            try {
+                if (IOException.class.isInstance(e)) {
+                    # !!!this line may occurs NullPointerException in some scenarios.
+                    String message = e.getMessage().toLowerCase();
+                    Matcher matcher = READ_TIME_OUT_PATTERN.matcher(message);
+                    if(matcher.find()) {
+                        return true;
+                    }
+                }
+                e = e.getCause();
+            } catch (Exception ex) {
+                logger.error("Unexpected other exception occurs when check if the income param e is socket read time out exception ", ex);
+                return false;
             }
-            e = e.getCause();
         } while (e != null);
         return false;
     }


### PR DESCRIPTION
this commit fix issue:
NullPointerException in maybeReadTimeOut() method can cause Eureka cluster registration inconsistency #1497