### PR TITLE
feat: Block registration for unacceptable IP addresses or subnet

### DIFF
--- a/eureka-core/build.gradle
+++ b/eureka-core/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     api 'jakarta.inject:jakarta.inject-api:2.0.1'
     api 'com.thoughtworks.xstream:xstream:1.4.20'
     implementation 'com.google.guava:guava:33.0.0-jre'
+    implementation 'commons-net:commons-net:3.11.1'
 
     // These dependencies are marked 'compileOnly' in the client, but we need them always on the server
     api "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${jacksonVersion}"

--- a/eureka-core/src/main/java/com/netflix/eureka/DefaultEurekaServerConfig.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/DefaultEurekaServerConfig.java
@@ -707,4 +707,17 @@ public class DefaultEurekaServerConfig implements EurekaServerConfig {
     public int getInitialCapacityOfResponseCache() {
         return configInstance.getIntProperty(namespace + "initialCapacityOfResponseCache", 1000).get();
     }
+
+    @Nullable
+    @Override
+    public Set<String> getBlockingIpAddresses() {
+        DynamicStringProperty blockingIpAddresses = configInstance.getStringProperty(namespace + "blockingIpAddresses", null);
+        if (null == blockingIpAddresses || null == blockingIpAddresses.get()) {
+            return null;
+        } else {
+            String blockingIpAddressesStr = blockingIpAddresses.get();
+            String[] whitelistEntries = blockingIpAddressesStr.split(",");
+            return new HashSet<String>(Arrays.asList(whitelistEntries));
+        }
+    }
 }

--- a/eureka-core/src/main/java/com/netflix/eureka/EurekaServerConfig.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/EurekaServerConfig.java
@@ -705,4 +705,11 @@ public interface EurekaServerConfig {
      * @return the capacity of responseCache.
      */
     int getInitialCapacityOfResponseCache();
+
+    /**
+     *
+     * @return A set of IP addresses that have to be blocked
+     */
+    @Nullable
+    Set<String> getBlockingIpAddresses();
 }

--- a/eureka-tests/src/test/java/com/netflix/eureka/AbstractTester.java
+++ b/eureka-tests/src/test/java/com/netflix/eureka/AbstractTester.java
@@ -37,6 +37,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
@@ -147,6 +148,7 @@ public class AbstractTester {
         remoteRegionAppsDelta.clear();
         ConfigurationManager.getConfigInstance().clearProperty("eureka.remoteRegionUrls");
         ConfigurationManager.getConfigInstance().clearProperty("eureka.deltaRetentionTimerIntervalInMs");
+        ConfigurationManager.getConfigInstance().clearProperty("eureka.blockingIpAddresses");
     }
 
     private static Application createRemoteApps() {
@@ -210,6 +212,12 @@ public class AbstractTester {
         return instanceBuilder.build();
     }
 
+    protected static InstanceInfo createLocalInstanceWithBlockingIpAddresses(String blockingIpAddresses) {
+        ConfigurationManager.getConfigInstance().clearProperty("eureka.blockingIpAddresses");
+        ConfigurationManager.getConfigInstance().setProperty("eureka.blockingIpAddresses", blockingIpAddresses);
+        return createLocalInstance(LOCAL_REGION_INSTANCE_1_HOSTNAME);
+    }
+
     private static AmazonInfo getAmazonInfo(@Nullable String availabilityZone, String instanceHostName) {
         AmazonInfo.Builder azBuilder = AmazonInfo.Builder.newBuilder();
         azBuilder.addMetadata(AmazonInfo.MetaDataKey.availabilityZone, null == availabilityZone ? "us-east-1a" : availabilityZone);
@@ -260,6 +268,10 @@ public class AbstractTester {
         registeredApps.add(new Pair<String, String>(LOCAL_REGION_APP_NAME, remoteInstance.getId()));
     }
 
+    protected void verifyInstanceNotRegistered(String appName, String id) {
+        InstanceInfo instance = registry.getInstanceByAppAndId(appName, id);
+        assertNull(instance);
+    }
 
     /**
      * Send renewal request to Eureka server to renew lease for 45 instances.

--- a/eureka-tests/src/test/java/com/netflix/eureka/registry/InstanceRegistryTest.java
+++ b/eureka-tests/src/test/java/com/netflix/eureka/registry/InstanceRegistryTest.java
@@ -316,4 +316,19 @@ public class InstanceRegistryTest extends AbstractTester {
         Assert.assertEquals(0, queue.size());
         Assert.assertEquals(Collections.emptyList(), new ArrayList<>(queue));
     }
+
+    @Test
+    public void testBlockingSpecificIpAddress() {
+        InstanceInfo blockedInstance = createLocalInstanceWithBlockingIpAddresses("10.10.101.1,192.168.0.1/32");
+        registry.register(blockedInstance, 10000000, false);
+        verifyInstanceNotRegistered(blockedInstance.getAppName(), blockedInstance.getId());
+    }
+
+    @Test
+    public void testBlockingIpAddressInSubnet() {
+        InstanceInfo blockedInstance = createLocalInstanceWithBlockingIpAddresses("10.10.101.0/24");
+        registry.register(blockedInstance, 10000000, false);
+        verifyInstanceNotRegistered(blockedInstance.getAppName(), blockedInstance.getId());
+    }
+
 }


### PR DESCRIPTION
The need for a function to block unauthorized registration has emerged and this function has been implemented.

Created a new property called `eureka.blockingIpAddress` to receive a specific IP or subnet, which prevents `AbstractInstanceRegistry#register` behavior if the registrant's IP corresponds to this.
