### PR TITLE
perf: Optimize Applications refresh internals

### DIFF
--- a/eureka-client/build.gradle
+++ b/eureka-client/build.gradle
@@ -15,7 +15,6 @@ dependencies {
     api "com.netflix.spectator:spectator-api:${spectatorVersion}"
     api "org.slf4j:slf4j-api:${slf4jVersion}"
     implementation "javax.annotation:javax.annotation-api:1.2"
-    implementation 'com.google.guava:guava:33.0.0-jre'
     // compile "com.sun.jersey:jersey-core:${jerseyVersion}"
     // compile "com.sun.jersey:jersey-client:${jerseyVersion}"
     // compile "com.sun.jersey.contribs:jersey-apache-client4:${jerseyVersion}"

--- a/eureka-client/build.gradle
+++ b/eureka-client/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     api "com.netflix.spectator:spectator-api:${spectatorVersion}"
     api "org.slf4j:slf4j-api:${slf4jVersion}"
     implementation "javax.annotation:javax.annotation-api:1.2"
+    implementation 'com.google.guava:guava:33.0.0-jre'
     // compile "com.sun.jersey:jersey-core:${jerseyVersion}"
     // compile "com.sun.jersey:jersey-client:${jerseyVersion}"
     // compile "com.sun.jersey.contribs:jersey-apache-client4:${jerseyVersion}"

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/Applications.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/Applications.java
@@ -471,7 +471,9 @@ public class Applications {
         // | Avg string length     | 29.5   | 25.8    |
         // | Max string length     | 204    | 468     |
 
-        if (vipAddresses == null || vipAddresses.isEmpty()) {
+        // Note: empty vipAddresses is intentionally allowed for backwards compatibility.
+        // Legacy behavior: "" creates a mapping with empty string key.
+        if (vipAddresses == null) {
             return;
         }
 

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/Applications.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/Applications.java
@@ -389,41 +389,63 @@ public class Applications {
      * Shuffle and filter instances for a single VIP.
      */
     private void shuffleAndFilterInstances(VipIndexSupport vipIndexSupport, boolean filterUpInstances, Random shuffleRandom) {
-        // Statistics from prod: 56% of VIPs have exactly 1 instance, 82% have <=3 instances.
-        // Optimized to avoid allocations for 0/1 instance cases.
-        List<InstanceInfo> vipInstances = vipIndexSupport.getInstances();
-        int size = vipInstances.size();
+        List<InstanceInfo> instances = vipIndexSupport.getInstances();
+        int size = instances.size();
 
-        final List<InstanceInfo> filteredInstances;
+        // Empty: nothing to do
         if (size == 0) {
-            // Empty: reuse existing emptyList
-            filteredInstances = vipInstances;
-        } else if (size == 1) {
-            // Single instance (56% of VIPs): no shuffle needed, reuse list if possible
-            InstanceInfo instance = vipInstances.get(0);
-            if (filterUpInstances && instance.getStatus() != InstanceStatus.UP) {
-                filteredInstances = Collections.emptyList();
-            } else {
-                filteredInstances = vipInstances;
-            }
-        } else {
-            // Multiple instances: filter with loop (avoids stream allocations) and shuffle
-            ArrayList<InstanceInfo> list = new ArrayList<>(size);
-            if (filterUpInstances) {
-                for (int i = 0; i < size; i++) {
-                    InstanceInfo instance = vipInstances.get(i);
-                    if (instance.getStatus() == InstanceStatus.UP) {
-                        list.add(instance);
-                    }
-                }
-            } else {
-                list.addAll(vipInstances);
-            }
-            Collections.shuffle(list, shuffleRandom);
-            filteredInstances = list;
+            vipIndexSupport.setVipList(instances);
+            return;
         }
-        vipIndexSupport.setVipList(filteredInstances);
-        vipIndexSupport.roundRobinIndex.set(0);
+
+        // Single instance: no shuffle needed, check status if filtering
+        if (size == 1) {
+            InstanceInfo instance = instances.get(0);
+            boolean keep = !filterUpInstances || instance.getStatus() == InstanceStatus.UP;
+            vipIndexSupport.setVipList(keep ? instances : Collections.emptyList());
+            return;
+        }
+
+        // Multiple instances (2+): instances is always an ArrayList at this point
+        ArrayList<InstanceInfo> list = (ArrayList<InstanceInfo>) instances;
+
+        // Filter in place if needed (no-op when all instances are UP)
+        if (filterUpInstances) {
+            filterToUpInstancesInPlace(list);
+            if (list.isEmpty()) {
+                vipIndexSupport.setVipList(Collections.emptyList());
+                return;
+            }
+        }
+
+        // Shuffle in place and reuse
+        Collections.shuffle(list, shuffleRandom);
+        vipIndexSupport.setVipList(list);
+    }
+
+    /**
+     * Filter list in place to keep only UP instances. Allocation-free.
+     */
+    private static void filterToUpInstancesInPlace(ArrayList<InstanceInfo> list) {
+        int size = list.size();
+        int writeIndex = 0;
+        // shift forward all of the UP instances
+        for (int i = 0; i < size; i++) {
+            InstanceInfo instance = list.get(i);
+            if (instance.getStatus() == InstanceStatus.UP) {
+                if (writeIndex != i) {
+                    list.set(writeIndex, instance);
+                }
+                writeIndex++;
+            }
+        }
+        // Truncate: remove tail elements. Allows old objects to be GCd.
+        // Array is not shrunk back, but, in the majority case this is not useful.
+        // More important that we clear the entries so the InstanceInfo elements
+        // can be released.
+        if (writeIndex < size) {
+            list.subList(writeIndex, size).clear();
+        }
     }
 
     /**

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/Applications.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/Applications.java
@@ -20,7 +20,6 @@ import jakarta.annotation.Nullable;
 import java.util.AbstractQueue;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -32,7 +31,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
+import com.google.common.collect.Maps;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -333,8 +332,8 @@ public class Applications {
             @Nullable Map<String, Applications> remoteRegionsRegistry, 
             @Nullable EurekaClientConfig clientConfig,
             @Nullable InstanceRegionChecker instanceRegionChecker) {
-        Map<String, VipIndexSupport> secureVirtualHostNameAppMap = new HashMap<>();
-        Map<String, VipIndexSupport> virtualHostNameAppMap = new HashMap<>();
+        Map<String, VipIndexSupport> secureVirtualHostNameAppMap = Maps.newHashMapWithExpectedSize(this.secureVirtualHostNameAppMap.size());
+        Map<String, VipIndexSupport> virtualHostNameAppMap = Maps.newHashMapWithExpectedSize(this.virtualHostNameAppMap.size());
         for (Application application : appNameApplicationMap.values()) {
             if (indexByRemoteRegions) {
                 application.shuffleAndStoreInstances(remoteRegionsRegistry, clientConfig, instanceRegionChecker);

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/Applications.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/Applications.java
@@ -65,9 +65,37 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
 @JsonRootName("applications")
 public class Applications {
     private static class VipIndexSupport {
-        final AbstractQueue<InstanceInfo> instances = new ConcurrentLinkedQueue<>();
+        // Progressive list: emptyList (0) -> singletonList (1) -> ArrayList (2+)
+        // This avoids CLQ and Node allocations. 56% of VIPs have exactly 1 instance.
+        private List<InstanceInfo> instances = Collections.emptyList();
         final AtomicLong roundRobinIndex = new AtomicLong(0);
         final AtomicReference<List<InstanceInfo>> vipList = new AtomicReference<>(Collections.emptyList());
+
+        void addInstance(InstanceInfo info) {
+            int size = instances.size();
+            if (size == 0) {
+                // 0 -> 1: use singletonList (56% of VIPs stop here)
+                instances = Collections.singletonList(info);
+            } else if (size == 1) {
+                // 1 -> 2: transition singletonList to ArrayList
+                InstanceInfo first = instances.get(0);
+                ArrayList<InstanceInfo> list = new ArrayList<>(12);
+                list.add(first);
+                list.add(info);
+                instances = list;
+            } else {
+                // 2+ -> n: append to ArrayList
+                ((ArrayList<InstanceInfo>) instances).add(info);
+            }
+        }
+
+        int instanceCount() {
+            return instances.size();
+        }
+
+        List<InstanceInfo> getInstances() {
+            return instances;
+        }
 
         public AtomicLong getRoundRobinIndex() {
             return roundRobinIndex;
@@ -352,7 +380,7 @@ public class Applications {
         Random shuffleRandom = new Random();
         for (Map.Entry<String, VipIndexSupport> entries : srcMap.entrySet()) {
             VipIndexSupport vipIndexSupport = entries.getValue();
-            AbstractQueue<InstanceInfo> vipInstances = vipIndexSupport.instances;
+            List<InstanceInfo> vipInstances = vipIndexSupport.getInstances();
             final List<InstanceInfo> filteredInstances;
             if (filterUpInstances) {
                 filteredInstances = vipInstances.stream().filter(ii -> ii.getStatus() == InstanceStatus.UP)
@@ -370,16 +398,45 @@ public class Applications {
      * Add the instance to the given map based if the vip address matches with
      * that of the instance. Note that an instance can be mapped to multiple vip
      * addresses.
-     *
      */
     private void addInstanceToMap(InstanceInfo info, String vipAddresses, Map<String, VipIndexSupport> vipMap) {
-        if (vipAddresses != null) {
-            String[] vipAddressArray = vipAddresses.toUpperCase(Locale.ROOT).split(",");
-            for (String vipAddress : vipAddressArray) {
-                VipIndexSupport vis = vipMap.computeIfAbsent(vipAddress, k -> new VipIndexSupport());
-                vis.instances.add(info);
-            }
+        // This code path is quite hot on allocations. We apply common-case optimizations to minimize allocations.
+        // Gathered statistics from a real cluster:
+        // | Metric                | Test   | Prod    |
+        // |-----------------------|--------|---------|
+        // | Total entries         | N      | 2x N    |
+        // | Single VIP (no comma) | 91.1%  | 91.7%   |
+        // | 2 VIPs                | 6.9%   | 5.9%    |
+        // | 3+ VIPs               | 0.4%   | 0.7%    |
+        // | Empty                 | 1.6%   | 1.7%    |
+        // | Max VIPs per entry    | 7      | 13      |
+        // | Avg string length     | 29.5   | 25.8    |
+        // | Max string length     | 204    | 468     |
+
+        if (vipAddresses == null || vipAddresses.isEmpty()) {
+            return;
         }
+
+        String upper = vipAddresses.toUpperCase(Locale.ROOT);
+
+        // Fast path (91.7% of cases) single VIP: no split() -> byte[], no substring() -> String
+        int commaIndex = upper.indexOf(',');
+        if (commaIndex == -1) {
+            vipMap.computeIfAbsent(upper, k -> new VipIndexSupport()).addInstance(info);
+            return;
+        }
+
+        // Multiple VIPs: uppercase once, then parse without split() byte[] allocation
+        int start = 0;
+        do {
+            String vipAddress = upper.substring(start, commaIndex);
+            vipMap.computeIfAbsent(vipAddress, k -> new VipIndexSupport()).addInstance(info);
+            start = commaIndex + 1;
+        } while ((commaIndex = upper.indexOf(',', start)) != -1);
+
+        // Last segment
+        String vipAddress = upper.substring(start);
+        vipMap.computeIfAbsent(vipAddress, k -> new VipIndexSupport()).addInstance(info);
     }
 
     /**

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/Applications.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/Applications.java
@@ -30,7 +30,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
 import com.google.common.collect.Maps;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -68,7 +70,7 @@ public class Applications {
         // This avoids CLQ and Node allocations. 56% of VIPs have exactly 1 instance.
         private List<InstanceInfo> instances = Collections.emptyList();
         final AtomicLong roundRobinIndex = new AtomicLong(0);
-        final AtomicReference<List<InstanceInfo>> vipList = new AtomicReference<>(Collections.emptyList());
+        private volatile List<InstanceInfo> vipList = Collections.emptyList();
 
         void addInstance(InstanceInfo info) {
             int size = instances.size();
@@ -100,8 +102,12 @@ public class Applications {
             return roundRobinIndex;
         }
 
-        public AtomicReference<List<InstanceInfo>> getVipList() {
+        List<InstanceInfo> getVipList() {
             return vipList;
+        }
+
+        void setVipList(List<InstanceInfo> vipList) {
+            this.vipList = vipList;
         }
     }
 
@@ -188,8 +194,7 @@ public class Applications {
     public List<InstanceInfo> getInstancesByVirtualHostName(String virtualHostName) {
         return Optional.ofNullable(this.virtualHostNameAppMap.get(virtualHostName.toUpperCase(Locale.ROOT)))
             .map(VipIndexSupport::getVipList)
-            .map(AtomicReference::get)
-            .orElseGet(Collections::emptyList); 
+            .orElseGet(Collections::emptyList);
     }
 
     /**
@@ -204,8 +209,7 @@ public class Applications {
     public List<InstanceInfo> getInstancesBySecureVirtualHostName(String secureVirtualHostName) {
         return Optional.ofNullable(this.secureVirtualHostNameAppMap.get(secureVirtualHostName.toUpperCase(Locale.ROOT)))
                 .map(VipIndexSupport::getVipList)
-                .map(AtomicReference::get)
-                .orElseGet(Collections::emptyList);        
+                .orElseGet(Collections::emptyList);
     }
 
     /**
@@ -418,7 +422,7 @@ public class Applications {
             Collections.shuffle(list, shuffleRandom);
             filteredInstances = list;
         }
-        vipIndexSupport.vipList.set(filteredInstances);
+        vipIndexSupport.setVipList(filteredInstances);
         vipIndexSupport.roundRobinIndex.set(0);
     }
 

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/Applications.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/Applications.java
@@ -78,7 +78,11 @@ public class Applications {
                 // 0 -> 1: use singletonList (56% of VIPs stop here)
                 instances = Collections.singletonList(info);
             } else if (size == 1) {
-                // 1 -> 2: transition singletonList to ArrayList
+                // 1 -> 2: transition singletonList to ArrayList.
+                // Capacity 12 chosen based on prod data analysis: covers 81% of multi-instance
+                // VIPs without resize (spikes at 6, 9, 12 instances from 3-AZ deployments).
+                // ArrayList grows 1.5x (12->18->27), aligning well with common sizes.
+                // Capacity 12 minimizes total allocation vs smaller capacities.
                 InstanceInfo first = instances.get(0);
                 ArrayList<InstanceInfo> list = new ArrayList<>(12);
                 list.add(first);

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/Applications.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/Applications.java
@@ -33,7 +33,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import com.google.common.collect.Maps;
+import com.netflix.discovery.util.MapUtil;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -336,8 +336,8 @@ public class Applications {
             @Nullable Map<String, Applications> remoteRegionsRegistry, 
             @Nullable EurekaClientConfig clientConfig,
             @Nullable InstanceRegionChecker instanceRegionChecker) {
-        Map<String, VipIndexSupport> secureVirtualHostNameAppMap = Maps.newHashMapWithExpectedSize(this.secureVirtualHostNameAppMap.size());
-        Map<String, VipIndexSupport> virtualHostNameAppMap = Maps.newHashMapWithExpectedSize(this.virtualHostNameAppMap.size());
+        Map<String, VipIndexSupport> secureVirtualHostNameAppMap = MapUtil.newHashMapWithExpectedSize(this.secureVirtualHostNameAppMap.size());
+        Map<String, VipIndexSupport> virtualHostNameAppMap = MapUtil.newHashMapWithExpectedSize(this.virtualHostNameAppMap.size());
         for (Application application : appNameApplicationMap.values()) {
             if (indexByRemoteRegions) {
                 application.shuffleAndStoreInstances(remoteRegionsRegistry, clientConfig, instanceRegionChecker);

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/Applications.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/Applications.java
@@ -376,22 +376,51 @@ public class Applications {
      *
      */
     private void shuffleAndFilterInstances(Map<String, VipIndexSupport> srcMap, boolean filterUpInstances) {
-
         Random shuffleRandom = new Random();
         for (Map.Entry<String, VipIndexSupport> entries : srcMap.entrySet()) {
-            VipIndexSupport vipIndexSupport = entries.getValue();
-            List<InstanceInfo> vipInstances = vipIndexSupport.getInstances();
-            final List<InstanceInfo> filteredInstances;
-            if (filterUpInstances) {
-                filteredInstances = vipInstances.stream().filter(ii -> ii.getStatus() == InstanceStatus.UP)
-                        .collect(Collectors.toCollection(() -> new ArrayList<>(vipInstances.size())));
-            } else {
-                filteredInstances = new ArrayList<InstanceInfo>(vipInstances);
-            }
-            Collections.shuffle(filteredInstances, shuffleRandom);
-            vipIndexSupport.vipList.set(filteredInstances);
-            vipIndexSupport.roundRobinIndex.set(0);
+            shuffleAndFilterInstances(entries.getValue(), filterUpInstances, shuffleRandom);
         }
+    }
+
+    /**
+     * Shuffle and filter instances for a single VIP.
+     */
+    private void shuffleAndFilterInstances(VipIndexSupport vipIndexSupport, boolean filterUpInstances, Random shuffleRandom) {
+        // Statistics from prod: 56% of VIPs have exactly 1 instance, 82% have <=3 instances.
+        // Optimized to avoid allocations for 0/1 instance cases.
+        List<InstanceInfo> vipInstances = vipIndexSupport.getInstances();
+        int size = vipInstances.size();
+
+        final List<InstanceInfo> filteredInstances;
+        if (size == 0) {
+            // Empty: reuse existing emptyList
+            filteredInstances = vipInstances;
+        } else if (size == 1) {
+            // Single instance (56% of VIPs): no shuffle needed, reuse list if possible
+            InstanceInfo instance = vipInstances.get(0);
+            if (filterUpInstances && instance.getStatus() != InstanceStatus.UP) {
+                filteredInstances = Collections.emptyList();
+            } else {
+                filteredInstances = vipInstances;
+            }
+        } else {
+            // Multiple instances: filter with loop (avoids stream allocations) and shuffle
+            ArrayList<InstanceInfo> list = new ArrayList<>(size);
+            if (filterUpInstances) {
+                for (int i = 0; i < size; i++) {
+                    InstanceInfo instance = vipInstances.get(i);
+                    if (instance.getStatus() == InstanceStatus.UP) {
+                        list.add(instance);
+                    }
+                }
+            } else {
+                list.addAll(vipInstances);
+            }
+            Collections.shuffle(list, shuffleRandom);
+            filteredInstances = list;
+        }
+        vipIndexSupport.vipList.set(filteredInstances);
+        vipIndexSupport.roundRobinIndex.set(0);
     }
 
     /**

--- a/eureka-client/src/main/java/com/netflix/discovery/util/MapUtil.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/util/MapUtil.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.discovery.util;
+
+import java.util.HashMap;
+
+/**
+ * Utility methods for working with Maps.
+ */
+public final class MapUtil {
+
+    private MapUtil() {
+        // Utility class
+    }
+
+    /**
+     * Creates a HashMap with enough capacity to hold the expected number of entries
+     * without resizing. This is equivalent to Guava's Maps.newHashMapWithExpectedSize().
+     *
+     * @param expectedSize the expected number of entries
+     * @param <K> the key type
+     * @param <V> the value type
+     * @return a new HashMap with appropriate initial capacity
+     */
+    public static <K, V> HashMap<K, V> newHashMapWithExpectedSize(int expectedSize) {
+        // HashMap resizes at load factor 0.75, so we need capacity = expectedSize / 0.75 + 1
+        return new HashMap<>((int) (expectedSize / 0.75f) + 1);
+    }
+}

--- a/eureka-client/src/test/java/com/netflix/discovery/shared/ApplicationsTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/shared/ApplicationsTest.java
@@ -389,6 +389,658 @@ public class ApplicationsTest {
         assertNotNull(applications.getRegisteredApplications("TestApp").getByInstanceId("test.hostname"));
         assertTrue(applications.getInstancesBySecureVirtualHostName("securetest.testname:7102").isEmpty());
         assertTrue(applications.getInstancesBySecureVirtualHostName("test.testname:1").isEmpty());
-    }    
+    }
+
+    // ==================== VIP Address Parsing Tests ====================
+
+    private static final DataCenterInfo TEST_DCI = () -> DataCenterInfo.Name.MyOwn;
+
+    @Test
+    public void testVipParsing_nullVip() {
+        Application app = new Application("TestApp");
+        Applications apps = new Applications();
+        apps.addApplication(app);
+        apps.shuffleInstances(false);
+
+        // No instances added
+        assertEquals(0, apps.getRegisteredApplications("TestApp").size());
+        assertEquals(0, apps.getRegisteredApplications("TestApp").getInstancesAsIsFromEureka().size());
+        // No VIP mappings exist
+        assertTrue(apps.getInstancesByVirtualHostName("anything").isEmpty());
+    }
+
+    @Test
+    public void testVipParsing_emptyVip() {
+        InstanceInfo instance = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("").setDataCenterInfo(TEST_DCI)
+                .setHostName("host1").setStatus(InstanceStatus.UP).build();
+        Application app = new Application("TestApp");
+        app.addInstance(instance);
+        Applications apps = new Applications();
+        apps.addApplication(app);
+        apps.shuffleInstances(false);
+
+        // Instance exists in application but no VIP mapping
+        assertEquals(1, apps.getRegisteredApplications("TestApp").size());
+        assertEquals(1, apps.getRegisteredApplications("TestApp").getInstancesAsIsFromEureka().size());
+        assertTrue(apps.getInstancesByVirtualHostName("").isEmpty());
+    }
+
+    @Test
+    public void testVipParsing_singleVip() {
+        InstanceInfo instance = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("host1").setStatus(InstanceStatus.UP).build();
+        Application app = new Application("TestApp");
+        app.addInstance(instance);
+        Applications apps = new Applications();
+        apps.addApplication(app);
+        apps.shuffleInstances(false);
+
+        assertEquals(1, apps.getRegisteredApplications("TestApp").size());
+        assertEquals(1, apps.getRegisteredApplications("TestApp").getInstancesAsIsFromEureka().size());
+        assertEquals(1, apps.getInstancesByVirtualHostName("my.vip").size());
+        assertEquals(1, apps.getInstancesByVirtualHostName("MY.VIP").size()); // case-insensitive lookup
+        assertTrue(apps.getInstancesByVirtualHostName("other.vip").isEmpty()); // no other entries
+    }
+
+    @Test
+    public void testVipParsing_singleVipMixedCase() {
+        InstanceInfo instance = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("My.Vip.Address").setDataCenterInfo(TEST_DCI)
+                .setHostName("host1").setStatus(InstanceStatus.UP).build();
+        Application app = new Application("TestApp");
+        app.addInstance(instance);
+        Applications apps = new Applications();
+        apps.addApplication(app);
+        apps.shuffleInstances(false);
+
+        assertEquals(1, apps.getRegisteredApplications("TestApp").size());
+        assertEquals(1, apps.getRegisteredApplications("TestApp").getInstancesAsIsFromEureka().size());
+        // All case variations should resolve to same entry
+        assertEquals(1, apps.getInstancesByVirtualHostName("my.vip.address").size());
+        assertEquals(1, apps.getInstancesByVirtualHostName("MY.VIP.ADDRESS").size());
+        assertEquals(1, apps.getInstancesByVirtualHostName("My.Vip.Address").size());
+    }
+
+    @Test
+    public void testVipParsing_twoVips() {
+        InstanceInfo instance = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("vip1,vip2").setDataCenterInfo(TEST_DCI)
+                .setHostName("host1").setStatus(InstanceStatus.UP).build();
+        Application app = new Application("TestApp");
+        app.addInstance(instance);
+        Applications apps = new Applications();
+        apps.addApplication(app);
+        apps.shuffleInstances(false);
+
+        // One instance in the application
+        assertEquals(1, apps.getRegisteredApplications("TestApp").size());
+        assertEquals(1, apps.getRegisteredApplications("TestApp").getInstancesAsIsFromEureka().size());
+        // Mapped to two VIPs
+        assertEquals(1, apps.getInstancesByVirtualHostName("vip1").size());
+        assertEquals(1, apps.getInstancesByVirtualHostName("vip2").size());
+        // No spurious entries
+        assertTrue(apps.getInstancesByVirtualHostName("vip1,vip2").isEmpty());
+        assertTrue(apps.getInstancesByVirtualHostName("vip3").isEmpty());
+    }
+
+    @Test
+    public void testVipParsing_threeVips() {
+        InstanceInfo instance = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("vip1,vip2,vip3").setDataCenterInfo(TEST_DCI)
+                .setHostName("host1").setStatus(InstanceStatus.UP).build();
+        Application app = new Application("TestApp");
+        app.addInstance(instance);
+        Applications apps = new Applications();
+        apps.addApplication(app);
+        apps.shuffleInstances(false);
+
+        assertEquals(1, apps.getRegisteredApplications("TestApp").size());
+        assertEquals(1, apps.getRegisteredApplications("TestApp").getInstancesAsIsFromEureka().size());
+        assertEquals(1, apps.getInstancesByVirtualHostName("vip1").size());
+        assertEquals(1, apps.getInstancesByVirtualHostName("vip2").size());
+        assertEquals(1, apps.getInstancesByVirtualHostName("vip3").size());
+        // No spurious entries from parsing
+        assertTrue(apps.getInstancesByVirtualHostName("vip1,vip2").isEmpty());
+        assertTrue(apps.getInstancesByVirtualHostName("vip2,vip3").isEmpty());
+        assertTrue(apps.getInstancesByVirtualHostName("vip1,vip2,vip3").isEmpty());
+    }
+
+    @Test
+    public void testVipParsing_multipleVipsMixedCase() {
+        InstanceInfo instance = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("Vip.One,VIP.TWO,vip.three").setDataCenterInfo(TEST_DCI)
+                .setHostName("host1").setStatus(InstanceStatus.UP).build();
+        Application app = new Application("TestApp");
+        app.addInstance(instance);
+        Applications apps = new Applications();
+        apps.addApplication(app);
+        apps.shuffleInstances(false);
+
+        assertEquals(1, apps.getRegisteredApplications("TestApp").size());
+        assertEquals(1, apps.getRegisteredApplications("TestApp").getInstancesAsIsFromEureka().size());
+        // All stored as uppercase, lookup case-insensitive
+        assertEquals(1, apps.getInstancesByVirtualHostName("vip.one").size());
+        assertEquals(1, apps.getInstancesByVirtualHostName("VIP.ONE").size());
+        assertEquals(1, apps.getInstancesByVirtualHostName("vip.two").size());
+        assertEquals(1, apps.getInstancesByVirtualHostName("vip.three").size());
+    }
+
+    @Test
+    public void testVipParsing_multipleInstancesOverlappingVips() {
+        // host1: vip.one, vip.two, vip.three
+        // host2: vip.two, vip.four
+        // host3: vip.three, vip.four, vip.five
+        InstanceInfo host1 = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("vip.one,vip.two,vip.three").setDataCenterInfo(TEST_DCI)
+                .setHostName("host1").setStatus(InstanceStatus.UP).build();
+        InstanceInfo host2 = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("vip.two,vip.four").setDataCenterInfo(TEST_DCI)
+                .setHostName("host2").setStatus(InstanceStatus.UP).build();
+        InstanceInfo host3 = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("vip.three,vip.four,vip.five").setDataCenterInfo(TEST_DCI)
+                .setHostName("host3").setStatus(InstanceStatus.UP).build();
+
+        Application app = new Application("TestApp");
+        app.addInstance(host1);
+        app.addInstance(host2);
+        app.addInstance(host3);
+        Applications apps = new Applications();
+        apps.addApplication(app);
+        apps.shuffleInstances(false);
+
+        // Verify application contains all 3 instances
+        assertEquals(3, apps.getRegisteredApplications("TestApp").size());
+        assertEquals(3, apps.getRegisteredApplications("TestApp").getInstancesAsIsFromEureka().size());
+
+        // vip.one -> host1 only
+        List<InstanceInfo> vipOneInstances = apps.getInstancesByVirtualHostName("vip.one");
+        assertEquals(1, vipOneInstances.size());
+        assertEquals("host1", vipOneInstances.get(0).getHostName());
+
+        // vip.two -> host1, host2
+        List<InstanceInfo> vipTwoInstances = apps.getInstancesByVirtualHostName("vip.two");
+        assertEquals(2, vipTwoInstances.size());
+        assertTrue(vipTwoInstances.stream().anyMatch(i -> "host1".equals(i.getHostName())));
+        assertTrue(vipTwoInstances.stream().anyMatch(i -> "host2".equals(i.getHostName())));
+
+        // vip.three -> host1, host3
+        List<InstanceInfo> vipThreeInstances = apps.getInstancesByVirtualHostName("vip.three");
+        assertEquals(2, vipThreeInstances.size());
+        assertTrue(vipThreeInstances.stream().anyMatch(i -> "host1".equals(i.getHostName())));
+        assertTrue(vipThreeInstances.stream().anyMatch(i -> "host3".equals(i.getHostName())));
+
+        // vip.four -> host2, host3
+        List<InstanceInfo> vipFourInstances = apps.getInstancesByVirtualHostName("vip.four");
+        assertEquals(2, vipFourInstances.size());
+        assertTrue(vipFourInstances.stream().anyMatch(i -> "host2".equals(i.getHostName())));
+        assertTrue(vipFourInstances.stream().anyMatch(i -> "host3".equals(i.getHostName())));
+
+        // vip.five -> host3 only
+        List<InstanceInfo> vipFiveInstances = apps.getInstancesByVirtualHostName("vip.five");
+        assertEquals(1, vipFiveInstances.size());
+        assertEquals("host3", vipFiveInstances.get(0).getHostName());
+
+        // Case-insensitive lookups work
+        assertEquals(2, apps.getInstancesByVirtualHostName("VIP.TWO").size());
+        assertEquals(2, apps.getInstancesByVirtualHostName("VIP.FOUR").size());
+
+        // No spurious VIP entries
+        assertTrue(apps.getInstancesByVirtualHostName("vip.six").isEmpty());
+        assertTrue(apps.getInstancesByVirtualHostName("vip.one,vip.two").isEmpty());
+    }
+
+    // ==================== shuffleAndFilterInstances Tests ====================
+
+    @Test
+    public void testMultipleInstancesFiltering() {
+        DataCenterInfo myDCI = new DataCenterInfo() {
+            public DataCenterInfo.Name getName() {
+                return DataCenterInfo.Name.MyOwn;
+            }
+        };
+        InstanceInfo up1 = InstanceInfo.Builder.newBuilder().setAppName("test")
+                .setVIPAddress("test.vip").setDataCenterInfo(myDCI)
+                .setHostName("up1.hostname").setStatus(InstanceStatus.UP).build();
+        InstanceInfo up2 = InstanceInfo.Builder.newBuilder().setAppName("test")
+                .setVIPAddress("test.vip").setDataCenterInfo(myDCI)
+                .setHostName("up2.hostname").setStatus(InstanceStatus.UP).build();
+        InstanceInfo down = InstanceInfo.Builder.newBuilder().setAppName("test")
+                .setVIPAddress("test.vip").setDataCenterInfo(myDCI)
+                .setHostName("down.hostname").setStatus(InstanceStatus.DOWN).build();
+
+        Application application = new Application("TestApp");
+        application.addInstance(up1);
+        application.addInstance(up2);
+        application.addInstance(down);
+
+        Applications applications = new Applications();
+        applications.addApplication(application);
+        applications.shuffleInstances(true);
+
+        List<InstanceInfo> result = applications.getInstancesByVirtualHostName("test.vip");
+        assertEquals(2, result.size());
+        assertTrue(result.contains(up1));
+        assertTrue(result.contains(up2));
+        assertFalse(result.contains(down));
+    }
+
+    @Test
+    public void testSingleInstanceUp_filterEnabled() {
+        InstanceInfo instance = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("host1").setStatus(InstanceStatus.UP).build();
+        Application app = new Application("TestApp");
+        app.addInstance(instance);
+        Applications apps = new Applications();
+        apps.addApplication(app);
+        apps.shuffleInstances(true);
+
+        List<InstanceInfo> result = apps.getInstancesByVirtualHostName("my.vip");
+        assertEquals(1, result.size());
+        assertTrue(result.contains(instance));
+    }
+
+    @Test
+    public void testSingleInstanceDown_filterEnabled() {
+        InstanceInfo instance = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("host1").setStatus(InstanceStatus.DOWN).build();
+        Application app = new Application("TestApp");
+        app.addInstance(instance);
+        Applications apps = new Applications();
+        apps.addApplication(app);
+        apps.shuffleInstances(true);
+
+        // Single DOWN instance should be filtered out
+        List<InstanceInfo> result = apps.getInstancesByVirtualHostName("my.vip");
+        assertTrue(result.isEmpty());
+        // But instance still exists in the application
+        assertEquals(1, apps.getRegisteredApplications("TestApp").size());
+    }
+
+    @Test
+    public void testMultipleInstances_filterDisabled() {
+        InstanceInfo up = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("up.host").setStatus(InstanceStatus.UP).build();
+        InstanceInfo down = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("down.host").setStatus(InstanceStatus.DOWN).build();
+        InstanceInfo oos = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("oos.host").setStatus(InstanceStatus.OUT_OF_SERVICE).build();
+
+        Application app = new Application("TestApp");
+        app.addInstance(up);
+        app.addInstance(down);
+        app.addInstance(oos);
+        Applications apps = new Applications();
+        apps.addApplication(app);
+        apps.shuffleInstances(false); // filterUpInstances = false
+
+        // All instances should be present regardless of status
+        List<InstanceInfo> result = apps.getInstancesByVirtualHostName("my.vip");
+        assertEquals(3, result.size());
+        assertTrue(result.contains(up));
+        assertTrue(result.contains(down));
+        assertTrue(result.contains(oos));
+    }
+
+    @Test
+    public void testAllInstancesNonUp_filterEnabled() {
+        InstanceInfo down = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("down.host").setStatus(InstanceStatus.DOWN).build();
+        InstanceInfo oos = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("oos.host").setStatus(InstanceStatus.OUT_OF_SERVICE).build();
+        InstanceInfo starting = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("starting.host").setStatus(InstanceStatus.STARTING).build();
+
+        Application app = new Application("TestApp");
+        app.addInstance(down);
+        app.addInstance(oos);
+        app.addInstance(starting);
+        Applications apps = new Applications();
+        apps.addApplication(app);
+        apps.shuffleInstances(true);
+
+        // All instances filtered out
+        List<InstanceInfo> result = apps.getInstancesByVirtualHostName("my.vip");
+        assertTrue(result.isEmpty());
+        // But all instances still exist in the application
+        assertEquals(3, apps.getRegisteredApplications("TestApp").size());
+    }
+
+    @Test
+    public void testSecureVipFiltering() {
+        InstanceInfo up = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setSecureVIPAddress("secure.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("up.host").setStatus(InstanceStatus.UP).build();
+        InstanceInfo down = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setSecureVIPAddress("secure.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("down.host").setStatus(InstanceStatus.DOWN).build();
+
+        Application app = new Application("TestApp");
+        app.addInstance(up);
+        app.addInstance(down);
+        Applications apps = new Applications();
+        apps.addApplication(app);
+        apps.shuffleInstances(true);
+
+        List<InstanceInfo> result = apps.getInstancesBySecureVirtualHostName("secure.vip");
+        assertEquals(1, result.size());
+        assertTrue(result.contains(up));
+        assertFalse(result.contains(down));
+    }
+
+    @Test
+    public void testReshuffleUpdatesFilteredList() {
+        InstanceInfo host1 = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("host1").setStatus(InstanceStatus.UP).build();
+        InstanceInfo host2 = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("host2").setStatus(InstanceStatus.UP).build();
+
+        Application app = new Application("TestApp");
+        app.addInstance(host1);
+        app.addInstance(host2);
+        Applications apps = new Applications();
+        apps.addApplication(app);
+        apps.shuffleInstances(true);
+
+        assertEquals(2, apps.getInstancesByVirtualHostName("my.vip").size());
+
+        // Change host2 to DOWN and reshuffle
+        host2.setStatus(InstanceStatus.DOWN);
+        apps.shuffleInstances(true);
+
+        // Only host1 should remain
+        List<InstanceInfo> result = apps.getInstancesByVirtualHostName("my.vip");
+        assertEquals(1, result.size());
+        assertTrue(result.contains(host1));
+        assertFalse(result.contains(host2));
+    }
+
+    @Test
+    public void testMixedVipAndSecureVipFiltering() {
+        InstanceInfo upBoth = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setSecureVIPAddress("secure.vip")
+                .setDataCenterInfo(TEST_DCI).setHostName("up.both").setStatus(InstanceStatus.UP).build();
+        InstanceInfo downBoth = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setSecureVIPAddress("secure.vip")
+                .setDataCenterInfo(TEST_DCI).setHostName("down.both").setStatus(InstanceStatus.DOWN).build();
+        InstanceInfo upVipOnly = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip")
+                .setDataCenterInfo(TEST_DCI).setHostName("up.vip").setStatus(InstanceStatus.UP).build();
+
+        Application app = new Application("TestApp");
+        app.addInstance(upBoth);
+        app.addInstance(downBoth);
+        app.addInstance(upVipOnly);
+        Applications apps = new Applications();
+        apps.addApplication(app);
+        apps.shuffleInstances(true);
+
+        // VIP should have 2 UP instances
+        List<InstanceInfo> vipResult = apps.getInstancesByVirtualHostName("my.vip");
+        assertEquals(2, vipResult.size());
+        assertTrue(vipResult.contains(upBoth));
+        assertTrue(vipResult.contains(upVipOnly));
+
+        // Secure VIP should have 1 UP instance
+        List<InstanceInfo> secureResult = apps.getInstancesBySecureVirtualHostName("secure.vip");
+        assertEquals(1, secureResult.size());
+        assertTrue(secureResult.contains(upBoth));
+    }
+
+    // ==================== Collection Progression Tests (emptyList -> singletonList -> ArrayList) ====================
+
+    @Test
+    public void testVipInstanceCountProgression() {
+        // Explicitly test 0->1->2->3->4 instance progression on same VIP
+        // Validates emptyList -> singletonList -> ArrayList(12) transitions
+        InstanceInfo inst1 = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("host1").setStatus(InstanceStatus.UP).build();
+        InstanceInfo inst2 = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("host2").setStatus(InstanceStatus.UP).build();
+        InstanceInfo inst3 = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("host3").setStatus(InstanceStatus.UP).build();
+        InstanceInfo inst4 = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("host4").setStatus(InstanceStatus.UP).build();
+
+        Application app = new Application("TestApp");
+        Applications apps = new Applications();
+
+        // 0 instances - no VIP entry exists yet
+        apps.addApplication(app);
+        apps.shuffleInstances(false);
+        assertTrue(apps.getInstancesByVirtualHostName("my.vip").isEmpty());
+
+        // 1 instance - singletonList path
+        app.addInstance(inst1);
+        apps = new Applications();
+        apps.addApplication(app);
+        apps.shuffleInstances(false);
+        List<InstanceInfo> result1 = apps.getInstancesByVirtualHostName("my.vip");
+        assertEquals(1, result1.size());
+        assertTrue(result1.contains(inst1));
+
+        // 2 instances - ArrayList transition
+        app.addInstance(inst2);
+        apps = new Applications();
+        apps.addApplication(app);
+        apps.shuffleInstances(false);
+        List<InstanceInfo> result2 = apps.getInstancesByVirtualHostName("my.vip");
+        assertEquals(2, result2.size());
+        assertTrue(result2.contains(inst1));
+        assertTrue(result2.contains(inst2));
+
+        // 3 instances - ArrayList grows
+        app.addInstance(inst3);
+        apps = new Applications();
+        apps.addApplication(app);
+        apps.shuffleInstances(false);
+        List<InstanceInfo> result3 = apps.getInstancesByVirtualHostName("my.vip");
+        assertEquals(3, result3.size());
+
+        // 4 instances - ArrayList continues to grow
+        app.addInstance(inst4);
+        apps = new Applications();
+        apps.addApplication(app);
+        apps.shuffleInstances(false);
+        List<InstanceInfo> result4 = apps.getInstancesByVirtualHostName("my.vip");
+        assertEquals(4, result4.size());
+        assertTrue(result4.contains(inst1));
+        assertTrue(result4.contains(inst2));
+        assertTrue(result4.contains(inst3));
+        assertTrue(result4.contains(inst4));
+    }
+
+    @Test
+    public void testFilteringWithSingletonList_instanceUp() {
+        // Single UP instance: singletonList should be preserved
+        InstanceInfo instance = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("host1").setStatus(InstanceStatus.UP).build();
+        Application app = new Application("TestApp");
+        app.addInstance(instance);
+        Applications apps = new Applications();
+        apps.addApplication(app);
+        apps.shuffleInstances(true);
+
+        List<InstanceInfo> result = apps.getInstancesByVirtualHostName("my.vip");
+        assertEquals(1, result.size());
+        assertTrue(result.contains(instance));
+    }
+
+    @Test
+    public void testFilteringWithSingletonList_instanceDown() {
+        // Single DOWN instance: should return emptyList
+        InstanceInfo instance = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("host1").setStatus(InstanceStatus.DOWN).build();
+        Application app = new Application("TestApp");
+        app.addInstance(instance);
+        Applications apps = new Applications();
+        apps.addApplication(app);
+        apps.shuffleInstances(true);
+
+        List<InstanceInfo> result = apps.getInstancesByVirtualHostName("my.vip");
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testFilteringWithArrayList_oneUpOneDown() {
+        // 2 instances (ArrayList), 1 UP 1 DOWN: filters to 1
+        InstanceInfo up = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("up.host").setStatus(InstanceStatus.UP).build();
+        InstanceInfo down = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("down.host").setStatus(InstanceStatus.DOWN).build();
+        Application app = new Application("TestApp");
+        app.addInstance(up);
+        app.addInstance(down);
+        Applications apps = new Applications();
+        apps.addApplication(app);
+        apps.shuffleInstances(true);
+
+        List<InstanceInfo> result = apps.getInstancesByVirtualHostName("my.vip");
+        assertEquals(1, result.size());
+        assertTrue(result.contains(up));
+        assertFalse(result.contains(down));
+    }
+
+    @Test
+    public void testFilteringWithArrayList_allDown() {
+        // 3 instances (ArrayList), all DOWN: should return emptyList
+        InstanceInfo down1 = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("down1.host").setStatus(InstanceStatus.DOWN).build();
+        InstanceInfo down2 = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("down2.host").setStatus(InstanceStatus.OUT_OF_SERVICE).build();
+        InstanceInfo down3 = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("down3.host").setStatus(InstanceStatus.STARTING).build();
+        Application app = new Application("TestApp");
+        app.addInstance(down1);
+        app.addInstance(down2);
+        app.addInstance(down3);
+        Applications apps = new Applications();
+        apps.addApplication(app);
+        apps.shuffleInstances(true);
+
+        List<InstanceInfo> result = apps.getInstancesByVirtualHostName("my.vip");
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testFilteringPreservesUpInstancesInOrder() {
+        // Verify UP instances are preserved (order may change due to shuffle)
+        InstanceInfo up1 = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("up1").setStatus(InstanceStatus.UP).build();
+        InstanceInfo down1 = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("down1").setStatus(InstanceStatus.DOWN).build();
+        InstanceInfo up2 = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("up2").setStatus(InstanceStatus.UP).build();
+        InstanceInfo down2 = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("down2").setStatus(InstanceStatus.OUT_OF_SERVICE).build();
+        InstanceInfo up3 = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("up3").setStatus(InstanceStatus.UP).build();
+
+        Application app = new Application("TestApp");
+        app.addInstance(up1);
+        app.addInstance(down1);
+        app.addInstance(up2);
+        app.addInstance(down2);
+        app.addInstance(up3);
+        Applications apps = new Applications();
+        apps.addApplication(app);
+        apps.shuffleInstances(true);
+
+        List<InstanceInfo> result = apps.getInstancesByVirtualHostName("my.vip");
+        assertEquals(3, result.size());
+        assertTrue(result.contains(up1));
+        assertTrue(result.contains(up2));
+        assertTrue(result.contains(up3));
+        assertFalse(result.contains(down1));
+        assertFalse(result.contains(down2));
+    }
+
+    @Test
+    public void testInstanceRemovalFromApplication() {
+        // Test that removing an instance from application is reflected after reshuffle
+        InstanceInfo inst1 = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("host1").setStatus(InstanceStatus.UP).build();
+        InstanceInfo inst2 = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("host2").setStatus(InstanceStatus.UP).build();
+        InstanceInfo inst3 = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("host3").setStatus(InstanceStatus.UP).build();
+
+        Application app = new Application("TestApp");
+        app.addInstance(inst1);
+        app.addInstance(inst2);
+        app.addInstance(inst3);
+        Applications apps = new Applications();
+        apps.addApplication(app);
+        apps.shuffleInstances(false);
+
+        assertEquals(3, apps.getInstancesByVirtualHostName("my.vip").size());
+
+        // Remove one instance
+        app.removeInstance(inst2);
+        apps.shuffleInstances(false);
+
+        List<InstanceInfo> result = apps.getInstancesByVirtualHostName("my.vip");
+        assertEquals(2, result.size());
+        assertTrue(result.contains(inst1));
+        assertFalse(result.contains(inst2));
+        assertTrue(result.contains(inst3));
+    }
+
+    @Test
+    public void testRemoveAllInstancesFromVip() {
+        // Test removing all instances results in empty VIP list
+        InstanceInfo inst1 = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("host1").setStatus(InstanceStatus.UP).build();
+        InstanceInfo inst2 = InstanceInfo.Builder.newBuilder()
+                .setAppName("test").setVIPAddress("my.vip").setDataCenterInfo(TEST_DCI)
+                .setHostName("host2").setStatus(InstanceStatus.UP).build();
+
+        Application app = new Application("TestApp");
+        app.addInstance(inst1);
+        app.addInstance(inst2);
+        Applications apps = new Applications();
+        apps.addApplication(app);
+        apps.shuffleInstances(false);
+
+        assertEquals(2, apps.getInstancesByVirtualHostName("my.vip").size());
+
+        // Remove all instances
+        app.removeInstance(inst1);
+        app.removeInstance(inst2);
+        apps.shuffleInstances(false);
+
+        assertTrue(apps.getInstancesByVirtualHostName("my.vip").isEmpty());
+    }
 
 }

--- a/eureka-client/src/test/java/com/netflix/discovery/shared/ApplicationsTest.java
+++ b/eureka-client/src/test/java/com/netflix/discovery/shared/ApplicationsTest.java
@@ -420,10 +420,11 @@ public class ApplicationsTest {
         apps.addApplication(app);
         apps.shuffleInstances(false);
 
-        // Instance exists in application but no VIP mapping
+        // Instance exists in application
         assertEquals(1, apps.getRegisteredApplications("TestApp").size());
         assertEquals(1, apps.getRegisteredApplications("TestApp").getInstancesAsIsFromEureka().size());
-        assertTrue(apps.getInstancesByVirtualHostName("").isEmpty());
+        // Legacy behavior: empty VIP creates a mapping with empty string key
+        assertEquals(1, apps.getInstancesByVirtualHostName("").size());
     }
 
     @Test


### PR DESCRIPTION
A few changes bundled here since they overlap in `Applications.java`.

(1) In 3d27645 the parsing of comma-delimited VIP is optimized to bypass the single-vip case, which is >90% of vips, and for multi-vip case we avoid allocation of an extra String[] array.

(2) In cd4c409 we special-case to avoid allocations for >50% of cases

(3) In 2af7d67 we preallocate hash sizes based on what we know from previous snapshot iterations

(4) In e9a5169 We swap the AtomicReference to a volatile, since the extra features of AtomicRef are never needed and we can save one object per application

(5) In a094911 we can avoid an extra ArrayList allocation by filtering in-place and dropping filtered values