### PR TITLE
Fix JDK setup in nebula-publish.yml

### DIFF
--- a/.github/workflows/nebula-publish.yml
+++ b/.github/workflows/nebula-publish.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup jdk 8
         uses: actions/setup-java@v5
         with:
-          java-version: 1.8
+          java-version: 8
           distribution: 'zulu'
       - uses: actions/cache@v5
         id: gradle-cache


### PR DESCRIPTION
'1.8' is no longer an alias for Java 8 in the Zulu distribution catalog. The publishing job fails with
```
No matching version found for SemVer '1.8'.
```
https://github.com/Netflix/eureka/actions/runs/32751209476

The other workflows - nebula-ci and nebula-snapshot already use Java 8.