### PR TITLE
Upgrade Jackson to 2.13.5. Upgrade Woodstox to 6.4.0.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,8 @@ allprojects {
         jetty_version = '11.0.11'
         junit_version = '4.11'
         mockitoVersion = '4.6.1'
-        mockserverVersion = '3.9.2'
+        mockserverVersion = '3.9.17'
+        jaxbVersion = '2.3.1'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -43,9 +43,9 @@ allprojects {
         spectatorVersion = '1.7.3'
         slf4jVersion = '1.7.36'
         archaiusVersion = '0.7.6'
-        jacksonVersion = '2.10.5'
-        jacksonDatabindVersion = '2.10.5.1'
-        woodstoxVersion = '5.2.1'
+        jacksonVersion = '2.13.5'
+        jacksonDatabindVersion = '2.13.5'
+        woodstoxVersion = '6.4.0'
 
         // test deps
         jetty_version = '11.0.11'

--- a/eureka-core-jersey3/build.gradle
+++ b/eureka-core-jersey3/build.gradle
@@ -23,4 +23,5 @@ dependencies {
     testImplementation "org.mock-server:mockserver-netty:${mockserverVersion}"
     testImplementation "org.mockito:mockito-core:${mockitoVersion}"
     testRuntimeOnly 'org.slf4j:slf4j-simple:1.7.10'
+    testRuntimeOnly "javax.xml.bind:jaxb-api:${jaxbVersion}"
 }


### PR DESCRIPTION
Previously used versions contained various vulnerabilities.

Linked to https://github.com/spring-cloud/spring-cloud-netflix/issues/4343.