### PR TITLE
Add basic auth headers if userinfo present.

### DIFF
--- a/eureka-client-jersey3/src/main/java/com/netflix/discovery/shared/transport/jersey3/AbstractJersey3EurekaHttpClient.java
+++ b/eureka-client-jersey3/src/main/java/com/netflix/discovery/shared/transport/jersey3/AbstractJersey3EurekaHttpClient.java
@@ -79,6 +79,10 @@ public abstract class AbstractJersey3EurekaHttpClient implements EurekaHttpClien
         }
         this.userName = localUserName;
         this.password = localPassword;
+        if (userName != null) {
+            HttpAuthenticationFeature basicAuth = HttpAuthenticationFeature.basic(userName, password);
+            this.jerseyClient.register(basicAuth);
+        }
     }
 
     @Override

--- a/eureka-client-jersey3/src/main/java/com/netflix/discovery/shared/transport/jersey3/EurekaJersey3ClientImpl.java
+++ b/eureka-client-jersey3/src/main/java/com/netflix/discovery/shared/transport/jersey3/EurekaJersey3ClientImpl.java
@@ -54,10 +54,9 @@ public class EurekaJersey3ClientImpl implements EurekaJersey3Client {
 
     private static final String PROTOCOL = "https";
     private static final String PROTOCOL_SCHEME = "SSL";
-    private static final int HTTPS_PORT = 443;
     private static final String KEYSTORE_TYPE = "JKS";
 
-    private final Client apacheHttpClient;
+    private final Client jerseyClient;
     
     private final ConnectionCleanerTask connectionCleanerTask;
 
@@ -91,7 +90,7 @@ public class EurekaJersey3ClientImpl implements EurekaJersey3Client {
             jerseyClientConfig.connectorProvider(new ApacheConnectorProvider());
             jerseyClientConfig.property(ClientProperties.CONNECT_TIMEOUT, connectionTimeout);
             jerseyClientConfig.property(ClientProperties.READ_TIMEOUT, readTimeout);
-            apacheHttpClient = ClientBuilder.newClient(jerseyClientConfig);
+            jerseyClient = ClientBuilder.newClient(jerseyClientConfig);
             connectionCleanerTask = new ConnectionCleanerTask(connectionIdleTimeout); 
             eurekaConnCleaner.scheduleWithFixedDelay(
                     connectionCleanerTask, HTTP_CONNECTION_CLEANER_INTERVAL_MS,
@@ -104,7 +103,7 @@ public class EurekaJersey3ClientImpl implements EurekaJersey3Client {
 
     @Override
     public Client getClient() {
-        return apacheHttpClient;
+        return jerseyClient;
     }
 
     /**
@@ -117,8 +116,8 @@ public class EurekaJersey3ClientImpl implements EurekaJersey3Client {
             eurekaConnCleaner.execute(connectionCleanerTask);
             eurekaConnCleaner.shutdown();
         }
-        if (apacheHttpClient != null) {
-            apacheHttpClient.close();
+        if (jerseyClient != null) {
+            jerseyClient.close();
         }
     }
 
@@ -344,7 +343,7 @@ public class EurekaJersey3ClientImpl implements EurekaJersey3Client {
         public void run() {
             Stopwatch start = executionTimeStats.start();
             try {
-                HttpClientConnectionManager cm = (HttpClientConnectionManager) apacheHttpClient
+                HttpClientConnectionManager cm = (HttpClientConnectionManager) jerseyClient
                         .getConfiguration()
                         .getProperty(ApacheClientProperties.CONNECTION_MANAGER);
                 cm.closeIdleConnections(connectionIdleTimeout, TimeUnit.SECONDS);

--- a/eureka-client-jersey3/src/test/java/com/netflix/discovery/shared/transport/jersey3/AbstractJersey3EurekaHttpClientTest.java
+++ b/eureka-client-jersey3/src/test/java/com/netflix/discovery/shared/transport/jersey3/AbstractJersey3EurekaHttpClientTest.java
@@ -45,9 +45,6 @@ public class AbstractJersey3EurekaHttpClientTest extends EurekaHttpClientCompati
     @Override
     protected EurekaHttpClient getEurekaHttpClient(URI serviceURI) {
         Jersey3ApplicationClientFactoryBuilder factoryBuilder = Jersey3ApplicationClientFactory.newBuilder();
-        if (serviceURI.getUserInfo() != null) {
-            factoryBuilder.withFeature(HttpAuthenticationFeature.basicBuilder().build());
-        }
         TransportClientFactory clientFactory = factoryBuilder.build();
         jerseyHttpClient = (AbstractJersey3EurekaHttpClient) clientFactory.newClient(new DefaultEndpoint(serviceURI.toString()));
         return jerseyHttpClient;


### PR DESCRIPTION
In Eureka `1.x` this is being done under the hood by Apache with `RequestTargetAuthentication`, added by the `DefaultHttpClient`, that is created through [this call](https://github.com/Netflix/eureka/blob/efc1cf6017f13f5f2491838bde894630a37dfd75/eureka-client/src/main/java/com/netflix/discovery/shared/transport/jersey/EurekaJerseyClientImpl.java#L52). 

This fixes https://github.com/spring-cloud/spring-cloud-netflix/issues/4161.

Additionally, I've renamed the client variable, as we no longer use the Apache Jersey Client and have removed unused constant.