### PR TITLE
Use AWS SDK for Java v2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,9 @@ buildscript {
         maven {
             url "https://plugins.gradle.org/m2"
         }
+        maven {
+            url "https://artifactory.appodeal.com/appodeal-public"
+        }
     }
 
     dependencies {
@@ -13,15 +16,8 @@ buildscript {
 
 plugins {
     id 'nebula.netflixoss' version '9.1.0'
-    id 'org.gretty' version '2.1.0'
+    id 'org.gretty' version '3.1.5'
 }
-
-idea {
-    project {
-        languageLevel = '1.8'
-    }
-}
-
 if (JavaVersion.current().isJava8Compatible()) {
     allprojects {
         tasks.withType(Javadoc) {
@@ -34,7 +30,7 @@ allprojects {
     ext {
         githubProjectName = 'eureka'
 
-        awsVersion = '1.11.277'
+        awsVersion = '2.31.37'
         servletVersion = '2.5'
         jerseyVersion = '1.19.1'
         jettisonVersion = '1.5.4'

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,15 @@ plugins {
     id 'nebula.netflixoss' version '9.1.0'
     id 'org.gretty' version '3.1.5'
 }
+
+idea {
+    project {
+        languageLevel = '1.8'
+    }
+}
+
+
+
 if (JavaVersion.current().isJava8Compatible()) {
     allprojects {
         tasks.withType(Javadoc) {

--- a/eureka-core/build.gradle
+++ b/eureka-core/build.gradle
@@ -1,11 +1,12 @@
 dependencies {
     compile project(':eureka-client')
 
-    compile "com.amazonaws:aws-java-sdk-core:${awsVersion}"
-    compile "com.amazonaws:aws-java-sdk-ec2:${awsVersion}"
-    compile "com.amazonaws:aws-java-sdk-autoscaling:${awsVersion}"
-    compile "com.amazonaws:aws-java-sdk-sts:${awsVersion}"
-    compile "com.amazonaws:aws-java-sdk-route53:${awsVersion}"
+    compile "software.amazon.awssdk:ec2:${awsVersion}"
+    compile "software.amazon.awssdk:autoscaling:${awsVersion}"
+    compile "software.amazon.awssdk:auth:${awsVersion}"
+    compile "software.amazon.awssdk:route53:${awsVersion}"
+    compile "software.amazon.awssdk:sesv2:${awsVersion}"
+    compile "software.amazon.awssdk:sts:${awsVersion}"
     compile "javax.servlet:servlet-api:${servletVersion}"
     compile 'com.thoughtworks.xstream:xstream:1.4.19'
     compile 'javax.ws.rs:jsr311-api:1.1.1'
@@ -20,5 +21,4 @@ dependencies {
     testCompile "org.mock-server:mockserver-netty:${mockserverVersion}"
     testCompile "com.jcraft:jzlib:1.1.3" // netty dependency
     testCompile "org.mockito:mockito-core:${mockitoVersion}"
-    testRuntime 'org.slf4j:slf4j-simple:1.7.10'
 }

--- a/eureka-core/src/main/java/com/netflix/eureka/aws/AwsAsgUtil.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/aws/AwsAsgUtil.java
@@ -89,7 +89,7 @@ public class AwsAsgUtil implements AsgClient {
                     thread.setDaemon(true);
                     return thread;
                 }
-            });
+    });
 
     private ListeningExecutorService listeningCacheReloadExecutor = MoreExecutors.listeningDecorator(cacheReloadExecutor);
 
@@ -106,8 +106,8 @@ public class AwsAsgUtil implements AsgClient {
 
     @Inject
     public AwsAsgUtil(EurekaServerConfig serverConfig,
-                        EurekaClientConfig clientConfig,
-                        InstanceRegistry registry) {
+                      EurekaClientConfig clientConfig,
+                      InstanceRegistry registry) {
         this.serverConfig = serverConfig;
         this.clientConfig = clientConfig;
         this.registry = registry;
@@ -164,7 +164,7 @@ public class AwsAsgUtil implements AsgClient {
                 // period, but no new values will be fetched while disabled.
 
                 logger.info(("'{}' is not cached at the moment and won't be fetched because querying AWS ASGs "
-                                + "has been disabled via the config, returning the fallback value."),
+                        + "has been disabled via the config, returning the fallback value."),
                         cacheKey);
 
                 return true;
@@ -243,8 +243,8 @@ public class AwsAsgUtil implements AsgClient {
         }
         // You can pass one name or a list of names in the request
         DescribeAutoScalingGroupsRequest request = DescribeAutoScalingGroupsRequest.builder()
-                .autoScalingGroupNames(asgName)
-                .build();
+        .autoScalingGroupNames(asgName)
+        .build();
         DescribeAutoScalingGroupsResponse result = awsClient.describeAutoScalingGroups(request);
         List<AutoScalingGroup> asgs = result.autoScalingGroups();
         if (asgs.isEmpty()) {

--- a/eureka-core/src/main/java/com/netflix/eureka/aws/ElasticNetworkInterfaceBinder.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/aws/ElasticNetworkInterfaceBinder.java
@@ -292,22 +292,15 @@ public class ElasticNetworkInterfaceBinder implements AwsBinder {
         String awsAccessId = serverConfig.getAWSAccessId();
         String awsSecretKey = serverConfig.getAWSSecretKey();
 
-        Ec2ClientBuilder ec2ServiceBuilder;
+        final Ec2ClientBuilder ec2ServiceBuilder = Ec2Client.builder()
+                .region(Region.of(clientConfig.getRegion().trim().toLowerCase()));
         if (awsAccessId != null && !awsAccessId.isEmpty() && awsSecretKey != null && !awsSecretKey.isEmpty()) {
             AwsBasicCredentials awsBasicCredentials = AwsBasicCredentials.create(awsAccessId, awsSecretKey);
-            ec2ServiceBuilder = Ec2Client.builder()
-                    .credentialsProvider(StaticCredentialsProvider.create(awsBasicCredentials))
-                    .region(Region.of(clientConfig.getRegion().trim().toLowerCase()));
+            ec2ServiceBuilder.credentialsProvider(StaticCredentialsProvider.create(awsBasicCredentials));
         }
         else {
-            ec2ServiceBuilder = Ec2Client.builder()
-                    .credentialsProvider(InstanceProfileCredentialsProvider.create())
-                    .region(Region.of(clientConfig.getRegion().trim().toLowerCase()));
+            ec2ServiceBuilder.credentialsProvider(InstanceProfileCredentialsProvider.create());
         }
-
-        // String region = clientConfig.getRegion().trim().toLowerCase();
-        // ec2ServiceBuilder.endpointOverride(URI.create("https://ec2." + region + ".amazonaws.com"));
-
         return ec2ServiceBuilder.build();
     }
 

--- a/eureka-core/src/main/java/com/netflix/eureka/aws/Route53Binder.java
+++ b/eureka-core/src/main/java/com/netflix/eureka/aws/Route53Binder.java
@@ -93,18 +93,18 @@ public class Route53Binder implements AwsBinder {
         try {
             doBind();
             timer.schedule(
-                    new TimerTask() {
-                        @Override
-                        public void run() {
-                            try {
-                                doBind();
-                            } catch (Throwable e) {
-                                logger.error("Could not bind to Route53", e);
-                            }
+                new TimerTask() {
+                    @Override
+                    public void run() {
+                        try {
+                            doBind();
+                        } catch (Throwable e) {
+                            logger.error("Could not bind to Route53", e);
                         }
-                    },
-                    serverConfig.getRoute53BindingRetryIntervalMs(),
-                    serverConfig.getRoute53BindingRetryIntervalMs());
+                    }
+                },
+                serverConfig.getRoute53BindingRetryIntervalMs(),
+                serverConfig.getRoute53BindingRetryIntervalMs());
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
@@ -303,16 +303,13 @@ public class Route53Binder implements AwsBinder {
         String awsAccessId = serverConfig.getAWSAccessId();
         String awsSecretKey = serverConfig.getAWSSecretKey();
 
-        Route53ClientBuilder route53ClientBuilder;
+        final Route53ClientBuilder route53ClientBuilder = Route53Client.builder()
+                .region(Region.of(clientConfig.getRegion().trim().toLowerCase()));
         if (awsAccessId != null && !awsAccessId.isEmpty() && awsSecretKey != null && !awsSecretKey.isEmpty()) {
             AwsBasicCredentials awsBasicCredentials = AwsBasicCredentials.create(awsAccessId, awsSecretKey);
-            route53ClientBuilder = Route53Client.builder()
-                    .credentialsProvider(StaticCredentialsProvider.create(awsBasicCredentials))
-                    .region(Region.of(clientConfig.getRegion().trim().toLowerCase()));
+            route53ClientBuilder.credentialsProvider(StaticCredentialsProvider.create(awsBasicCredentials));
         } else {
-            route53ClientBuilder = Route53Client.builder()
-                    .credentialsProvider(InstanceProfileCredentialsProvider.create())
-                    .region(Region.of(clientConfig.getRegion().trim().toLowerCase()));
+            route53ClientBuilder.credentialsProvider(InstanceProfileCredentialsProvider.create());
         }
 
         return route53ClientBuilder.build();

--- a/eureka-core/src/test/java/com/netflix/eureka/test/async/executor/AsyncSequentialExecutor.java
+++ b/eureka-core/src/test/java/com/netflix/eureka/test/async/executor/AsyncSequentialExecutor.java
@@ -3,8 +3,8 @@ package com.netflix.eureka.test.async.executor;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import com.amazonaws.util.CollectionUtils;
 import com.google.common.base.Optional;
+import software.amazon.awssdk.utils.CollectionUtils;
 
 /**
  * Run a sequential events in asynchronous way.


### PR DESCRIPTION
AWS SDK for Java v2 will be used instead of v1.

For applications requiring FIPS endpoints, this sdk uses the env variable AWS_USE_FIPS_ENDPOINT=true and will target the fips endpoints for services instead of standard.
This change also removes hard coding of endpoints for AWS services if region != us-east-1.  If aws_region is set properly in the config, or if AWS_REGION env variable is set, the AWS sdk will target the correct endpoint in the local region if available.

