### PR TITLE
Add debug log for sending registry information in Eureka server

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/resources/ApplicationsResource.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/resources/ApplicationsResource.java
@@ -43,6 +43,8 @@ import com.netflix.eureka.registry.Key.KeyType;
 import com.netflix.eureka.registry.ResponseCacheImpl;
 import com.netflix.eureka.registry.Key;
 import com.netflix.eureka.util.EurekaMonitors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A <em>jersey</em> resource that handles request related to all
@@ -54,6 +56,7 @@ import com.netflix.eureka.util.EurekaMonitors;
 @Path("/{version}/apps")
 @Produces({"application/xml", "application/json"})
 public class ApplicationsResource {
+    private static final Logger logger = LoggerFactory.getLogger(ApplicationsResource.class);
     private static final String HEADER_ACCEPT = "Accept";
     private static final String HEADER_ACCEPT_ENCODING = "Accept-Encoding";
     private static final String HEADER_CONTENT_ENCODING = "Content-Encoding";
@@ -161,6 +164,7 @@ public class ApplicationsResource {
                     .build();
         }
         CurrentRequestVersion.remove();
+        logger.debug("Sent registry information to client.");
         return response;
     }
 


### PR DESCRIPTION
## Description

Add logs for debugging on the side that sends the registry information.


## Background

Sometimes when I give a setting like `eureka.client.registry-fetch-interval-seconds`, I want to know that it works.

On the Eureka client, it displays the message `Getting all instance registry info from the eureka server`.

But not on the server.

And it's not easy to find the corresponding code on the client.

**Corresponding class and method name**

| client | server |
| --- | --- |
| `DiscoveryClient.fetchRegistry(..)` | `ApplicationsResource.getContainers(..)` |


If we had a single line of log, it would have been much easier to figure this out.

## Purpose



For debugging, to know where and when Registry information was returned.

To know when the Eureka server sent registry information and which class is responsible for that.

We expect this log to be informative for open source contributors as well.