### PR TITLE
Upgrade xstream-1.4.20 to 1.4.21

### DIFF
--- a/eureka-client/build.gradle
+++ b/eureka-client/build.gradle
@@ -5,7 +5,7 @@ configurations.all {
 
 dependencies {
     api "com.netflix.netflix-commons:netflix-eventbus:0.3.0"
-    api 'com.thoughtworks.xstream:xstream:1.4.20'
+    api 'com.thoughtworks.xstream:xstream:1.4.21'
     api "com.netflix.archaius:archaius-core:${archaiusVersion}"
     api 'javax.ws.rs:jsr311-api:1.1.1'
     api "com.netflix.servo:servo-core:${servoVersion}"

--- a/eureka-core/build.gradle
+++ b/eureka-core/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     api "com.amazonaws:aws-java-sdk-sts:${awsVersion}"
     api "com.amazonaws:aws-java-sdk-route53:${awsVersion}"
     api "javax.servlet:servlet-api:${servletVersion}"
-    api 'com.thoughtworks.xstream:xstream:1.4.20'
+    api 'com.thoughtworks.xstream:xstream:1.4.21'
     api 'javax.ws.rs:jsr311-api:1.1.1'
 
     // These dependencies are marked 'compileOnly' in the client, but we need them always on the server


### PR DESCRIPTION
This brings the master branch in parity with 2.x

- https://github.com/Netflix/eureka/blob/2.x/eureka-core/build.gradle#L13
- https://github.com/Netflix/eureka/blob/2.x/eureka-client/build.gradle#L10