### PR TITLE
fix(jersey3): Fix issue: server will not reregister after peer server restarts

### DIFF
--- a/eureka-client-jersey3/src/main/java/com/netflix/discovery/shared/transport/jersey3/AbstractJersey3EurekaHttpClient.java
+++ b/eureka-client-jersey3/src/main/java/com/netflix/discovery/shared/transport/jersey3/AbstractJersey3EurekaHttpClient.java
@@ -147,7 +147,7 @@ public abstract class AbstractJersey3EurekaHttpClient implements EurekaHttpClien
             requestBuilder.accept(MediaType.APPLICATION_JSON_TYPE);
             response = requestBuilder.put(Entity.entity("{}", MediaType.APPLICATION_JSON_TYPE)); // Jersey3 refuses to handle PUT with no body
             EurekaHttpResponseBuilder<InstanceInfo> eurekaResponseBuilder = anEurekaHttpResponse(response.getStatus(), InstanceInfo.class).headers(headersOf(response));
-            if (response.hasEntity()) {
+            if (response.getStatus() != Status.NOT_FOUND.getStatusCode() && response.hasEntity()) {
                 eurekaResponseBuilder.entity(response.readEntity(InstanceInfo.class));
             }
             return eurekaResponseBuilder.build();


### PR DESCRIPTION
When we got a 404, the payload does not contains a json that can be map into an InstanceInfo


more detail with reprductibe example at: https://github.com/spring-cloud/spring-cloud-netflix/issues/4220#issuecomment-1900788126

It's fixing issue: 
* https://github.com/Netflix/eureka/issues/1515 
* and the related issue at spring-cloud-eureka: https://github.com/spring-cloud/spring-cloud-netflix/issues/4220