### PR TITLE
Update build.gradle

### DIFF
--- a/eureka-server-governator/build.gradle
+++ b/eureka-server-governator/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compile "com.sun.jersey:jersey-server:${jerseyVersion}"
     compile "com.sun.jersey:jersey-servlet:${jerseyVersion}"
     compile "com.sun.jersey.contribs:jersey-guice:${jerseyVersion}"
-    compile 'org.slf4j:slf4j-log4j12:1.6.1'
+    implementation 'org.slf4j:slf4j-simple:1.7.36'
     runtimeOnly "org.codehaus.jettison:jettison:${jettisonVersion}"
     providedCompile "javax.servlet:servlet-api:${servletVersion}"
 


### PR DESCRIPTION
The slf4j-log4j12:1.6.1 library is linked to Log4j 1.x.

Log4j version 1.x contains serious vulnerabilities, most notably the possibility of remote command execution (RCE) by serializing/deserializing untrusted data in components such as SocketServer, JMSSink, or when reading logs from an external source.

This version may allow serialized objects to be received over the network or files, which could lead to exploitation.

Simply put:

Using slf4j-log4j12:1.6.1 exposes you to serious vulnerabilities such as RCE due to mishandling of untrusted data during logging or networking operations.