### PR TITLE
toString() Adjustment for log clarity

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/shared/resolver/DefaultEndpoint.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/resolver/DefaultEndpoint.java
@@ -145,6 +145,6 @@ public class DefaultEndpoint implements EurekaEndpoint {
 
     @Override
     public String toString() {
-        return "DefaultEndpoint{ serviceUrl='" + serviceUrl + '}';
+        return "DefaultEndpoint{ serviceUrl='" + serviceUrl + " '}";
     }
 }


### PR DESCRIPTION
Because the trailing `}` is directly against the URL, and we have `serviceUrl='`, it can be unclear when scanning logs about the actual form of the URL before checking what the logger is doing.

This change ensures that there is a trailing `'` as well, and uses whitespace to prevent misinterpretation from `http://url.com/'}`.