### PR TITLE
Switch order of literals to prevent NullPointerException

### DIFF
--- a/eureka-core/src/main/java/com/netflix/eureka/aws/AwsAsgUtil.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/aws/AwsAsgUtil.java
@@ -205,7 +205,7 @@ public class AwsAsgUtil implements AsgClient {
      */
     private boolean isAddToLoadBalancerSuspended(String asgAccountId, String asgName) {
         AutoScalingGroup asg;
-        if(asgAccountId == null || asgAccountId.equals(accountId)) {
+        if(asgAccountId == null || accountId.equals(asgAccountId)) {
             asg = retrieveAutoScalingGroup(asgName);
         } else {
             asg = retrieveAutoScalingGroupCrossAccount(asgAccountId, asgName);
@@ -263,7 +263,7 @@ public class AwsAsgUtil implements AsgClient {
     private Credentials initializeStsSession(String asgAccount) {
         AWSSecurityTokenService sts = new AWSSecurityTokenServiceClient(new InstanceProfileCredentialsProvider());
         String region = clientConfig.getRegion();
-        if (!region.equals("us-east-1")) {
+        if (!"us-east-1".equals(region)) {
             sts.setEndpoint("sts." + region + ".amazonaws.com");
         }
 
@@ -301,7 +301,7 @@ public class AwsAsgUtil implements AsgClient {
         );
 
         String region = clientConfig.getRegion();
-        if (!region.equals("us-east-1")) {
+        if (!"us-east-1".equals(region)) {
             autoScalingClient.setEndpoint("autoscaling." + region + ".amazonaws.com");
         }
 

--- a/eureka-core/src/main/java/com/netflix/eureka/registry/RemoteRegionRegistry.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/RemoteRegionRegistry.java
@@ -117,7 +117,7 @@ public class RemoteRegionRegistry implements LookupService<String> {
                 .withMaxTotalConnections(serverConfig.getRemoteRegionTotalConnections())
                 .withConnectionIdleTimeout(serverConfig.getRemoteRegionConnectionIdleTimeoutSeconds());
 
-        if (remoteRegionURL.getProtocol().equals("http")) {
+        if ("http".equals(remoteRegionURL.getProtocol())) {
             clientBuilder.withClientName("Discovery-RemoteRegionClient-" + regionName);
         } else if ("true".equals(System.getProperty("com.netflix.eureka.shouldSSLConnectionsUseSystemSocketFactory"))) {
             clientBuilder.withClientName("Discovery-RemoteRegionSystemSecureClient-" + regionName)


### PR DESCRIPTION
This change defensively switches the order of literals in comparison expressions to ensure that no null pointer exceptions are unexpectedly thrown. Runtime exceptions especially can cause exceptional and unexpected code paths to be taken, and this can result in unexpected behavior. 

Both simple vulnerabilities (like information disclosure) and complex vulnerabilities (like business logic flaws) can take advantage of these unexpected code paths.

Our changes look something like this:

```diff
  String fieldName = header.getFieldName();
  String fieldValue = header.getFieldValue();
- if(fieldName.equals("requestId")) {
+ if("requestId".equals(fieldName)) {
    logRequest(fieldValue);
  }
```

<details>
  <summary>More reading</summary>

  * [https://cwe.mitre.org/data/definitions/476.html](https://cwe.mitre.org/data/definitions/476.html)
  * [https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException](https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException)
  * [https://rules.sonarsource.com/java/RSPEC-1132/](https://rules.sonarsource.com/java/RSPEC-1132/)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:java/switch-literal-first](https://docs.pixee.ai/codemods/java/pixee_java_switch-literal-first)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Java%2Feureka%7C9c78bd85af3e298742ebe9936af0594181b0af69)

<!--{"type":"DRIP","codemod":"pixee:java/switch-literal-first"}-->