### PR TITLE
Fix handling null messages during timeout evaluation.

### DIFF
--- a/eureka-client/build.gradle
+++ b/eureka-client/build.gradle
@@ -39,6 +39,6 @@ dependencies {
     testCompile "org.mock-server:mockserver-netty:${mockserverVersion}"
     testCompile "com.netflix.governator:governator:${governatorVersion}"
     testCompile "com.github.tomakehurst:wiremock-jre8:2.25.1"
-    testCompile "org.assertj:assertj-core:3.11.1"
+    testCompile "org.assertj:assertj-core:3.24.2"
     testCompile "javax.servlet:javax.servlet-api:4.0.1"
 }

--- a/eureka-core/build.gradle
+++ b/eureka-core/build.gradle
@@ -21,4 +21,5 @@ dependencies {
     testCompile "com.jcraft:jzlib:1.1.3" // netty dependency
     testCompile "org.mockito:mockito-core:${mockitoVersion}"
     testRuntime 'org.slf4j:slf4j-simple:1.7.10'
+    testCompile "org.assertj:assertj-core:3.24.2"
 }

--- a/eureka-core/src/main/java/com/netflix/eureka/cluster/ReplicationTaskProcessor.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/cluster/ReplicationTaskProcessor.java
@@ -192,8 +192,8 @@ class ReplicationTaskProcessor implements TaskProcessor<ReplicationTask> {
      */
     private static boolean maybeReadTimeOut(Throwable e) {
         do {
-            if (IOException.class.isInstance(e)) {
-            	String message = e.getMessage().toLowerCase();
+            if (e instanceof IOException) {
+                String message = e.getMessage() != null ? e.getMessage().toLowerCase() :  "";
             	Matcher matcher = READ_TIME_OUT_PATTERN.matcher(message);
             	if(matcher.find()) {
             		return true;

--- a/eureka-core/src/test/java/com/netflix/eureka/cluster/ReplicationTaskProcessorTest.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/cluster/ReplicationTaskProcessorTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import static com.netflix.eureka.cluster.TestableInstanceReplicationTask.aReplicationTask;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * @author Tomasz Bak
@@ -81,7 +82,7 @@ public class ReplicationTaskProcessorTest {
         assertThat(status, is(ProcessingResult.Congestion));
         assertThat(task.getProcessingState(), is(ProcessingState.Pending));
     }
-    
+
     @Test
     public void testBatchableTaskNetworkReadTimeOutHandling() throws Exception {
         TestableInstanceReplicationTask task = aReplicationTask().build();
@@ -117,5 +118,14 @@ public class ReplicationTaskProcessorTest {
 
         assertThat(status, is(ProcessingResult.Success));
         assertThat(task.getProcessingState(), is(ProcessingState.Failed));
+    }
+
+    @Test
+    public void testHandlingNullMessagesWhileEvaluatingTimeout() {
+        assertThatCode(() -> {
+            replicationClient.withEmptyMessageException();
+            TestableInstanceReplicationTask task = aReplicationTask().build();
+            replicationTaskProcessor.process(Collections.singletonList(task));
+        }).doesNotThrowAnyException();
     }
 }


### PR DESCRIPTION
We are getting NPEs for [certain scenarios over at Spring Cloud Netflix](https://github.com/spring-cloud/spring-cloud-netflix/issues/4161) due to lack of handling of `null` exception messages. That's what gets logged:

```
java.lang.NullPointerException: Cannot invoke "String.toLowerCase()" because the return value of "java.lang.Throwable.getMessage()" is null
	at com.netflix.eureka.cluster.ReplicationTaskProcessor.maybeReadTimeOut(ReplicationTaskProcessor.java:196) ~[eureka-core-2.0.0.jar:2.0.0]
	at com.netflix.eureka.cluster.ReplicationTaskProcessor.process(ReplicationTaskProcessor.java:95) ~[eureka-core-2.0.0.jar:2.0.0]
	at com.netflix.eureka.util.batcher.TaskExecutors$BatchWorkerRunnable.run(TaskExecutors.java:190) ~[eureka-core-2.0.0.jar:2.0.0]
	at java.base/java.lang.Thread.run(Thread.java:833) ~[na:na]
```
Since I've seen AssertJ was already being used in the project, I have added it to the module where I've made modifications. While at it, have also upgraded the AssertJ version.

If you accept this PR, could you also merge this change into `2.x`?