### PR TITLE
Refactor InternalPrefixedConfig to use StringBuilder for namespace construction

### DIFF
--- a/eureka-client-archaius2/src/main/java/com/netflix/discovery/internal/util/InternalPrefixedConfig.java
+++ b/eureka-client-archaius2/src/main/java/com/netflix/discovery/internal/util/InternalPrefixedConfig.java
@@ -1,6 +1,7 @@
 package com.netflix.discovery.internal.util;
 
 import com.netflix.archaius.api.Config;
+import org.apache.commons.lang.StringUtils;
 
 import java.util.Iterator;
 
@@ -16,16 +17,14 @@ public final class InternalPrefixedConfig {
 
     public InternalPrefixedConfig(Config config, String... namespaces) {
         this.config = config;
-        String tempNamespace = "";
+        StringBuilder builder = new StringBuilder();
         for (String namespace : namespaces) {
-            if (namespace != null && !namespace.isEmpty()) {
-                tempNamespace += namespace.endsWith(".")
-                        ? namespace
-                        : namespace + ".";
-            }
+            if (StringUtils.isEmpty(namespace)) continue;
+            builder.append(namespace);
+            if (!namespace.endsWith(".")) builder.append('.');
         }
 
-        this.namespace = tempNamespace;
+        this.namespace = builder.toString();
     }
 
     public String getNamespace() {

--- a/eureka-client-archaius2/src/test/java/com/netflix/discovery/internal/util/InternalPrefixedConfigTest.java
+++ b/eureka-client-archaius2/src/test/java/com/netflix/discovery/internal/util/InternalPrefixedConfigTest.java
@@ -23,4 +23,22 @@ public class InternalPrefixedConfigTest {
         config = new InternalPrefixedConfig(configInstance, "foo", "bar");
         Assert.assertEquals("foo.bar.", config.getNamespace());
     }
+
+    @Test
+    public void testEmptyAndNullPrefixesAreIgnored() {
+        Config configInstance = Mockito.mock(Config.class);
+
+        InternalPrefixedConfig config = new InternalPrefixedConfig(configInstance, null, "", "foo");
+
+        Assert.assertEquals("foo.", config.getNamespace());
+    }
+
+    @Test
+    public void testPrefixEndingWithDotIsNotDuplicated() {
+        Config configInstance = Mockito.mock(Config.class);
+
+        InternalPrefixedConfig config = new InternalPrefixedConfig(configInstance, "foo.", "bar");
+
+        Assert.assertEquals("foo.bar.", config.getNamespace());
+    }
 }


### PR DESCRIPTION
### Summary
Refactored InternalPrefixedConfig to avoid String concatenation inside a loop by using StringBuilder.

### Problem
The constructor of InternalPrefixedConfig was building the namespace prefix using String concatenation (+=) inside a loop, which is less efficient due to repeated String object creation.

### Changes Made
- Replaced String concatenation with StringBuilder in the constructor.
- Preserved existing behavior for null, empty, and dotted namespace values.
- Added unit tests to cover edge cases and ensure identical behavior.

### Result
The code is more efficient, and clearer, with no behavioral changes.

### Fixes
Fixes #1606