### PR TITLE
[ISSUE-1588] Fix dependency resolution issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,9 @@ buildscript {
         maven {
             url "https://plugins.gradle.org/m2"
         }
+        maven {
+            url "https://artifactory.appodeal.com/appodeal-public"
+        }
     }
 
     dependencies {
@@ -13,7 +16,7 @@ buildscript {
 
 plugins {
     id 'nebula.netflixoss' version '9.1.0'
-    id 'org.gretty' version '2.1.0'
+    id 'org.gretty' version '3.1.5'
 }
 
 idea {


### PR DESCRIPTION
## Changes
1. Bump `gretty-core` version from 2.1.0 to 3.1.5
2. Add the Appodeal repository for `grgit-core`

### gretty-core
- Version 2.1.0 is missing in the Central repository.
- Version 4.x.y versions may not be compatible with JDK 1.8, so the version is updated to 3.1.5.

### grgit-core
- Version 4.0.2 is hosted on the Appodeal repository.
- Unable to update.

![build](https://github.com/user-attachments/assets/f71c2483-c61b-45fa-9a50-02845938e81d)
