### PR TITLE
Add support for EIPs associated with secondary ENIs

### DIFF
--- a/eureka-client/src/main/java/com/netflix/appinfo/AmazonInfo.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/AmazonInfo.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -63,6 +64,13 @@ public class AmazonInfo implements DataCenterInfo, UniqueIdentifier {
         availabilityZone("availability-zone", "placement/"),
         publicHostname("public-hostname"),
         publicIpv4("public-ipv4"),
+        macs("macs", "network/interfaces/"), // macs declared above public-ipv4s so will be found before publicIpv4s (where it is needed)
+        publicIpv4s("public-ipv4s", "network/interfaces/macs/") {
+            @Override
+            public URL getURL(String prepend, String mac) throws MalformedURLException {
+                return new URL(AWS_METADATA_URL + this.path + mac + "/" + this.name);
+            }
+        },
         ipv6("ipv6"),
         spotTerminationTime("termination-time", "spot/"),
         spotInstanceAction("instance-action", "spot/"),
@@ -200,10 +208,27 @@ public class AmazonInfo implements DataCenterInfo, UniqueIdentifier {
                 int numOfRetries = config.getNumRetries();
                 while (numOfRetries-- > 0) {
                     try {
+                        if (key == MetaDataKey.publicIpv4s) {
+                            // macs should be read before publicIpv4s due to declaration order
+                            String[] macs = result.metadata.get(MetaDataKey.macs.getName()).split("\n");
+                            for (String mac : macs) {
+                                URL url = key.getURL(null, mac);
+                                String publicIpv4s = AmazonInfoUtils.readEc2MetadataUrl(key, url, config.getConnectTimeout(), config.getReadTimeout());
+
+                                if (publicIpv4s != null) {
+                                    // only support registering the first found public IPv4 address
+                                    result.metadata.put(key.getName(), publicIpv4s.split("\n")[0]);
+                                    break;
+                                }
+                            }
+                            break;
+                        }
+
                         String mac = null;
                         if (key == MetaDataKey.vpcId) {
                             mac = result.metadata.get(MetaDataKey.mac.getName());  // mac should be read before vpcId due to declaration order
                         }
+
                         URL url = key.getURL(null, mac);
                         String value = AmazonInfoUtils.readEc2MetadataUrl(key, url, config.getConnectTimeout(), config.getReadTimeout());
                         if (value != null) {

--- a/eureka-client/src/main/java/com/netflix/appinfo/CloudInstanceConfig.java
+++ b/eureka-client/src/main/java/com/netflix/appinfo/CloudInstanceConfig.java
@@ -137,6 +137,12 @@ public class CloudInstanceConfig extends PropertiesInstanceConfig implements Ref
     }
     private String getPublicIpv4Addr() {
         String publicIpv4Addr = amazonInfoHolder.get().get(MetaDataKey.publicIpv4);
+        if (publicIpv4Addr == null) {
+            // publicIpv4s is named as a plural to not conflict with the existing publicIpv4 key. In AmazonInfo.java,
+            // we filter out for the first found IPv4 address in any of the network interface IMDS keys. If it exists,
+            // the value for MetaDataKey.publicIpv4s will always be a string with at most 1 public IPv4 address.
+            publicIpv4Addr = amazonInfoHolder.get().get(MetaDataKey.publicIpv4s);
+        }
         return publicIpv4Addr == null ? super.getIpAddress() : publicIpv4Addr;
     }
 


### PR DESCRIPTION
Currently, Eureka client only supports registering EIPs that are directly associated to an instance and available via the root `public-ipv4` IMDS key. This PR adds support to register an EIP that is attached via a secondary ENI. Due to the complexities of discovering and registering multiple public IPs for a single instance, we only register the first found public IP address. If an instance has both an EIP directly associated and and EIP associated via an ENI, the directly associated EIP will be registered. If the instance only has a EIP(s) associated via a ENI(s), the first found EIP will be registered. Additional use cases (i.e., registering multiple public IPv4 addresses) will not be supported.