### PR TITLE
perf: Jackson Codec allocation improvements

### DIFF
--- a/eureka-client/src/main/java/com/netflix/discovery/converters/EurekaJacksonCodec.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/converters/EurekaJacksonCodec.java
@@ -424,6 +424,15 @@ public class EurekaJacksonCodec {
     public static class InstanceInfoDeserializer extends JsonDeserializer<InstanceInfo> {
         private static char[] BUF_AT_CLASS = "@class".toCharArray();
 
+        /** Extract uppercase from current JsonParser cursor. Avoids lambda capture. */
+        private static String toUpperCase(JsonParser jp) {
+            try {
+                return jp.getText().toUpperCase();
+            } catch (IOException e) {
+                throw new RuntimeJsonMappingException(e.getMessage());
+            }
+        }
+
         enum InstanceInfoField {
             HOSTNAME(ELEM_HOST),
             INSTANCE_ID(ELEM_INSTANCE_ID),
@@ -515,14 +524,7 @@ public class EurekaJacksonCodec {
                         break;
                     case APP:
                         builder.setAppNameForDeser(
-                                intern.apply(jp, CacheScope.APPLICATION_SCOPE,
-                                ()->{
-                                    try {
-                                        return jp.getText().toUpperCase();
-                                    } catch (IOException e) {
-                                        throw new RuntimeJsonMappingException(e.getMessage());
-                                    }
-                              }));
+                                intern.apply(jp, CacheScope.APPLICATION_SCOPE, InstanceInfoDeserializer::toUpperCase));
                         break;
                     case IP:
                         builder.setIPAddr(intern.apply(jp));
@@ -590,14 +592,8 @@ public class EurekaJacksonCodec {
                         builder.setHealthCheckUrlsForDeser(null, intern.apply(jp.getText()));
                         break;
                     case APPGROUPNAME:
-                        builder.setAppGroupNameForDeser(intern.apply(jp, CacheScope.GLOBAL_SCOPE, 
-                                ()->{
-                                    try {
-                                        return jp.getText().toUpperCase();
-                                    } catch (IOException e) {
-                                        throw new RuntimeJsonMappingException(e.getMessage());
-                                    }
-                              }));
+                        builder.setAppGroupNameForDeser(
+                                intern.apply(jp, CacheScope.GLOBAL_SCOPE, InstanceInfoDeserializer::toUpperCase));
                         break;
                     case HOMEPAGEURL:
                         builder.setHomePageUrlForDeser(intern.apply(jp.getText()));

--- a/eureka-client/src/main/java/com/netflix/discovery/util/DeserializerStringCache.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/util/DeserializerStringCache.java
@@ -207,11 +207,12 @@ public class DeserializerStringCache implements Function<String, String> {
      * 
      * @param jp
      * @param cacheScope
+     * @param transform optional transform function applied to the parser text on cache miss
      * @return a possibly interned String
      * @throws IOException
      */
-    public String apply(final JsonParser jp, CacheScope cacheScope, Supplier<String> source) throws IOException {
-        parserLookupBuffer.reset(jp, source);
+    public String apply(final JsonParser jp, CacheScope cacheScope, Function<JsonParser, String> transform) throws IOException {
+        parserLookupBuffer.reset(jp, transform);
         int keyLength = parserLookupBuffer.length();
         if (lengthLimit < 0 || keyLength <= lengthLimit) {
             Map<CharBuffer, String> cache = (cacheScope == CacheScope.GLOBAL_SCOPE) ? globalCache : applicationCache;
@@ -360,14 +361,16 @@ public class DeserializerStringCache implements Function<String, String> {
      * Reset before each use to avoid allocations on cache hits.
      */
     private static class MutableArrayCharBuffer implements CharBuffer {
+        private JsonParser jp;
         private char[] source;
         private int offset;
         private int length;
-        private Supplier<String> valueTransform;
+        private Function<JsonParser, String> valueTransform;
         private int variant;
         private int hash;
 
-        void reset(JsonParser jp, Supplier<String> valueTransform) throws IOException {
+        void reset(JsonParser jp, Function<JsonParser, String> valueTransform) throws IOException {
+            this.jp = jp;
             this.source = jp.getTextCharacters();
             this.offset = jp.getTextOffset();
             this.length = jp.getTextLength();
@@ -428,13 +431,13 @@ public class DeserializerStringCache implements Function<String, String> {
 
         @Override
         public String toString() {
-            return valueTransform == null ? new String(this.source, offset, length) : valueTransform.get();
+            return valueTransform == null ? new String(this.source, offset, length) : valueTransform.apply(jp);
         }
 
         @Override
         public String consume(BiConsumer<CharBuffer, String> valueConsumer) {
             String key = new String(this.source, offset, length);
-            String value = valueTransform == null ? key : valueTransform.get();
+            String value = valueTransform == null ? key : valueTransform.apply(jp);
             valueConsumer.accept(new CharBuffer.StringCharBuffer(key, variant), value);
             return value;
         }

--- a/eureka-client/src/main/java/com/netflix/discovery/util/DeserializerStringCache.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/util/DeserializerStringCache.java
@@ -45,6 +45,10 @@ public class DeserializerStringCache implements Function<String, String> {
     private final Map<CharBuffer, String> applicationCache;
     private final int lengthLimit = LENGTH_LIMIT;
 
+    // Reusable lookup buffers to avoid allocation on cache hits (single-threaded usage)
+    private final MutableArrayCharBuffer parserLookupBuffer = new MutableArrayCharBuffer();
+    private final MutableStringCharBuffer stringLookupBuffer = new MutableStringCharBuffer();
+
     /**
      * adds a new DeserializerStringCache to the passed-in ObjectReader
      * 
@@ -207,44 +211,17 @@ public class DeserializerStringCache implements Function<String, String> {
      * @throws IOException
      */
     public String apply(final JsonParser jp, CacheScope cacheScope, Supplier<String> source) throws IOException {
-        return apply(CharBuffer.wrap(jp, source), cacheScope);
-    }
-
-    /**
-     * returns a String that may be interned at app-scope to reduce heap
-     * consumption
-     * 
-     * @param charValue
-     * @return a possibly interned String
-     */
-    public String apply(final CharBuffer charValue) {
-        return apply(charValue, CacheScope.APPLICATION_SCOPE);
-    }
-
-    /**
-     * returns a object of type T that may be interned at the specified scope to
-     * reduce heap consumption
-     * 
-     * @param charValue
-     * @param cacheScope
-     * @param trabsform
-     * @return a possibly interned instance of T
-     */
-    public String apply(CharBuffer charValue, CacheScope cacheScope) {
-        int keyLength = charValue.length();
-        if ((lengthLimit < 0 || keyLength <= lengthLimit)) {
+        parserLookupBuffer.reset(jp, source);
+        int keyLength = parserLookupBuffer.length();
+        if (lengthLimit < 0 || keyLength <= lengthLimit) {
             Map<CharBuffer, String> cache = (cacheScope == CacheScope.GLOBAL_SCOPE) ? globalCache : applicationCache;
-            String value = cache.get(charValue);
+            String value = cache.get(parserLookupBuffer);
             if (value == null) {
-                value = charValue.consume((k, v) -> {
-                    cache.put(k, v);
-                });
-            } else {
-                // System.out.println("cache hit");
+                value = parserLookupBuffer.consume(cache::put);
             }
             return value;
         }
-        return charValue.toString();
+        return parserLookupBuffer.toString();
     }
 
     /**
@@ -269,11 +246,15 @@ public class DeserializerStringCache implements Function<String, String> {
      */
     public String apply(final String stringValue, CacheScope cacheScope) {
         if (stringValue != null && (lengthLimit < 0 || stringValue.length() <= lengthLimit)) {
-            return (String) (cacheScope == CacheScope.GLOBAL_SCOPE ? globalCache : applicationCache)
-                    .computeIfAbsent(CharBuffer.wrap(stringValue), s -> {
-                        logger.trace(" (string) writing new interned value {} into {} cache scope", stringValue, cacheScope);
-                        return stringValue;
-                    });
+            stringLookupBuffer.reset(stringValue);
+            Map<CharBuffer, String> cache = (cacheScope == CacheScope.GLOBAL_SCOPE) ? globalCache : applicationCache;
+            String value = cache.get(stringLookupBuffer);
+            if (value == null) {
+                logger.trace(" (string) writing new interned value {} into {} cache scope", stringValue, cacheScope);
+                cache.put(new CharBuffer.StringCharBuffer(stringValue), stringValue);
+                value = stringValue;
+            }
+            return value;
         }
         return stringValue;
     }
@@ -285,18 +266,6 @@ public class DeserializerStringCache implements Function<String, String> {
     private interface CharBuffer {
         static final int DEFAULT_VARIANT = -1;
 
-        public static CharBuffer wrap(JsonParser source, Supplier<String> stringSource) throws IOException {
-            return new ArrayCharBuffer(source, stringSource);
-        }
-
-        public static CharBuffer wrap(JsonParser source) throws IOException {
-            return new ArrayCharBuffer(source);
-        }
-
-        public static CharBuffer wrap(String source) {
-            return new StringCharBuffer(source);
-        }
-
         String consume(BiConsumer<CharBuffer, String> valueConsumer);
 
         int length();
@@ -305,118 +274,20 @@ public class DeserializerStringCache implements Function<String, String> {
 
         OfInt chars();
 
-        static class ArrayCharBuffer implements CharBuffer {
-            private final char[] source;
-            private final int offset;
-            private final int length;
-            private final Supplier<String> valueTransform;
-            private final int variant;
-            private final int hash;
-
-            ArrayCharBuffer(JsonParser source) throws IOException {
-                this(source, null);
-            }
-
-            ArrayCharBuffer(JsonParser source, Supplier<String> valueTransform) throws IOException {
-                this.source = source.getTextCharacters();
-                this.offset = source.getTextOffset();
-                this.length = source.getTextLength();
-                this.valueTransform = valueTransform;
-                this.variant = valueTransform == null ? DEFAULT_VARIANT : System.identityHashCode(valueTransform.getClass());
-                this.hash =  31 * arrayHash(this.source, offset, length) + variant;
-            }
-
-            @Override
-            public int length() {
-                return length;
-            }
-
-            @Override
-            public int variant() {
-                return variant;
-            }
-
-            @Override
-            public int hashCode() {
-                return hash;
-            }
-
-            @Override
-            public boolean equals(Object other) {
-                if (other instanceof CharBuffer) {
-                    CharBuffer otherBuffer = (CharBuffer) other;
-                    if (otherBuffer.length() == length) {
-                        if (otherBuffer.variant() == variant) {
-                            OfInt otherText = otherBuffer.chars();
-                            for (int i = offset; i < length; i++) {
-                                if (source[i] != otherText.nextInt()) {
-                                    return false;
-                                }
-                            }
-                        return true;
-                        }
-                    }
-                }
-                return false;
-            }
-
-            @Override
-            public OfInt chars() {
-                return new OfInt() {
-                    int index = offset;
-                    int limit = index + length;
-
-                    @Override
-                    public boolean hasNext() {
-                        return index < limit;
-                    }
-
-                    @Override
-                    public int nextInt() {
-                        return source[index++];
-                    }
-                };
-            }
-
-            @Override
-            public String toString() {
-                return valueTransform  == null ? new String(this.source, offset, length) : valueTransform.get();
-            }
-
-            @Override
-            public String consume(BiConsumer<CharBuffer, String> valueConsumer) {
-                String key = new String(this.source, offset, length);
-                String value = valueTransform == null ? key : valueTransform.get();
-                valueConsumer.accept(new StringCharBuffer(key, variant), value);
-                return value;
-            }
-
-            private static int arrayHash(char[] a, int offset, int length) {
-                if (a == null)
-                    return 0;
-                int result = 0;
-                int limit = offset + length;
-                for (int i = offset; i < limit; i++) {
-                    result = 31 * result + a[i];
-                }
-                return result;
-            }
-        }
-
         static class StringCharBuffer implements CharBuffer {
             private final String source;
             private final int variant;
             private final int hashCode;
 
             StringCharBuffer(String source) {
-                this(source, -1);
+                this(source, DEFAULT_VARIANT);
             }
 
             StringCharBuffer(String source, int variant) {
                 this.source = source;
                 this.variant = variant;
                 this.hashCode = 31 * source.hashCode() + variant;
-            }            
+            }
 
             @Override
             public int hashCode() {
@@ -482,5 +353,178 @@ public class DeserializerStringCache implements Function<String, String> {
             }
         }
 
+    }
+
+    /**
+     * Mutable version of ArrayCharBuffer for reusable lookups.
+     * Reset before each use to avoid allocations on cache hits.
+     */
+    private static class MutableArrayCharBuffer implements CharBuffer {
+        private char[] source;
+        private int offset;
+        private int length;
+        private Supplier<String> valueTransform;
+        private int variant;
+        private int hash;
+
+        void reset(JsonParser jp, Supplier<String> valueTransform) throws IOException {
+            this.source = jp.getTextCharacters();
+            this.offset = jp.getTextOffset();
+            this.length = jp.getTextLength();
+            this.valueTransform = valueTransform;
+            this.variant = valueTransform == null ? DEFAULT_VARIANT : System.identityHashCode(valueTransform.getClass());
+            this.hash = 31 * arrayHash(this.source, offset, length) + variant;
+        }
+
+        @Override
+        public int length() {
+            return length;
+        }
+
+        @Override
+        public int variant() {
+            return variant;
+        }
+
+        @Override
+        public int hashCode() {
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (other instanceof CharBuffer) {
+                CharBuffer otherBuffer = (CharBuffer) other;
+                if (otherBuffer.length() == length && otherBuffer.variant() == variant) {
+                    OfInt otherText = otherBuffer.chars();
+                    for (int i = offset; i < offset + length; i++) {
+                        if (source[i] != otherText.nextInt()) {
+                            return false;
+                        }
+                    }
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public OfInt chars() {
+            return new OfInt() {
+                int index = offset;
+                int limit = index + length;
+
+                @Override
+                public boolean hasNext() {
+                    return index < limit;
+                }
+
+                @Override
+                public int nextInt() {
+                    return source[index++];
+                }
+            };
+        }
+
+        @Override
+        public String toString() {
+            return valueTransform == null ? new String(this.source, offset, length) : valueTransform.get();
+        }
+
+        @Override
+        public String consume(BiConsumer<CharBuffer, String> valueConsumer) {
+            String key = new String(this.source, offset, length);
+            String value = valueTransform == null ? key : valueTransform.get();
+            valueConsumer.accept(new CharBuffer.StringCharBuffer(key, variant), value);
+            return value;
+        }
+
+        private static int arrayHash(char[] a, int offset, int length) {
+            if (a == null)
+                return 0;
+            int result = 0;
+            int limit = offset + length;
+            for (int i = offset; i < limit; i++) {
+                result = 31 * result + a[i];
+            }
+            return result;
+        }
+    }
+
+    /**
+     * Mutable version of StringCharBuffer for reusable lookups.
+     * Reset before each use to avoid allocations on cache hits.
+     */
+    private static class MutableStringCharBuffer implements CharBuffer {
+        private String source;
+        private int hashCode;
+
+        void reset(String source) {
+            this.source = source;
+            this.hashCode = 31 * source.hashCode() + DEFAULT_VARIANT;
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode;
+        }
+
+        @Override
+        public int variant() {
+            return DEFAULT_VARIANT;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (other instanceof CharBuffer) {
+                CharBuffer otherBuffer = (CharBuffer) other;
+                if (otherBuffer.variant() == DEFAULT_VARIANT) {
+                    int length = source.length();
+                    if (otherBuffer.length() == length) {
+                        OfInt otherText = otherBuffer.chars();
+                        for (int i = 0; i < length; i++) {
+                            if (source.charAt(i) != otherText.nextInt()) {
+                                return false;
+                            }
+                        }
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public int length() {
+            return source.length();
+        }
+
+        @Override
+        public String toString() {
+            return source;
+        }
+
+        @Override
+        public OfInt chars() {
+            return new OfInt() {
+                int index;
+
+                @Override
+                public boolean hasNext() {
+                    return index < source.length();
+                }
+
+                @Override
+                public int nextInt() {
+                    return source.charAt(index++);
+                }
+            };
+        }
+
+        @Override
+        public String consume(BiConsumer<CharBuffer, String> valueConsumer) {
+            valueConsumer.accept(new CharBuffer.StringCharBuffer(source), source);
+            return source;
+        }
     }
 }

--- a/eureka-client/src/test/java/com/netflix/discovery/util/DeserializerStringCacheTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/util/DeserializerStringCacheTest.java
@@ -3,7 +3,7 @@ package com.netflix.discovery.util;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
@@ -42,7 +42,7 @@ public class DeserializerStringCacheTest {
         assertThat(lowerCaseValue, is("value"));
 
         try (JsonParser jsonParser = createParser("value")) {
-            String upperCaseValue = cache.apply(jsonParser, CacheScope.APPLICATION_SCOPE, () -> "VALUE");
+            String upperCaseValue = cache.apply(jsonParser, CacheScope.APPLICATION_SCOPE, jp -> "VALUE");
             assertThat(upperCaseValue, is("VALUE"));
         }
     }
@@ -60,7 +60,7 @@ public class DeserializerStringCacheTest {
             String expectedValue = new String(expectedValueChars);
 
             String upperCaseValue = cache.apply(jsonParser, CacheScope.APPLICATION_SCOPE,
-                    () -> longString.toUpperCase());
+                    jp -> longString.toUpperCase());
             assertThat(upperCaseValue, is(expectedValue));
         }
     }
@@ -106,23 +106,23 @@ public class DeserializerStringCacheTest {
     }
 
     @Test
-    public void testSupplierOnlyCalledOnCacheMiss() throws IOException {
+    public void testTransformOnlyCalledOnCacheMiss() throws IOException {
         DeserializerStringCache cache = createCache();
         AtomicInteger callCount = new AtomicInteger(0);
 
-        Supplier<String> countingSupplier = () -> {
+        Function<JsonParser, String> countingTransform = jp -> {
             callCount.incrementAndGet();
             return "TRANSFORMED";
         };
 
         try (JsonParser p1 = createParser("value")) {
-            cache.apply(p1, CacheScope.APPLICATION_SCOPE, countingSupplier);
+            cache.apply(p1, CacheScope.APPLICATION_SCOPE, countingTransform);
         }
         try (JsonParser p2 = createParser("value")) {
-            cache.apply(p2, CacheScope.APPLICATION_SCOPE, countingSupplier);
+            cache.apply(p2, CacheScope.APPLICATION_SCOPE, countingTransform);
         }
 
-        assertEquals("Supplier should only be called once (on cache miss)", 1, callCount.get());
+        assertEquals("Transform should only be called once (on cache miss)", 1, callCount.get());
     }
 
     @Test
@@ -222,15 +222,15 @@ public class DeserializerStringCacheTest {
             lowercase = cache.apply(p1, CacheScope.APPLICATION_SCOPE);
         }
 
-        // Use a different supplier class - this should create a different cache entry
-        // because the variant is based on the supplier class identity
-        class UpperCaseSupplier implements Supplier<String> {
-            public String get() { return "APP"; }
+        // Use a different function class - this should create a different cache entry
+        // because the variant is based on the function class identity
+        class UpperCaseTransform implements Function<JsonParser, String> {
+            public String apply(JsonParser jp) { return "APP"; }
         }
 
         String uppercase;
         try (JsonParser p2 = createParser("app")) {
-            uppercase = cache.apply(p2, CacheScope.APPLICATION_SCOPE, new UpperCaseSupplier());
+            uppercase = cache.apply(p2, CacheScope.APPLICATION_SCOPE, new UpperCaseTransform());
         }
 
         assertEquals("Lowercase should be 'app'", "app", lowercase);

--- a/eureka-client/src/test/java/com/netflix/discovery/util/DeserializerStringCacheTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/util/DeserializerStringCacheTest.java
@@ -2,60 +2,239 @@ package com.netflix.discovery.util;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
+import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.netflix.discovery.util.DeserializerStringCache.CacheScope;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class DeserializerStringCacheTest {
 
+    private static final JsonFactory JSON_FACTORY = new JsonFactory();
+
+    private static JsonParser createParser(String jsonValue) throws IOException {
+        // Create a real parser positioned at a string value
+        JsonParser parser = JSON_FACTORY.createParser("\"" + jsonValue + "\"");
+        parser.nextToken(); // Move to VALUE_STRING
+        return parser;
+    }
+
+    private DeserializerStringCache createCache() {
+        ObjectReader reader = DeserializerStringCache.init(new ObjectMapper().reader());
+        return (DeserializerStringCache) reader.getAttributes().getAttribute("deserInternCache");
+    }
+
     @Test
     public void testUppercaseConversionWithLowercasePreset() throws IOException {
-        DeserializationContext deserializationContext = mock(DeserializationContext.class);
-        DeserializerStringCache deserializerStringCache = DeserializerStringCache.from(deserializationContext);
+        DeserializerStringCache cache = createCache();
 
-        String lowerCaseValue = deserializerStringCache.apply("value", CacheScope.APPLICATION_SCOPE);
+        String lowerCaseValue = cache.apply("value", CacheScope.APPLICATION_SCOPE);
         assertThat(lowerCaseValue, is("value"));
 
-        JsonParser jsonParser = mock(JsonParser.class);
-        when(jsonParser.getTextCharacters()).thenReturn(new char[] {'v', 'a', 'l', 'u', 'e'});
-        when(jsonParser.getTextLength()).thenReturn(5);
-
-        String upperCaseValue = deserializerStringCache.apply(jsonParser, CacheScope.APPLICATION_SCOPE, () -> "VALUE");
-        assertThat(upperCaseValue, is("VALUE"));
+        try (JsonParser jsonParser = createParser("value")) {
+            String upperCaseValue = cache.apply(jsonParser, CacheScope.APPLICATION_SCOPE, () -> "VALUE");
+            assertThat(upperCaseValue, is("VALUE"));
+        }
     }
 
     @Test
     public void testUppercaseConversionWithLongString() throws IOException {
-        DeserializationContext deserializationContext = mock(DeserializationContext.class);
-        DeserializerStringCache deserializerStringCache = DeserializerStringCache.from(deserializationContext);
+        DeserializerStringCache cache = createCache();
         char[] lowercaseValue = new char[1024];
         Arrays.fill(lowercaseValue, 'a');
+        String longString = new String(lowercaseValue);
 
-        JsonParser jsonParser = mock(JsonParser.class);
-        when(jsonParser.getText()).thenReturn(new String(lowercaseValue));
-        when(jsonParser.getTextCharacters()).thenReturn(lowercaseValue);
-        when(jsonParser.getTextOffset()).thenReturn(0);
-        when(jsonParser.getTextLength()).thenReturn(lowercaseValue.length);
+        try (JsonParser jsonParser = createParser(longString)) {
+            char[] expectedValueChars = new char[1024];
+            Arrays.fill(expectedValueChars, 'A');
+            String expectedValue = new String(expectedValueChars);
 
-        String upperCaseValue = deserializerStringCache.apply(jsonParser, CacheScope.APPLICATION_SCOPE, () -> {
-            try {
-                return jsonParser.getText().toUpperCase();
-            }
-            catch(IOException ioe) {
-                // not likely from mock above
-                throw new IllegalStateException("mock threw unexpected exception", ioe);
-            }
-        });
-        char[] expectedValueChars = new char[1024];
-        Arrays.fill(expectedValueChars, 'A');
-        String expectedValue = new String(expectedValueChars);
-        assertThat(upperCaseValue, is(expectedValue));
+            String upperCaseValue = cache.apply(jsonParser, CacheScope.APPLICATION_SCOPE,
+                    () -> longString.toUpperCase());
+            assertThat(upperCaseValue, is(expectedValue));
+        }
+    }
+
+    @Test
+    public void testCacheHitReturnsIdenticalInstance() throws IOException {
+        DeserializerStringCache cache = createCache();
+
+        String first;
+        try (JsonParser p1 = createParser("testValue")) {
+            first = cache.apply(p1, CacheScope.APPLICATION_SCOPE);
+        }
+
+        String second;
+        try (JsonParser p2 = createParser("testValue")) {
+            second = cache.apply(p2, CacheScope.APPLICATION_SCOPE);
+        }
+
+        assertSame("Cache hit should return identical instance", first, second);
+    }
+
+    @Test
+    public void testCacheHitWithStringReturnsIdenticalInstance() throws IOException {
+        DeserializerStringCache cache = createCache();
+
+        String first = cache.apply(new String("testValue"), CacheScope.APPLICATION_SCOPE);
+        String second = cache.apply(new String("testValue"), CacheScope.APPLICATION_SCOPE);
+
+        assertSame("Cache hit should return identical instance", first, second);
+    }
+
+    @Test
+    public void testCacheHitAcrossParserAndString() throws IOException {
+        DeserializerStringCache cache = createCache();
+
+        String fromParser;
+        try (JsonParser parser = createParser("testValue")) {
+            fromParser = cache.apply(parser, CacheScope.APPLICATION_SCOPE);
+        }
+        String fromString = cache.apply(new String("testValue"), CacheScope.APPLICATION_SCOPE);
+
+        assertSame("Cache should work across parser and string lookups", fromParser, fromString);
+    }
+
+    @Test
+    public void testSupplierOnlyCalledOnCacheMiss() throws IOException {
+        DeserializerStringCache cache = createCache();
+        AtomicInteger callCount = new AtomicInteger(0);
+
+        Supplier<String> countingSupplier = () -> {
+            callCount.incrementAndGet();
+            return "TRANSFORMED";
+        };
+
+        try (JsonParser p1 = createParser("value")) {
+            cache.apply(p1, CacheScope.APPLICATION_SCOPE, countingSupplier);
+        }
+        try (JsonParser p2 = createParser("value")) {
+            cache.apply(p2, CacheScope.APPLICATION_SCOPE, countingSupplier);
+        }
+
+        assertEquals("Supplier should only be called once (on cache miss)", 1, callCount.get());
+    }
+
+    @Test
+    public void testGlobalScopeSurvivesApplicationScopeClear() throws IOException {
+        ObjectReader reader = DeserializerStringCache.init(new ObjectMapper().reader());
+        DeserializerStringCache cache = (DeserializerStringCache) reader.getAttributes()
+                .getAttribute("deserInternCache");
+
+        String globalValue;
+        try (JsonParser p1 = createParser("globalKey")) {
+            globalValue = cache.apply(p1, CacheScope.GLOBAL_SCOPE);
+        }
+
+        String appValue;
+        try (JsonParser p2 = createParser("appKey")) {
+            appValue = cache.apply(p2, CacheScope.APPLICATION_SCOPE);
+        }
+
+        // Clear only application scope
+        DeserializerStringCache.clear(reader, CacheScope.APPLICATION_SCOPE);
+
+        // Global should still return same instance
+        String globalAgain;
+        try (JsonParser p3 = createParser("globalKey")) {
+            globalAgain = cache.apply(p3, CacheScope.GLOBAL_SCOPE);
+        }
+        assertSame("Global value should survive application scope clear", globalValue, globalAgain);
+
+        // Application scope was cleared, so this should be a new instance
+        String appAgain;
+        try (JsonParser p4 = createParser("appKey")) {
+            appAgain = cache.apply(p4, CacheScope.APPLICATION_SCOPE);
+        }
+        assertNotSame("Application value should be new after clear", appValue, appAgain);
+        assertEquals("Application value should have same content", appValue, appAgain);
+    }
+
+    @Test
+    public void testGlobalScopeClearClearsBothScopes() throws IOException {
+        ObjectReader reader = DeserializerStringCache.init(new ObjectMapper().reader());
+        DeserializerStringCache cache = (DeserializerStringCache) reader.getAttributes()
+                .getAttribute("deserInternCache");
+
+        String globalValue;
+        try (JsonParser p1 = createParser("globalKey")) {
+            globalValue = cache.apply(p1, CacheScope.GLOBAL_SCOPE);
+        }
+
+        String appValue;
+        try (JsonParser p2 = createParser("appKey")) {
+            appValue = cache.apply(p2, CacheScope.APPLICATION_SCOPE);
+        }
+
+        // Clear global scope (should clear both)
+        DeserializerStringCache.clear(reader, CacheScope.GLOBAL_SCOPE);
+
+        String globalAgain;
+        try (JsonParser p3 = createParser("globalKey")) {
+            globalAgain = cache.apply(p3, CacheScope.GLOBAL_SCOPE);
+        }
+
+        String appAgain;
+        try (JsonParser p4 = createParser("appKey")) {
+            appAgain = cache.apply(p4, CacheScope.APPLICATION_SCOPE);
+        }
+
+        assertNotSame("Global value should be new after global clear", globalValue, globalAgain);
+        assertNotSame("Application value should be new after global clear", appValue, appAgain);
+    }
+
+    @Test
+    public void testParserWithNonZeroOffset() throws IOException {
+        DeserializerStringCache cache = createCache();
+
+        // First cache "value" from a normal parse
+        String cached;
+        try (JsonParser p1 = createParser("value")) {
+            cached = cache.apply(p1, CacheScope.APPLICATION_SCOPE);
+        }
+        assertEquals("Should extract correct value", "value", cached);
+
+        // Verify same value from different parse returns cached instance
+        String cachedAgain;
+        try (JsonParser p2 = createParser("value")) {
+            cachedAgain = cache.apply(p2, CacheScope.APPLICATION_SCOPE);
+        }
+        assertSame("Should match cache entry", cached, cachedAgain);
+    }
+
+    @Test
+    public void testDifferentTransformsForSameKeyAreCachedSeparately() throws IOException {
+        DeserializerStringCache cache = createCache();
+
+        // Same raw key "app" but different transforms (identity vs toUpperCase)
+        String lowercase;
+        try (JsonParser p1 = createParser("app")) {
+            lowercase = cache.apply(p1, CacheScope.APPLICATION_SCOPE);
+        }
+
+        // Use a different supplier class - this should create a different cache entry
+        // because the variant is based on the supplier class identity
+        class UpperCaseSupplier implements Supplier<String> {
+            public String get() { return "APP"; }
+        }
+
+        String uppercase;
+        try (JsonParser p2 = createParser("app")) {
+            uppercase = cache.apply(p2, CacheScope.APPLICATION_SCOPE, new UpperCaseSupplier());
+        }
+
+        assertEquals("Lowercase should be 'app'", "app", lowercase);
+        assertEquals("Uppercase should be 'APP'", "APP", uppercase);
+        assertNotSame("Different transforms should cache separately", lowercase, uppercase);
     }
 }


### PR DESCRIPTION
Two changes, (1) the getText toUpperCase call gets a slight transform to avoid a lambda capture. More significantly, we (2) introduce a mutable ArrayCharBuffer and StringCharBuffer to avoid repeated allocations of the buffer themselves. The buffers are only used during intermediate calls, and, the class is clearly marked as not-thread-safe and is attached to independent ObjectReader.