### PR TITLE
Upgrade commons-lang to commons-lang3 and refactor commons-configuration usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ allprojects {
         jerseyVersion = '1.19.1'
         jettisonVersion = '1.5.4'
         apacheHttpClientVersion = '4.5.3'
-        commonsConfigurationVersion = '1.10'
+        commonsLang3Version = '3.20.0'
         jsr305Version = '3.0.2'
         guiceVersion = '4.1.0'
         servoVersion = '0.12.21'

--- a/eureka-client/build.gradle
+++ b/eureka-client/build.gradle
@@ -14,7 +14,9 @@ dependencies {
     api "com.sun.jersey.contribs:jersey-apache-client4:${jerseyVersion}"
     api "org.apache.httpcomponents:httpclient:${apacheHttpClientVersion}"
     api "com.google.code.findbugs:jsr305:${jsr305Version}"
-    api "commons-configuration:commons-configuration:${commonsConfigurationVersion}"
+    api "org.apache.commons:commons-lang3:${commonsLang3Version}"
+    // commons-configuration v1 required at compile time by archaius-core 0.7.6
+    api "commons-configuration:commons-configuration:1.10"
     api "com.google.inject:guice:${guiceVersion}"
 
     api "com.github.vlsi.compactmap:compactmap:2.0"

--- a/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/DiscoveryClient.java
@@ -52,7 +52,7 @@ import javax.ws.rs.core.Response.Status;
 
 import com.netflix.discovery.shared.resolver.EndpointRandomizer;
 import com.netflix.discovery.shared.resolver.ResolverUtils;
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/eureka-client/src/main/java/com/netflix/discovery/shared/transport/decorator/RedirectingEurekaHttpClient.java
+++ b/eureka-client/src/main/java/com/netflix/discovery/shared/transport/decorator/RedirectingEurekaHttpClient.java
@@ -31,7 +31,7 @@ import com.netflix.discovery.shared.transport.EurekaHttpResponse;
 import com.netflix.discovery.shared.transport.TransportClientFactory;
 import com.netflix.discovery.shared.transport.TransportException;
 import com.netflix.discovery.shared.transport.TransportUtils;
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                         
- Upgrade from `commons-lang:2.x` to `commons-lang3:3.20.0`                                                                                                                                                        
- Refactor code to remove direct dependency on `commons-configuration` Configuration interface                                                                                                                     
- Add explicit `commons-lang3` dependency (previously pulled transitively)                                                                                                                                         

Fixes #1603
                                                                                                                                                                                                                   
## Changes                                                                                                                                                                                                         
                                                                                                                                                                                                                   
### Dependencies (`build.gradle`, `eureka-client/build.gradle`)                                                                                                                                                    
- Added `commons-lang3:3.20.0` as explicit dependency                                                                                                                                                              
- Kept `commons-configuration:1.10` (required at compile time by `archaius-core:0.7.6`)                                                                                                                            
                                                                                                                                                                                                                   
### Code changes                                                                                                                                                                                                   
- `PropertiesInstanceConfig.java`: Refactored `getMetadataMap()` to use `ConfigurationManager.getConfigInstance()` directly instead of casting to `Configuration` interface                                        
- `DiscoveryClient.java`: Updated import from `org.apache.commons.lang.exception.ExceptionUtils` to `org.apache.commons.lang3.exception.ExceptionUtils`                                                            
- `RedirectingEurekaHttpClient.java`: Same import update                                                                                                                                                           
                                                                                                                                                                                                                   
## Notes                                                                                                                                                                                                           
- `commons-configuration:1.10` cannot be fully removed because `archaius-core:0.7.6` requires it at compile time (its API returns `AbstractConfiguration` types)                                                   
- Full migration to `commons-configuration2` would require upgrading to `archaius2`, which is a larger breaking change affecting 24+ files                                                                         
- The `eureka-client-archaius2` module already exists as an alternative for users who want archaius2 support                                                                                                       
                                                                                                                                                                                                                   
## Testing                                                                                                                                                                                                         
- All modules compile successfully                                                                                                                                                                                 
- All tests pass (verified with Java 8 in Docker)                                                                                                                                                                  
- No API changes for consumers  