### PR TITLE
fix  NullPointerException

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/cluster/ReplicationTaskProcessor.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/cluster/ReplicationTaskProcessor.java
@@ -193,11 +193,13 @@ class ReplicationTaskProcessor implements TaskProcessor<ReplicationTask> {
     private static boolean maybeReadTimeOut(Throwable e) {
         do {
             if (IOException.class.isInstance(e)) {
-            	String message = e.getMessage().toLowerCase();
-            	Matcher matcher = READ_TIME_OUT_PATTERN.matcher(message);
-            	if(matcher.find()) {
-            		return true;
-            	}
+            	String message = e.getMessage();
+                if (message != null) {
+                    Matcher matcher = READ_TIME_OUT_PATTERN.matcher(message.toLowerCase());
+                    if(matcher.find()) {
+                        return true;
+                    }
+                }
             }
             e = e.getCause();
         } while (e != null);


### PR DESCRIPTION
fix "NullPointerException throw by maybeReadTimeOut() that can cause Eureka cluster registration inconsistency"

https://github.com/Netflix/eureka/issues/1497