### PR TITLE
fix: Replace static %d placeholders with AtomicInteger in thread factories

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
@@ -354,9 +354,10 @@ public class DiscoveryClient implements EurekaClient {
             // default size of 2 - 1 each for heartbeat and cacheRefresh
             scheduler = Executors.newScheduledThreadPool(2,
                 new ThreadFactory() {
+                    private final AtomicInteger threadNumber = new AtomicInteger(1);
                     @Override
                     public Thread newThread(Runnable r) {
-                        Thread thread = new Thread(r, "DiscoveryClient-%d");
+                        Thread thread = new Thread(r, "DiscoveryClient-" + threadNumber.getAndIncrement());
                         thread.setDaemon(true);
                         return thread;
                     }
@@ -366,9 +367,10 @@ public class DiscoveryClient implements EurekaClient {
                     1, clientConfig.getHeartbeatExecutorThreadPoolSize(), 0, TimeUnit.SECONDS,
                     new SynchronousQueue<Runnable>(),
                 new ThreadFactory() {
+                    private final AtomicInteger threadNumber = new AtomicInteger(1);
                     @Override
                     public Thread newThread(Runnable r) {
-                        Thread thread = new Thread(r, "DiscoveryClient-HeartbeatExecutor-%d");
+                        Thread thread = new Thread(r, "DiscoveryClient-HeartbeatExecutor-" + threadNumber.getAndIncrement());
                         thread.setDaemon(true);
                         return thread;
                     }
@@ -379,9 +381,10 @@ public class DiscoveryClient implements EurekaClient {
                     1, clientConfig.getCacheRefreshExecutorThreadPoolSize(), 0, TimeUnit.SECONDS,
                     new SynchronousQueue<Runnable>(),
                 new ThreadFactory() {
+                    private final AtomicInteger threadNumber = new AtomicInteger(1);
                     @Override
                     public Thread newThread(Runnable r) {
-                        Thread thread = new Thread(r, "DiscoveryClient-CacheRefreshExecutor-%d");
+                        Thread thread = new Thread(r, "DiscoveryClient-CacheRefreshExecutor-" + threadNumber.getAndIncrement());
                         thread.setDaemon(true);
                         return thread;
                     }
@@ -460,7 +463,7 @@ public class DiscoveryClient implements EurekaClient {
     private void scheduleServerEndpointTask(EurekaTransport eurekaTransport,
                                             AbstractDiscoveryClientOptionalArgs args) {
 
-            
+
         Collection<?> additionalFilters = args == null
                 ? Collections.emptyList()
                 : args.additionalFilters;

--- a/eureka-client/src/main/java/com/netflix/discovery/InstanceInfoReplicator.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/InstanceInfoReplicator.java
@@ -12,6 +12,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -45,9 +46,10 @@ class InstanceInfoReplicator implements Runnable {
         this.instanceInfo = instanceInfo;
         this.scheduler = Executors.newScheduledThreadPool(1,
             new ThreadFactory() {
+                private final AtomicInteger threadNumber = new AtomicInteger(1);
                 @Override
                 public Thread newThread(Runnable r) {
-                    Thread thread = new Thread(r, "DiscoveryClient-InstanceInfoReplicator-%d");
+                    Thread thread = new Thread(r, "DiscoveryClient-InstanceInfoReplicator-" + threadNumber.getAndIncrement());
                     thread.setDaemon(true);
                     return thread;
                 }
@@ -95,13 +97,13 @@ class InstanceInfoReplicator implements Runnable {
                     @Override
                     public void run() {
                         logger.debug("Executing on-demand update of local InstanceInfo");
-    
+
                         Future latestPeriodic = scheduledPeriodicRef.get();
                         if (latestPeriodic != null && !latestPeriodic.isDone()) {
                             logger.debug("Canceling the latest scheduled update, it will be rescheduled at the end of on demand update");
                             latestPeriodic.cancel(false);
                         }
-    
+
                         InstanceInfoReplicator.this.run();
                     }
                 });

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/resolver/AsyncResolver.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/resolver/AsyncResolver.java
@@ -15,6 +15,7 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.netflix.discovery.EurekaClientNames.METRIC_RESOLVER_PREFIX;
@@ -109,9 +110,10 @@ public class AsyncResolver<T extends EurekaEndpoint> implements ClosableResolver
             this, AsyncResolver::getLastLoadTimestamp);
 
         this.executorService = Executors.newScheduledThreadPool(1, new ThreadFactory() {
+            private final AtomicInteger threadNumber = new AtomicInteger(1);
             @Override
             public Thread newThread(Runnable r) {
-                Thread thread = new Thread(r, "AsyncResolver-" + name + "-%d");
+                Thread thread = new Thread(r, "AsyncResolver-" + name + "-" + threadNumber.getAndIncrement());
                 thread.setDaemon(true);
                 return thread;
             }
@@ -121,9 +123,10 @@ public class AsyncResolver<T extends EurekaEndpoint> implements ClosableResolver
             1, executorThreadPoolSize, 0, TimeUnit.SECONDS,
             new SynchronousQueue<Runnable>(),  // use direct handoff
             new ThreadFactory() {
+                private final AtomicInteger threadNumber = new AtomicInteger(1);
                 @Override
                 public Thread newThread(Runnable r) {
-                    Thread thread = new Thread(r, "AsyncResolver-" + name + "-executor-%d");
+                    Thread thread = new Thread(r, "AsyncResolver-" + name + "-executor-" + threadNumber.getAndIncrement());
                     thread.setDaemon(true);
                     return thread;
                 }

--- a/eureka-core/src/main/java/com/netflix/eureka/registry/RemoteRegionRegistry.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/registry/RemoteRegionRegistry.java
@@ -29,6 +29,7 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
@@ -191,9 +192,10 @@ public class RemoteRegionRegistry implements LookupService<String> {
 
         scheduler = Executors.newScheduledThreadPool(1,
             new ThreadFactory() {
+                private final AtomicInteger threadNumber = new AtomicInteger(1);
                 @Override
                 public Thread newThread(Runnable r) {
-                    Thread thread = new Thread(r, "Eureka-RemoteRegionCacheRefresher_" + regionName + "-%d");
+                    Thread thread = new Thread(r, "Eureka-RemoteRegionCacheRefresher_" + regionName + "-" + threadNumber.getAndIncrement());
                     thread.setDaemon(true);
                     return thread;
                 }


### PR DESCRIPTION
### Summary  
Resolves thread naming issues caused by removing Guava's `ThreadFactoryBuilder` in #1526. Previously, thread names like `Eureka-Worker-%d` relied on Guava's formatting. This PR replaces `%d` with `AtomicInteger` to generate unique names (e.g., `Eureka-Worker-1`).

### Changes  
- Added `AtomicInteger` to dynamically number threads.  
- Fixed 3-4 instances of thread factories.  