### PR TITLE
ci: add dependabot config (gradle + github-actions), mirroring Netflix/zuul

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Hi, and thank you for Eureka.

Small governance add: this repo has no `.github/dependabot.yml`, so neither Gradle dependencies nor the workflow actions ever get automated update PRs. Your sister repo **Netflix/zuul** runs exactly this config (gradle + github-actions) and merges its dependabot bumps routinely — this PR mirrors it, at `weekly` rather than zuul's `daily` to respect this repo's slower merge cadence.

Context that motivated it: eureka's client dependency set has a number of long-open version-bump asks (e.g. #1584, #1483, #1445) — automated PRs won't fix policy questions, but they remove the manual overhead for the routine bumps.

README asks for an issue first for non-trivial changes — this is a 10-line additive config file, so I hoped it qualifies as trivial; happy to convert to an issue-first discussion if you'd rather.

For transparency: I used AI assistance to spot and draft this; I verified the missing config and zuul's precedent myself.
