### PR TITLE
Add distribution to builds

### DIFF
--- a/.github/workflows/nebula-publish.yml
+++ b/.github/workflows/nebula-publish.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: 11
+          distribution: 'zulu'
       - uses: actions/cache@v5
         id: gradle-cache
         with:

--- a/.github/workflows/nebula-snapshot.yml
+++ b/.github/workflows/nebula-snapshot.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: 11
+          distribution: 'zulu'
       - uses: actions/cache@v5
         id: gradle-cache
         with:


### PR DESCRIPTION
It's required by setup-java@v5, and zulu was the default in v1