### PR TITLE
Update build.gradle

### DIFF
--- a/eureka-server-governator/build.gradle
+++ b/eureka-server-governator/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compile "com.sun.jersey:jersey-server:${jerseyVersion}"
     compile "com.sun.jersey:jersey-servlet:${jerseyVersion}"
     compile "com.sun.jersey.contribs:jersey-guice:${jerseyVersion}"
-    compile 'org.slf4j:slf4j-log4j12:1.6.1'
+    compile 'org.slf4j:slf4j-log4j12:1.7.26'
     runtimeOnly "org.codehaus.jettison:jettison:${jettisonVersion}"
     providedCompile "javax.servlet:servlet-api:${servletVersion}"
 


### PR DESCRIPTION
Upgrade org.slf4j:slf4j-ext to version 1.7.26, 1.8.0-beta2 or higher.

https://security.snyk.io/vuln/SNYK-JAVA-ORGSLF4J-32138 https://www.slf4j.org/log4shell.html